### PR TITLE
Allow users to read config files with relative paths in gwdetchar-omega

### DIFF
--- a/bin/gwdetchar-omega
+++ b/bin/gwdetchar-omega
@@ -86,6 +86,17 @@ ifo = args.ifo
 obs = ifo[0]
 far = args.far_threshold
 
+# parse configuration file
+config_files = [os.path.abspath(f) for f in args.config_file]
+cp = config.OmegaConfigParser(ifo=ifo)
+cp.read(config_files)
+
+# prepare html variables
+htmlv = {
+    'title': '%s Qscan | %s' % (ifo, gps),
+    'config': config_files,
+}
+
 # set output directory
 outdir = args.output_directory
 if outdir is None:
@@ -94,16 +105,6 @@ if not os.path.isdir(outdir):
     os.makedirs(outdir)
 os.chdir(outdir)
 print("Output directory created as %s" % outdir)
-
-# parse configuration file
-cp = config.OmegaConfigParser(ifo=ifo)
-cp.read(args.config_file)
-
-# prepare html variables
-htmlv = {
-    'title': '%s Qscan | %s' % (ifo, gps),
-    'config': args.config_file,
-}
 
 
 # -- FIXME: Eventually move these classes to gwdetchar.omega ------------------


### PR DESCRIPTION
Previously there was a bug which prevented config files from being read when they are specified with relative paths. This PR adapts for this by using `:meth:os.path.abspath`:

```
config_files = [os.path.abspath(s) for s in args.config_file]
```

Example output is [here](https://ldas-jobs.ligo-la.caltech.edu/~aurban/wdq/blips/L1_1162450736.150/) (requires `LIGO.ORG` credentials). Note, on the [about](https://ldas-jobs.ligo-la.caltech.edu/~aurban/wdq/blips/L1_1162450736.150/about) page the config file is specified as `blips.ini` with no absolute path.

This fixes #107.