### PR TITLE
Updating matplotlib dependence requirement from 1.4.1 to 2.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 six
 numpy >= 1.10
 scipy >= 0.16
-matplotlib >= 1.4.1
+matplotlib >= 2.0.0
 astropy >= 1.2
 gwpy >= 0.7
 lalsuite

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ install_requires = [
     'six',
     'numpy>=1.10',
     'scipy>=0.16',
-    'matplotlib>=1.4.1',
+    'matplotlib>=2.0.0',
     'astropy>=1.2',
     'gwpy>=0.5',
     'lscsoft-glue',


### PR DESCRIPTION
This PR updates the dependence requirement from matplotlib version 1.4.1 to version 2.0.0, which introduces `:meth:matplotlib.axes.Axes.set_facecolor`.