### PR TITLE
Add scatter plots for range and blrms

### DIFF
--- a/bin/gwdetchar-slow-correlation
+++ b/bin/gwdetchar-slow-correlation
@@ -305,8 +305,6 @@ def process_channel(input_,):
         # plot scatter plots
         rangeColor = 'red'
         darmblrmsColor = 'blue'
-        #plotHeight = 10
-        #plotWidth = 20
 
         tsCopy = ts.reshape(-1, 1)
         rangetsCopy = rangets.reshape(-1, 1)
@@ -320,13 +318,10 @@ def process_channel(input_,):
         rangeReg.fit(tsCopy, rangetsCopy)
         rangeFit = rangeReg.predict(tsCopy)
 
-        fig = gwplot(figsize = (12, 6))
+        fig = gwplot(figsize=(12, 6))
         fig.subplots_adjust(*p2)
         ax = fig.add_subplot(121)
-        #axes = scatPlot.gca()
-        #ax.set_xlabel(channelstub.replace('_', '\_'), labelpad=30)
         ax.set_xlabel('Channel units')
-        #ax.set_ylabel(primary.replace('_', '\_') + ' [strain]')
         ax.set_ylabel('Sensitive range [Mpc]')
         yrange = abs(max(darmblrms.value) - min(darmblrms.value))
         upperLim = max(darmblrms.value) + .1 * yrange
@@ -339,14 +334,9 @@ def process_channel(input_,):
                           edgecolor='black'))
         fig.add_scatter(ts, darmblrms, color=darmblrmsColor)
         fig.add_line(ts, darmblrmsFit, color='black')
-        #fig.set_figheight(plotHeight)
-        #fig.set_figwidth(plotWidth)
 
         ax = fig.add_subplot(122)
-        #axes = scatPlot.gca()
-        #ax.set_xlabel(channelstub.replace('_', '\_'), labelpad=30)
         ax.set_xlabel('Channel units')
-        #ax.set_ylabel(rangechannel.replace('_', '\_') + ' [Mpc]')
         ax.set_ylabel('$h(t)$ BLRMS [strain]')
         ax.text(.9, .1, 'r = ' + str('{0:.2}'.format(corr2)),
                 verticalalignment='bottom', horizontalalignment='right',
@@ -355,8 +345,6 @@ def process_channel(input_,):
                           edgecolor='black'))
         fig.add_scatter(ts, rangets, color=rangeColor)
         fig.add_line(ts, rangeFit, color='black')
-        #scatPlot.set_figheight(plotHeight)
-        #scatPlot.set_figwidth(plotWidth)
 
         plot3 = '%s_SCATTER-%s.png' % (channelstub, gpsstub)
         try:

--- a/bin/gwdetchar-slow-correlation
+++ b/bin/gwdetchar-slow-correlation
@@ -34,11 +34,15 @@ use('agg')
 from gwpy.timeseries import (TimeSeries, TimeSeriesDict)
 from gwpy.time import from_gps
 from gwpy.plotter import TimeSeriesPlot
+from gwpy.plotter import Plot as gwplot
 from gwpy.detector import ChannelList
 from gwpy.io import nds2 as io_nds2
 
 from gwdetchar import cli
 from gwdetchar.io import html
+
+from sklearn import linear_model, preprocessing, datasets
+from sklearn.metrics import mean_squared_error, r2_score
 
 parser = cli.create_parser(
     description=__doc__,
@@ -215,6 +219,7 @@ def process_channel(input_,):
         corr2s = None
         plot1 = None
         plot2 = None
+	plot3 = None
     else:
         corr1 = numpy.corrcoef(ts.value, darmblrms.value)[0, 1]
         corr1s = spearmanr(ts.value, darmblrms.value)[0]
@@ -229,7 +234,8 @@ def process_channel(input_,):
                 and (numpy.absolute(corr2) < args.threshold) and (numpy.absolute(corr2s) < args.threshold)):
             plot1 = None
             plot2 = None
-            return chan, corr1, corr2, plot1, plot2, corr1s, corr2s
+	    plot3 = None
+            return chan, corr1, corr2, plot1, plot2, plot3, corr1s, corr2s
         plot = TimeSeriesPlot(darmblrms, ts, rangets, sep=True, sharex=True,
                               figsize=(12, 12))
         plot.subplots_adjust(*p1)
