### PR TITLE
Removing gwdetchar.utils.which from wdq

### DIFF
--- a/bin/wdq
+++ b/bin/wdq
@@ -34,7 +34,6 @@ from gwpy.time import to_gps
 
 from gwdetchar import (cli, omega, const)
 from gwdetchar.io import datafind
-from gwdetchar.utils import which
 
 parser = cli.create_parser(description=__doc__)
 parser.add_argument('gpstime', type=str, help='GPS time of scan')


### PR DESCRIPTION
Very minor PR that removes a deprecated import from `bin/wdq`.

Test output with the change is here (requires `LIGO.ORG` credentials): https://ldas-jobs.ligo-la.caltech.edu/~aurban/wdq-test/L1_1183077855.74/

This fixes #108.