### PR TITLE
Adding proper support for python2.x version of ConfigParser

### DIFF
--- a/bin/gwdetchar-omega
+++ b/bin/gwdetchar-omega
@@ -294,7 +294,10 @@ for d in [plotdir, aboutdir]:
         os.makedirs(d)
 
 # determine channel blocks
-blocks = [OmegaChannelList(**cp[s]) for s in cp.sections()]
+try:  # python 3.x
+    blocks = [OmegaChannelList(**cp[s]) for s in cp.sections()]
+except:  # python 2.x
+    blocks = [OmegaChannelList(**dict(cp.items(s))) for s in cp.sections()]
 
 # set up html output
 gprint('Setting up HTML at %s/index.html...' % outdir)

--- a/gwdetchar/omega/config.py
+++ b/gwdetchar/omega/config.py
@@ -24,7 +24,7 @@ How to write a configuration file
 =================================
 """
 
-try:
+try:  # python 3.x
     import configparser
 except ImportError:  # python 2.x
     import ConfigParser as configparser


### PR DESCRIPTION
This PR adds proper support for `ConfigParser`, the native python2 configuration parser. It solves a version issue by creating a dictionary of section parameters if a call to `configparser[section]` fails.

Test output is here (requires `LIGO.ORG` credentials): https://ldas-jobs.ligo-la.caltech.edu/~aurban/wdq/L1_1172489783.07/

This fixes #100.