@@ -284,6 +290,67 @@ def process_channel(input_,):
                 raise
         plot.close()
 
+        #plot scatter plots
+        rangeColor="red"
+        darmblrmsColor="blue"
+        plotHeight=10
+        plotWidth=20
+
+        tsCopy=ts.reshape(-1,1)
+        rangetsCopy=rangets.reshape(-1,1)
+        darmblrmsCopy=darmblrms.reshape(-1,1)
+
+        darmblrmsReg = linear_model.LinearRegression()
+        darmblrmsReg.fit(tsCopy, darmblrmsCopy)
+        darmblrmsFit = darmblrmsReg.predict(tsCopy)
+
+        rangeReg = linear_model.LinearRegression()
+        rangeReg.fit(tsCopy, rangetsCopy)
+        rangeFit = rangeReg.predict(tsCopy)
+
+
+        scatPlot=gwplot()
+
+        scatPlot.add_subplot(121)
+        axes = scatPlot.gca()
+        axes.set_xlabel(channelstub.replace("_","\_"), labelpad=30)
+        axes.set_ylabel(primary.replace("_","\_")+" [strain]")
+        range=abs(max(darmblrms.value)-min(darmblrms.value))
+        upperLim=max(darmblrms.value)+.1*range
+        lowerLim=min(darmblrms.value)-.1*range
+        axes.set_ylim(lowerLim,upperLim)
+        axes.text(.9,.1,"r = " + str('{0:.2}'.format(corr1)), verticalalignment='bottom', horizontalalignment='right',
+            transform=axes.transAxes, color="black", size=30)
+        scatPlot.add_scatter(ts, darmblrms, color=darmblrmsColor)
+        scatPlot.add_line(ts, darmblrmsFit, color="black")
+        scatPlot.set_figheight(plotHeight)
+        scatPlot.set_figwidth(plotWidth)
+
+        scatPlot.add_subplot(122)
+        axes = scatPlot.gca()
+        axes.set_xlabel(channelstub.replace("_","\_"), labelpad=30)
+        axes.set_ylabel(rangechannel.replace("_","\_")+" [Mpc]")
+        axes.text(.9,.1,"r = " + str('{0:.2}'.format(corr2)), verticalalignment='bottom', horizontalalignment='right',
+            transform=axes.transAxes, color="black", size=30)
+        scatPlot.add_scatter(ts, rangets, color=rangeColor)
+        scatPlot.add_line(ts, rangeFit, color="black")
+        scatPlot.set_figheight(plotHeight)
+        scatPlot.set_figwidth(plotWidth)
+
+
+        plot3 = '%s_SCATTER-%s.png' % (channelstub, gpsstub)
+	try:
+            scatPlot.save(plot3)
+        except (IOError, IndexError):
+            scatPlot.save(plot3)
+        except RuntimeError as e:
+            if 'latex' in str(e).lower():
+                scatPlot.save(plot3)
+            else:
+                raise
+
+        scatPlot.close()
+
     # increment counter and print status
     with counter.get_lock():
         counter.value += 1
@@ -291,18 +358,18 @@ def process_channel(input_,):
         print("Completed [%d/%d] %3d%% %-50s"
               % (counter.value, nchan, pc, '(%s)' % str(chan)), end='\r')
         sys.stdout.flush()
-    return chan, corr1, corr2, plot1, plot2, corr1s, corr2s
+    return chan, corr1, corr2, plot1, plot2, plot3, corr1s, corr2s
 
 pool = multiprocessing.Pool(nprocplot)
 results = pool.map(process_channel, auxdata.iteritems())
 results.sort(key=lambda x: (x[1] is not None and max(abs(x[1]),abs(x[2]),
-             abs(x[5]),abs(x[6])) or 0, x[0]), reverse=True)
+             abs(x[6]),abs(x[7])) or 0, x[0]), reverse=True)
 rhos = numpy.asarray([x[1] for x in results if x is not None])
 
 print("")
 
 with open('results.txt', 'w') as f:
-    for ch, corr1, corr2, _, _, corr1s, corr2s in results:
+    for ch, corr1, corr2, _, _, _, corr1s, corr2s in results:
         print('%s %s %s %s %s' % (ch, corr1, corr2, corr1s, corr2s), file=f)
 
 # -- write html
