### PR TITLE
Fixed deprecated import of OrderedDict

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,9 @@ addons:
       - liblapack-dev  # scipy
 
 python:
-  - '2.6'
   - '2.7'
   - '3.5'
+  - '3.6'
 
 env:
   global:
@@ -33,20 +33,14 @@ env:
     - PIP_FLAGS="--quiet"
 
 matrix:
-  exclude:
-    - python: '2.6'
-      env: PIP_FLAGS="--quiet --pre"
   allow_failures:
-    - python: '2.6'
     - python: '3.5'
+    - python: '3.6'
   fast_finish: true
 
 before_install:
   - pip install -q --upgrade pip
-  # need to install astropy 1.1 specifically for py26
-  - if [[ ${TRAVIS_PYTHON_VERSION} == '2.6' ]]; then pip install "astropy==1.1"; fi
   - pip install ${PIP_FLAGS} -r requirements.txt
-  - .travis/build-lal.sh
   - pip install ${PIP_FLAGS} coveralls unittest2 pytest
 
 install:

--- a/bin/gwdetchar-scattering
+++ b/bin/gwdetchar-scattering
@@ -25,19 +25,20 @@ from __future__ import division
 import os.path
 import re
 import warnings
-from StringIO import StringIO
+from collections import OrderedDict
+
+from six.moves import StringIO
 
 import numpy
 
 from matplotlib import (use, rcParams)
-use('agg')
+use('agg')  # nopep8
 
 import trigfind
 
 from glue.lal import Cache
 
 from gwpy.plotter import (figure, HistogramPlot)
-from gwpy.utils.compat import OrderedDict
 from gwpy.utils import gprint
 from gwpy.table import EventTable
 from gwpy.timeseries import TimeSeriesDict

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,10 @@
+numpy >= 1.10
+scipy >= 0.16
+matplotlib >= 1.4.1
+astropy >= 1.2
+gwpy >= 0.7
+lalsuite
+lscsoft-glue
+dqsegdb
 beautifulsoup4
-astropy
-m2crypto
-pykerberos
-python-cjson
-http://software.ligo.org/lscsoft/source/glue-1.54.1.tar.gz
-http://software.ligo.org/lscsoft/source/dqsegdb-1.4.0.tar.gz
 https://github.com/ligovirgo/trigfind/archive/v0.3.tar.gz
-gwpy>=0.4

--- a/setup.py
+++ b/setup.py
@@ -22,10 +22,6 @@
 
 from __future__ import print_function
 
-import sys
-if sys.version < '2.6':
-    raise ImportError("Python versions older than 2.6 are not supported.")
-
 import glob
 import os.path
 


### PR DESCRIPTION
This PR fixes the broken import of `collections.OrderedDict` in `gwdetchar-scattering`, since the module used as a reference was removed from gwpy. We can just import that object from the standard library anyway.

This PR also revamps the requirements lists in `requirements.txt` and `setup.py` to bring them a bit more up-to-date, and removes python2.6 from the travis-ci configuration (replacing with python**3**.6).