### PR TITLE
Updated to use renamed gwtrigfind module

### DIFF
--- a/bin/gwdetchar-scattering
+++ b/bin/gwdetchar-scattering
@@ -34,7 +34,7 @@ import numpy
 from matplotlib import (use, rcParams)
 use('agg')  # nopep8
 
-import trigfind
+import gwtrigfind
 
 from glue.lal import Cache
 
@@ -158,8 +158,8 @@ if args.plot_main_tiles:
 
 fullcache = Cache()
 for seg in statea:
-    cache = trigfind.find_trigger_files(args.main_channel, 'omicron',
-                                        seg[0], seg[1])
+    cache = gwtrigfind.find_trigger_files(args.main_channel, 'omicron',
+                                          seg[0], seg[1])
     if len(cache) == 0:
         warnings.warn("No Omicron triggers found for %s in segment [%d .. %d)"
                       % (args.main_channel, seg[0], seg[1]))

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ lscsoft-glue
 dqsegdb
 beautifulsoup4
 lxml
-https://github.com/ligovirgo/trigfind/archive/v0.3.tar.gz
+gwtrigfind

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ install_requires = [
     'astropy>=1.2',
     'gwpy>=0.5',
     'lscsoft-glue',
-    'trigfind>=0.3',
+    'gwtrigfind',
 ]
 requires = [
     'numpy',
@@ -91,10 +91,6 @@ setup(name=DISTNAME,
       install_requires=install_requires,
       requires=requires,
       extras_require=extras_require,
-      dependency_links=[
-          'https://github.com/ligovirgo/trigfind/archive/v0.3.tar.gz'
-              '#egg=trigfind-0.3',
-      ],
       use_2to3=True,
       classifiers=[
           'Programming Language :: Python',


### PR DESCRIPTION
This PR updates this package to use the newly renamed and distributed [`gwtrigfind`](//pypi.org/project/gwtrigfind) package. This should resolve the annoying errors when installing this package from source related to `trigfind`.