@@ -361,7 +428,7 @@ if args.trend_type == 'minute':
         % (r_blrms, rho_blrms, primary, r_range, rho_range, rangechannel, r, corr_p, rho, corr_s))
     
 page.div(class_='panel-group', id_='results')
-for i, (ch, corr1, corr2, plot1, plot2, corr1s, corr2s) in enumerate(results):
+for i, (ch, corr1, corr2, plot1, plot2, plot3, corr1s, corr2s) in enumerate(results):
     if corr1 is None:
         h = '%s [flat]' % ch
     elif plot1 is None:
@@ -396,7 +463,7 @@ for i, (ch, corr1, corr2, plot1, plot2, corr1s, corr2s) in enumerate(results):
     elif plot1 is None:
         page.p("Niether r or rho are above the threshold of %.2f." %(args.threshold))
     else:
-        for p in (plot1, plot2):
+        for p in (plot1, plot2, plot3):
             page.a(href=p, target='_blank')
             page.img(class_='img-responsive', src=p)
             page.a.close()

--- a/bin/gwdetchar-slow-correlation
+++ b/bin/gwdetchar-slow-correlation
@@ -30,6 +30,7 @@ from scipy.interpolate import UnivariateSpline
 
 from matplotlib import use
 use('agg')
+import matplotlib.pyplot as plt
 
 from gwpy.timeseries import (TimeSeries, TimeSeriesDict)
 from gwpy.time import from_gps
@@ -71,7 +72,7 @@ parser.add_argument('-R', '--range-frametype',
                     help='frametype for --range-channel')
 parser.add_argument('-O', '--remove-outliers', type=float, default=None,
                     help='Std. dev. limit for removing outliers')
-parser.add_argument('-t', '--threshold', type=float, default=0.1, 
+parser.add_argument('-t', '--threshold', type=float, default=0.1,
                     help='threshold for making a plot')
 
 psig = parser.add_argument_group('Signal processing options')
@@ -101,24 +102,29 @@ if not os.path.isdir(args.output_dir):
 os.chdir(args.output_dir)
 nprocplot = args.nproc_plot or args.nproc
 
-def remove_outliers(ts,N):
-    outliers = numpy.nonzero(abs(ts - numpy.mean(ts)) > N*numpy.std(ts))[0]
+
+def remove_outliers(ts, N):
+    outliers = find_outliers(ts, N)
     c = 1
     if outliers.any():
-        print('-- Found %d outliers in %s, recursively removing' % (len(outliers),ts.name))
+        print("-- Found %d outliers in %s, recursively removing"
+              % (len(outliers), ts.name))
         while outliers.any():
+            unit = ts.unit
             cache = outliers
             mask = numpy.ones(len(ts), dtype=bool)
             mask[outliers] = False
-            spline = UnivariateSpline(ts[mask].times.value,ts[mask].value,s=0,k=3)
-            ts[outliers] = spline(ts[outliers].times.value)
-            outliers = numpy.nonzero(abs(ts - numpy.mean(ts)) > N*numpy.std(ts))[0]
-            print('Completed %d removal cycles' % c)
-            if numpy.array_equal(outliers,cache):
-                print('Outliers did not change, breaking recursion')
+            spline = UnivariateSpline(ts[mask].times.value, ts[mask].value,
+                                      s=0, k=3)
+            ts[outliers] = (spline(ts[outliers].times.value) * unit)
+            outliers = find_outliers(ts, N)
+            print("Completed %d removal cycles" % c)
+            if numpy.array_equal(outliers, cache):
+                print("Outliers did not change, breaking recursion")
                 break
-            print('%d outliers remain' % len(outliers))
+            print("%d outliers remain" % len(outliers))
             c += 1
+
 
 # load data
 print("-- Loading range data")
@@ -145,19 +151,21 @@ else:
     stride = 1
 if flower:
     darmblrms = (
-        darmts.highpass(flower/2., fstop=flower/4., filtfilt=False, ftype='butter').notch(
-        60, filtfilt=False).bandpass(
-        flower, fupper, fstop=[flower/2., fupper*1.5], filtfilt=False, ftype='butter').crop(
-        dstart, dend).rms(stride))
+        darmts.highpass(flower/2., fstop=flower/4.,
+                        filtfilt=False, ftype='butter')
+        .notch(60, filtfilt=False)
+        .bandpass(flower, fupper, fstop=[flower/2., fupper*1.5],
+                  filtfilt=False, ftype='butter')
+        .crop(dstart, dend).rms(stride))
     darmblrms.name = '%s %s-%s Hz BLRMS' % (primary, flower, fupper)
 else:
     darmblrms = darmts.notch(60).crop(dstart, dend).rms(stride)
     darmblrms.name = '%s RMS' % primary
 
 if args.remove_outliers:
-    print('-- Removing outliers above %f sigma' % args.remove_outliers)
-    remove_outliers(darmblrms,args.remove_outliers)
-    remove_outliers(rangets,args.remove_outliers)
+    print("-- Removing outliers above %f sigma" % args.remove_outliers)
+    remove_outliers(darmblrms, args.remove_outliers)
+    remove_outliers(rangets, args.remove_outliers)
 
 if args.trend_type == 'minute':
     # calculate the r value between the DARM BLRMS and the Range timeseries
@@ -168,7 +176,7 @@ else:
     # for second trends, set correlation to 0 since sample rates differ
     corr_p = 0
     corr_s = 0
-    
+
 # create scaled versions of data to compare to each other
 print("-- Creating scaled data")
 rangescaled = rangets.detrend()
@@ -176,7 +184,7 @@ rangerms = numpy.sqrt(sum(rangescaled**2.0)/len(rangescaled))
 darmscaled = darmblrms.detrend()
 darmrms = numpy.sqrt(sum(darmscaled**2.0)/len(darmscaled))
 
-#create scaled darm using the rms(range) and the rms(darm)
+# create scaled darm using the rms(range) and the rms(darm)
 if args.trend_type == 'minute':
     darmscaled *= (-rangerms / darmrms)
 
@@ -192,9 +200,9 @@ else:
 nchan = len(channels)
 print("Identified %d channels" % nchan)
 if args.trend_type == 'minute':
-    frametype = '%s_M' % args.ifo # for minute trends
+    frametype = '%s_M' % args.ifo  # for minute trends
 else:
-    frametype = '%s_T' % args.ifo # for second trends
+    frametype = '%s_T' % args.ifo  # for second trends
 auxdata = TimeSeriesDict.get(map(str, channels), dstart, dend, verbose=True,
                              frametype=frametype, nproc=args.nproc,
                              observatory=args.ifo[0], pad=0)
@@ -209,6 +217,7 @@ counter = multiprocessing.Value('i', 0)
 p1 = (.1, .1, .9, .95)
 p2 = (.1, .15, .9, .9)
 
+
 def process_channel(input_,):
     chan, ts = input_
     flat = ts.value.min() == ts.value.max()
@@ -219,7 +228,7 @@ def process_channel(input_,):
         corr2s = None
         plot1 = None
         plot2 = None
-	plot3 = None
+        plot3 = None
     else:
         corr1 = numpy.corrcoef(ts.value, darmblrms.value)[0, 1]
         corr1s = spearmanr(ts.value, darmblrms.value)[0]
@@ -229,13 +238,16 @@ def process_channel(input_,):
         else:
             corr2 = 0.0
             corr2s = 0.0
-        #if all corralations are below threshold it does not plot
-        if((numpy.absolute(corr1) < args.threshold) and (numpy.absolute(corr1s) < args.threshold)
-                and (numpy.absolute(corr2) < args.threshold) and (numpy.absolute(corr2s) < args.threshold)):
+        # if all corralations are below threshold it does not plot
+        if((abs(corr1) < args.threshold)
+           and (abs(corr1s) < args.threshold)
+           and (abs(corr2) < args.threshold)
+           and (abs(corr2s) < args.threshold)):
             plot1 = None
             plot2 = None
-	    plot3 = None
+            plot3 = None
             return chan, corr1, corr2, plot1, plot2, plot3, corr1s, corr2s
+
         plot = TimeSeriesPlot(darmblrms, ts, rangets, sep=True, sharex=True,
                               figsize=(12, 12))
         plot.subplots_adjust(*p1)
@@ -290,15 +302,15 @@ def process_channel(input_,):
                 raise
         plot.close()
 
-        #plot scatter plots
-        rangeColor="red"
-        darmblrmsColor="blue"
-        plotHeight=10
-        plotWidth=20
+        # plot scatter plots
+        rangeColor = 'red'
+        darmblrmsColor = 'blue'
+        #plotHeight = 10
+        #plotWidth = 20
 
-        tsCopy=ts.reshape(-1,1)
-        rangetsCopy=rangets.reshape(-1,1)
-        darmblrmsCopy=darmblrms.reshape(-1,1)
+        tsCopy = ts.reshape(-1, 1)
+        rangetsCopy = rangets.reshape(-1, 1)
+        darmblrmsCopy = darmblrms.reshape(-1, 1)
 
         darmblrmsReg = linear_model.LinearRegression()
         darmblrmsReg.fit(tsCopy, darmblrmsCopy)
@@ -308,48 +320,55 @@ def process_channel(input_,):
         rangeReg.fit(tsCopy, rangetsCopy)
         rangeFit = rangeReg.predict(tsCopy)
 
+        fig = gwplot(figsize = (12, 6))
+        fig.subplots_adjust(*p2)
+        ax = fig.add_subplot(121)
+        #axes = scatPlot.gca()
+        #ax.set_xlabel(channelstub.replace('_', '\_'), labelpad=30)
+        ax.set_xlabel('Channel units')
+        #ax.set_ylabel(primary.replace('_', '\_') + ' [strain]')
+        ax.set_ylabel('Sensitive range [Mpc]')
+        yrange = abs(max(darmblrms.value) - min(darmblrms.value))
+        upperLim = max(darmblrms.value) + .1 * yrange
+        lowerLim = min(darmblrms.value) - .1 * yrange
+        ax.set_ylim(lowerLim, upperLim)
+        ax.text(.9, .1, 'r = ' + str('{0:.2}'.format(corr1)),
+                verticalalignment='bottom', horizontalalignment='right',
+                transform=ax.transAxes, color='black', size=20,
+                bbox=dict(boxstyle='square', facecolor='white', alpha=.75,
+                          edgecolor='black'))
+        fig.add_scatter(ts, darmblrms, color=darmblrmsColor)
+        fig.add_line(ts, darmblrmsFit, color='black')
+        #fig.set_figheight(plotHeight)
+        #fig.set_figwidth(plotWidth)
 
-        scatPlot=gwplot()
-
-        scatPlot.add_subplot(121)
-        axes = scatPlot.gca()
-        axes.set_xlabel(channelstub.replace("_","\_"), labelpad=30)
-        axes.set_ylabel(primary.replace("_","\_")+" [strain]")
-        range=abs(max(darmblrms.value)-min(darmblrms.value))
-        upperLim=max(darmblrms.value)+.1*range
-        lowerLim=min(darmblrms.value)-.1*range
-        axes.set_ylim(lowerLim,upperLim)
-        axes.text(.9,.1,"r = " + str('{0:.2}'.format(corr1)), verticalalignment='bottom', horizontalalignment='right',
-            transform=axes.transAxes, color="black", size=30)
-        scatPlot.add_scatter(ts, darmblrms, color=darmblrmsColor)
-        scatPlot.add_line(ts, darmblrmsFit, color="black")
-        scatPlot.set_figheight(plotHeight)
-        scatPlot.set_figwidth(plotWidth)
-
-        scatPlot.add_subplot(122)
-        axes = scatPlot.gca()
-        axes.set_xlabel(channelstub.replace("_","\_"), labelpad=30)
-        axes.set_ylabel(rangechannel.replace("_","\_")+" [Mpc]")
-        axes.text(.9,.1,"r = " + str('{0:.2}'.format(corr2)), verticalalignment='bottom', horizontalalignment='right',
-            transform=axes.transAxes, color="black", size=30)
-        scatPlot.add_scatter(ts, rangets, color=rangeColor)
-        scatPlot.add_line(ts, rangeFit, color="black")
-        scatPlot.set_figheight(plotHeight)
-        scatPlot.set_figwidth(plotWidth)
-
+        ax = fig.add_subplot(122)
+        #axes = scatPlot.gca()
+        #ax.set_xlabel(channelstub.replace('_', '\_'), labelpad=30)
+        ax.set_xlabel('Channel units')
+        #ax.set_ylabel(rangechannel.replace('_', '\_') + ' [Mpc]')
+        ax.set_ylabel('$h(t)$ BLRMS [strain]')
+        ax.text(.9, .1, 'r = ' + str('{0:.2}'.format(corr2)),
+                verticalalignment='bottom', horizontalalignment='right',
+                transform=ax.transAxes, color='black', size=20,
+                bbox=dict(boxstyle='square', facecolor='white', alpha=.75,
+                          edgecolor='black'))
+        fig.add_scatter(ts, rangets, color=rangeColor)
+        fig.add_line(ts, rangeFit, color='black')
+        #scatPlot.set_figheight(plotHeight)
+        #scatPlot.set_figwidth(plotWidth)
 
         plot3 = '%s_SCATTER-%s.png' % (channelstub, gpsstub)
-	try:
-            scatPlot.save(plot3)
+        try:
+            fig.save(plot3)
         except (IOError, IndexError):
-            scatPlot.save(plot3)
+            fig.save(plot3)
         except RuntimeError as e:
             if 'latex' in str(e).lower():
-                scatPlot.save(plot3)
+                fig.save(plot3)
             else:
                 raise
-
-        scatPlot.close()
+        plt.close(fig)
 
     # increment counter and print status
     with counter.get_lock():
@@ -360,13 +379,12 @@ def process_channel(input_,):
         sys.stdout.flush()
     return chan, corr1, corr2, plot1, plot2, plot3, corr1s, corr2s
 
+
 pool = multiprocessing.Pool(nprocplot)
 results = pool.map(process_channel, auxdata.iteritems())
-results.sort(key=lambda x: (x[1] is not None and max(abs(x[1]),abs(x[2]),
-             abs(x[6]),abs(x[7])) or 0, x[0]), reverse=True)
+results.sort(key=lambda x: (x[1] is not None and max(abs(x[1]), abs(x[2]),
+             abs(x[6]), abs(x[7])) or 0, x[0]), reverse=True)
 rhos = numpy.asarray([x[1] for x in results if x is not None])
-
-print("")
 
 with open('results.txt', 'w') as f:
     for ch, corr1, corr2, _, _, _, corr1s, corr2s in results:
@@ -379,7 +397,8 @@ page.div(class_='container')
 
 # header
 if flower:
-    pstr = '<code>%s</code> (band-limited %s-%s Hz)' % (primary, flower, fupper)
+    pstr = ('<code>%s</code> (band-limited %s-%s Hz)'
+            % (primary, flower, fupper))
 else:
     pstr = primary
 if args.trend_type == 'minute':
@@ -418,34 +437,40 @@ scipylink = html.markup.oneliner.a(
     href="http://docs.scipy.org/doc/scipy-0.14.0/reference/generated/"
          "scipy.stats.spearmanr.html",
     rel="external")
-page.p("In the results below, all %s values are calculated as the square of %s using %s"
-"and all %s values are calculated as the square of %s using %s."
+page.p("In the results below, all %s values are calculated as"
+       " the square of %s using %s and all %s values are calculated"
+       " as the square of %s using %s."
        % (r, Pearson_wikilink, numpylink, rho, Spearman_wikilink, scipylink))
 if args.trend_type == 'minute':
-    page.p("%s and %s are reported for <code>%s</code>. %s and %s are reported for"
-    "<code>%s</code>. The %s between these two channels is %.2f."
-    "The %s between these two channels is %.2f."
-        % (r_blrms, rho_blrms, primary, r_range, rho_range, rangechannel, r, corr_p, rho, corr_s))
-    
+    page.p("%s and %s are reported for <code>%s</code>."
+           " %s and %s are reported for <code>%s</code>."
+           " The %s between these two channels is %.2f."
+           " The %s between these two channels is %.2f."
+           % (r_blrms, rho_blrms, primary, r_range, rho_range,
+              rangechannel, r, corr_p, rho, corr_s))
+
 page.div(class_='panel-group', id_='results')
 for i, (ch, corr1, corr2, plot1, plot2, plot3, corr1s, corr2s) in enumerate(results):
     if corr1 is None:
         h = '%s [flat]' % ch
     elif plot1 is None:
-        h = '%s [%s = %.2f, %s = %.2f] [%s = %.2f, %s = %.2f] [below threshold]' % (ch, r_blrms, corr1,
-        r_range, corr2, rho_blrms, corr1s, rho_range, corr2s)
+        h = ('%s [%s = %.2f, %s = %.2f] [%s = %.2f, %s = %.2f]'
+             ' [below threshold]'
+             % (ch, r_blrms, corr1, r_range, corr2, rho_blrms,
+                corr1s, rho_range, corr2s))
     elif args.trend_type == 'minute':
-        h = '%s [%s = %.2f, %s = %.2f] [%s = %.2f, %s = %.2f]' % (ch, r_blrms, corr1,
-        r_range, corr2, rho_blrms, corr1s, rho_range, corr2s)
+        h = ('%s [%s = %.2f, %s = %.2f] [%s = %.2f, %s = %.2f]'
+             % (ch, r_blrms, corr1, r_range, corr2, rho_blrms,
+                corr1s, rho_range, corr2s))
     else:
         h = '%s [%s = %.2f]' % (ch, r_blrms, corr1)
     if (corr1 is None) or (corr1 == 0) or (plot1 is None):
         context = 'panel-default'
     elif((numpy.absolute(corr1) >= .6) or (numpy.absolute(corr1s) >= .6)
-          or (numpy.absolute(corr2) >= .6) or (numpy.absolute(corr2s) >= .6)):
+         or (numpy.absolute(corr2) >= .6) or (numpy.absolute(corr2s) >= .6)):
         context = 'panel-danger'
     elif((numpy.absolute(corr1) >= .4) or (numpy.absolute(corr1s) >= .4)
-          or (numpy.absolute(corr2) >= .4) or (numpy.absolute(corr2s) >= .4)):
+         or (numpy.absolute(corr2) >= .4) or (numpy.absolute(corr2s) >= .4)):
         context = 'panel-warning'
     else:
         context = 'panel-info'
@@ -459,9 +484,11 @@ for i, (ch, corr1, corr2, plot1, plot2, plot3, corr1s, corr2s) in enumerate(resu
     page.div(id_='channel%d' % i, class_='panel-collapse collapse')
     page.div(class_='panel-body')
     if corr1 is None:
-        page.p("The amplitude data for this channel is flat (does not change) for the chosen time period.")
+        page.p("The amplitude data for this channel is flat"
+               " (does not change) for the chosen time period.")
     elif plot1 is None:
-        page.p("Niether r or rho are above the threshold of %.2f." %(args.threshold))
+        page.p("Niether r nor rho are above the threshold of %.2f."
+               % (args.threshold))
     else:
         for p in (plot1, plot2, plot3):
             page.a(href=p, target='_blank')
@@ -472,12 +499,14 @@ for i, (ch, corr1, corr2, plot1, plot2, plot3, corr1s, corr2s) in enumerate(resu
     page.div.close()  # panel
 page.div.close()  # panel-group
 
+
 # params
 def write_param(param, value):
     page.p()
     page.strong('%s: ' % param)
     page.add(str(value))
     page.p.close()
+
 
 page.h2('Parameters')
 page.p('This analysis used the following parameters:')


### PR DESCRIPTION
Hi Duncan,

I added to the file code that generates two scatter plots for each auxiliary channel: 1) channel vs strain and 2) channel vs range. When I run this, it generates an HTML page output like so (https://ldas-jobs.ligo-la.caltech.edu/~alexandra.macedo/detchar/O1/L1-slow-correlation-1133906417-7199/), where the two scatter plots have been added below the other plots for each channel.

Disclaimers: With your last commit, c05f107 (https://github.com/ligovirgo/gwdetchar/commit/c05f1070baa9648d9902fdcc4592c61576c3ae2c#diff-c611d65ec72daf5387046f33ba3faed8), and its changes to gwdetchar-slow-correlation, I am unable to run gwdetchar-slow-correlation with the virtual environment install via these instructions that you and Dr. Smith provided (https://wiki.ligo.org/viewauth/DetChar/O1NoiseBreathing). In order to run gwdetchar-slow-correlation at all, it only works if I source detchar's install of gwpysoft and point to my own code with your last commit reverted (meaning, I undid the 2 changes you made to gwdetchar-slow-correlation that were made in commit c05f107). However, it seems you may be working on a new module, nds2, so after I got my code to work with the commit reverted, I replaced the lines to reflect your latest commit so that it is consistent with what you are currently working on. Please refer to the CSUF slack thread for the command that generates the error and the error message, itself, when I try to run gwdetchar-slow-correlation with the virtual environment's install of gwpysoft.