### PR TITLE
rescaling and black primary

### DIFF
--- a/bin/gwdetchar-lasso-correlation
+++ b/bin/gwdetchar-lasso-correlation
@@ -153,8 +153,10 @@ lsig.add_argument('-C', '--no-cluster', action='store_true', default=False,
                   help='do not generate clustered channel plots')
 lsig.add_argument('-c', '--cluster-coefficient', default=.85, type=float,
                   help='correlation coefficient threshold for clustering')
-lsig.add_argument('-L', '--line-size', default=1, type=float,
+lsig.add_argument('-L', '--line-size-primary', default=1, type=float,
                   help='line width of primary channel')
+lsig.add_argument('-l', '--line-size-aux', default=0.75, type=float,
+                  help='line width of auxilary channel')
 
 args = parser.parse_args()
 
@@ -416,8 +418,9 @@ fig = plt.figure(figsize=(12, 6))
 fig.subplots_adjust(*p1)
 ax = fig.add_subplot(1, 1, 1)
 ax.plot(hour_axis, descaler(scale(primaryts.value)), color='black',
-        linewidth=args.line_size, label=primary.replace('_', '\_'))
-ax.plot(hour_axis, descaler(modelFit), label='Lasso model')
+        linewidth=args.line_size_primary, label=primary.replace('_', '\_'))
+ax.plot(hour_axis, descaler(modelFit),
+        linewidth=args.line_size_aux, label='Lasso model')
 ax.margins(x=0)
 ax.set_xlabel(auto_xlabel)
 if range_is_primary:
@@ -449,11 +452,14 @@ fig.subplots_adjust(*p1)
 ax = fig.add_subplot(1, 1, 1)
 firstchan = sorted_results[0][0]
 
+cmap = plt.get_cmap('tab20')
+colormaps = [cmap(i) for i in numpy.linspace(0, 1, len(nonzerodata)+1)]
+
 line1 = ax.plot(
     hour_axis,
     descaler(scale(primaryts.value)),
     color='black',
-    linewidth=args.line_size,
+    linewidth=args.line_size_primary,
     label=primary.replace('_', '\_'))
 colors.append(line1[0].get_color())
 labels.append(line1[0].get_label())
@@ -461,7 +467,7 @@ labels.append(line1[0].get_label())
 line2 = ax.plot(
     hour_axis,
     descaler(scale(nonzerodata[firstchan].value)*nonzerocoef[firstchan]),
-    label='Channel 1')
+    linewidth=args.line_size_aux, label='Channel 1', color=colormaps[0])
 colors.append(line2[0].get_color())
 labels.append(line2[0].get_label())
 
@@ -472,7 +478,8 @@ for n in range(1, len(nonzerodata)):
         summation = numpy.add(summation, (scale(nonzerodata[chan].value)
                                           * nonzerocoef[chan]))
     line = ax.plot(hour_axis, descaler(summation),
-                   label='Channels 1-' + str(n+1))
+                   linewidth=args.line_size_aux,
+                   label='Channels 1-' + str(n+1), color=colormaps[n])
     colors.append(line[0].get_color())
     labels.append(line[0].get_label())
 
@@ -530,7 +537,8 @@ fig = plt.figure(figsize=(8, 5))
 fig.subplots_adjust(*p1)
 ax = fig.add_subplot(1, 1, 1)
 line = ax.plot(hour_axis, descaler(scale(primaryts.value)), color='black',
-               linewidth=args.line_size, label=primary.replace('_', '\_'))
+               linewidth=args.line_size_primary,
+               label=primary.replace('_', '\_'))
 colors.append(line[0].get_color())
 labels.append(line[0].get_label())
 
@@ -539,8 +547,9 @@ for n in range(0, len(nonzerodata)):
     if nonzerodata[chan] is not None:
         line = ax.plot(hour_axis,
                        (descaler(scale(nonzerodata[chan].value)
-                           * nonzerocoef[chan])),
-                       label=chan.replace('_', '\_'))
+                                 * nonzerocoef[chan])),
+                       linewidth=args.line_size_aux,
+                       label=chan.replace('_', '\_'), color=colormaps[n])
         colors.append(line[0].get_color())
         labels.append(line[0].get_label())
 
@@ -631,8 +640,11 @@ def process_channel(input_,):
 
         # create time series subplots
         fig, (ax1, ax2) = plt.subplots(2, sharex=True, figsize=(12, 12))
-        ax1.plot(hour_axis, primaryts, color='black', linewidth=args.line_size, label=primary.replace('_', '\_'))
-        ax2.plot(hour_axis, ts, label=chan.replace('_', '\_'))
+        ax1.plot(hour_axis, primaryts, color='black',
+                 linewidth=args.line_size_primary,
+                 label=primary.replace('_', '\_'))
+        ax2.plot(hour_axis, ts,
+                 linewidth=args.line_size_aux, label=chan.replace('_', '\_'))
         fig.subplots_adjust(*p4)
         if range_is_primary:
             ax1.set_ylabel('Sensitive range [Mpc]')
@@ -672,10 +684,11 @@ def process_channel(input_,):
         ax = fig.add_subplot(1, 1, 1)
         ax.plot(
             hour_axis, descaler(scale(primaryts.value)),
-            color='black', linewidth=args.line_size,
+            color='black', linewidth=args.line_size_primary,
             label=primary.replace('_', '\_'))
         ax.plot(
             hour_axis, descaler(tsscaled),
+            linewidth=args.line_size_aux,
             label=chan.replace('_', '\_'))
         ax.margins(x=0)
         ax.set_xlabel(auto_xlabel)
@@ -815,16 +828,11 @@ def generate_cluster(input_,):
             fig = plt.figure(figsize=(8, 5))
             fig.subplots_adjust(*p7)
             ax = fig.add_subplot(1, 1, 1)
-            line = ax.plot(
-                hour_axis,
-                scale(currentts.value)*numpy.sign(input_[1][1]),
-                label=currentchan.replace('_', '\_'))
-            colors.append(line[0].get_color())
-            labels.append(line[0].get_label())
             current_cluster = sorted(current_cluster, key=lambda x: abs(x[2]),
                                      reverse=True)
 
             exceeds_max_chans = len(current_cluster) > max_correlated_channels
+            cmap = plt.get_cmap('tab20')
             if exceeds_max_chans:
                 cluster_range = max_correlated_channels
                 clustertab = (
@@ -836,15 +844,26 @@ def generate_cluster(input_,):
                             .replace('_', '-', 1),
                     gpsstub)
                 clustertab.write(plot7_list, format='ascii', overwrite=True)
+                colormaps = [cmap(i) for i in numpy.linspace(0, 1, 21)]
             else:
                 cluster_range = len(current_cluster)
-
+                colormaps = [cmap(i) for i in
+                             numpy.linspace(0, 1, cluster_range+1)]
+            line = ax.plot(
+                hour_axis,
+                scale(currentts.value)*numpy.sign(input_[1][1]),
+                linewidth=args.line_size_aux,
+                label=currentchan.replace('_', '\_'), color=colormaps[0])
+            colors.append(line[0].get_color())
+            labels.append(line[0].get_label())
             for i in range(0, cluster_range):
                 line = ax.plot(
                     hour_axis,
                     (scale(current_cluster[i][1].value)
                         * numpy.sign(input_[1][1])
                         * numpy.sign(current_cluster[i][2])),
+                    color=colormaps[i+1],
+                    linewidth=args.line_size_aux,
                     label=(current_cluster[i][3].replace('_', '\_')
                            + ', r = '
                            + str('{0:.2}'.format(current_cluster[i][2]))))

--- a/bin/gwdetchar-lasso-correlation
+++ b/bin/gwdetchar-lasso-correlation
@@ -30,7 +30,6 @@ import shutil
 
 from math import (isnan, isinf, log, log10)
 import numpy
-from scipy.stats import spearmanr
 from scipy.interpolate import UnivariateSpline
 import astropy.units as u
 
@@ -154,6 +153,8 @@ lsig.add_argument('-C', '--no-cluster', action='store_true', default=False,
                   help='do not generate clustered channel plots')
 lsig.add_argument('-c', '--cluster-coefficient', default=.85, type=float,
                   help='correlation coefficient threshold for clustering')
+lsig.add_argument('-L', '--line-size', default=1, type=float,
+                  help='line width of primary channel')
 
 args = parser.parse_args()
 
@@ -222,6 +223,17 @@ else:
 if args.remove_outliers:
     print("-- Removing outliers above %f sigma" % args.remove_outliers)
     remove_outliers(primaryts, args.remove_outliers)
+
+primary_mean = numpy.mean(primaryts.value)
+primary_std = numpy.std(primaryts.value)
+
+
+def descaler(l, *coef):
+    if coef:
+        return [((x * primary_std * coef[0]) + primary_mean) for x in l]
+    else:
+        return [((x * primary_std) + primary_mean) for x in l]
+
 
 hour_axis = (numpy.arange(len(primaryts.value)))/60
 for i in range(len(hour_axis)):
@@ -403,14 +415,16 @@ p1 = (.1, .15, .9, .9)  # global plot defaults for plot1, lasso model
 fig = plt.figure(figsize=(12, 6))
 fig.subplots_adjust(*p1)
 ax = fig.add_subplot(1, 1, 1)
-ax.plot(hour_axis, scale(primaryts.value), label=primary.replace('_', '\_'))
-ax.plot(hour_axis, modelFit, label='Lasso model')
+ax.plot(hour_axis, descaler(scale(primaryts.value)), color='black',
+        linewidth=args.line_size, label=primary.replace('_', '\_'))
+ax.plot(hour_axis, descaler(modelFit), label='Lasso model')
 ax.margins(x=0)
 ax.set_xlabel(auto_xlabel)
-ax.set_ylabel('Scaled arbitrary units')
 if range_is_primary:
+    ax.set_ylabel('Sensitive range [Mpc]')
     ax.set_title('Lasso Model of Range')
 else:
+    ax.set_ylabel('Primary Channel Units')
     ax.set_title('Lasso Model of Primary Channel')
 ax.legend(loc='best')
 fig.canvas.draw_idle()
@@ -437,14 +451,16 @@ firstchan = sorted_results[0][0]
 
 line1 = ax.plot(
     hour_axis,
-    scale(primaryts.value),
+    descaler(scale(primaryts.value)),
+    color='black',
+    linewidth=args.line_size,
     label=primary.replace('_', '\_'))
 colors.append(line1[0].get_color())
 labels.append(line1[0].get_label())
 
 line2 = ax.plot(
     hour_axis,
-    scale(nonzerodata[firstchan].value)*nonzerocoef[firstchan],
+    descaler(scale(nonzerodata[firstchan].value)*nonzerocoef[firstchan]),
     label='Channel 1')
 colors.append(line2[0].get_color())
 labels.append(line2[0].get_label())
@@ -455,13 +471,17 @@ for n in range(1, len(nonzerodata)):
         chan = sorted_results[0][m]
         summation = numpy.add(summation, (scale(nonzerodata[chan].value)
                                           * nonzerocoef[chan]))
-    line = ax.plot(hour_axis, summation, label='Channels 1-' + str(n+1))
+    line = ax.plot(hour_axis, descaler(summation),
+                   label='Channels 1-' + str(n+1))
     colors.append(line[0].get_color())
     labels.append(line[0].get_label())
 
 ax.margins(x=0)
 ax.set_xlabel(auto_xlabel)
-ax.set_ylabel('Scaled arbitrary units')
+if range_is_primary:
+    ax.set_ylabel('Sensitive range [Mpc]')
+else:
+    ax.set_ylabel('Primary Channel Units')
 ax.set_title('Summations of Channel Contributions to Model')
 fig.canvas.draw_idle()
 
@@ -509,8 +529,8 @@ labels = []
 fig = plt.figure(figsize=(8, 5))
 fig.subplots_adjust(*p1)
 ax = fig.add_subplot(1, 1, 1)
-line = ax.plot(hour_axis, scale(primaryts.value),
-               label=primary.replace('_', '\_'))
+line = ax.plot(hour_axis, descaler(scale(primaryts.value)), color='black',
+               linewidth=args.line_size, label=primary.replace('_', '\_'))
 colors.append(line[0].get_color())
 labels.append(line[0].get_label())
 
@@ -518,15 +538,18 @@ for n in range(0, len(nonzerodata)):
     chan = sorted_results[0][n]
     if nonzerodata[chan] is not None:
         line = ax.plot(hour_axis,
-                       (scale(nonzerodata[chan].value)
-                           * nonzerocoef[chan]),
+                       (descaler(scale(nonzerodata[chan].value)
+                           * nonzerocoef[chan])),
                        label=chan.replace('_', '\_'))
         colors.append(line[0].get_color())
         labels.append(line[0].get_label())
 
 ax.margins(x=0)
 ax.set_xlabel(auto_xlabel)
-ax.set_ylabel('Scaled arbitrary units')
+if range_is_primary:
+    ax.set_ylabel('Sensitive range [Mpc]')
+else:
+    ax.set_ylabel('Primary Channel Units')
 ax.set_title('Individual Channel Contributions to Model')
 fig.canvas.draw_idle()
 
@@ -607,28 +630,29 @@ def process_channel(input_,):
             return chan, lassocoef, plot4, plot5, plot6, ts
 
         # create time series subplots
-        fig = TimeSeriesPlot(primaryts, ts, sep=True, sharex=True,
-                             figsize=(12, 12))
+        fig, (ax1, ax2) = plt.subplots(2, sharex=True, figsize=(12, 12))
+        ax1.plot(hour_axis, primaryts, color='black', linewidth=args.line_size, label=primary.replace('_', '\_'))
+        ax2.plot(hour_axis, ts, label=chan.replace('_', '\_'))
         fig.subplots_adjust(*p4)
         if range_is_primary:
-            fig.axes[0].set_ylabel('Sensitive range [Mpc]')
+            ax1.set_ylabel('Sensitive range [Mpc]')
         else:
-            fig.axes[0].set_ylabel('Primary channel units')
-        fig.axes[1].set_ylabel('Channel units')
+            ax1.set_ylabel('Primary channel units')
+        ax2.set_ylabel('Channel units')
         for ax in fig.axes:
             ax.legend(loc='best')
-            ax.set_xlim(start, end)
-            ax.set_epoch(start)
+            ax.margins(x=0)
+        ax2.set_xlabel(auto_xlabel)
         channelstub = re_delim.sub('_', str(chan)).replace('_', '-', 1)
 
         plot4 = '%s_TRENDS-%s.png' % (channelstub, gpsstub)
         try:
             fig.canvas.draw_idle()
-            fig.save(plot4)
+            fig.savefig(plot4)
         except (RuntimeError, IOError, IndexError):
             try:
                 fig.canvas.draw_idle()
-                fig.save(plot4)
+                fig.savefig(plot4)
             except (RuntimeError, IOError, IndexError) as e:
                 print("Error trying to save plot4 image, %s: " % plot4)
                 print(e)
@@ -647,14 +671,18 @@ def process_channel(input_,):
         fig.subplots_adjust(*p1)
         ax = fig.add_subplot(1, 1, 1)
         ax.plot(
-            hour_axis, scale(primaryts.value),
+            hour_axis, descaler(scale(primaryts.value)),
+            color='black', linewidth=args.line_size,
             label=primary.replace('_', '\_'))
         ax.plot(
-            hour_axis, tsscaled,
+            hour_axis, descaler(tsscaled),
             label=chan.replace('_', '\_'))
         ax.margins(x=0)
         ax.set_xlabel(auto_xlabel)
-        ax.set_ylabel('Scaled amplitude [arbitrary units]')
+        if range_is_primary:
+            ax.set_ylabel('Sensitive range [Mpc]')
+        else:
+            ax.set_ylabel('Primary Channel Units')
         ax.legend(loc='best')
 
         plot5 = '%s_COMPARISON-%s.png' % (channelstub, gpsstub)

--- a/bin/gwdetchar-lasso-correlation
+++ b/bin/gwdetchar-lasso-correlation
@@ -835,20 +835,22 @@ def generate_cluster(input_,):
             cmap = plt.get_cmap('tab20')
             if exceeds_max_chans:
                 cluster_range = max_correlated_channels
-                clustertab = (
-                    Table(data=(zip(*current_cluster)[3],
-                                zip(*current_cluster)[2]),
-                          names=('Channel', 'Pearson Coefficient')))
-                plot7_list = '%s_CLUSTER_LIST-%s.txt' % (
-                    re_delim.sub('_', str(currentchan))
-                            .replace('_', '-', 1),
-                    gpsstub)
-                clustertab.write(plot7_list, format='ascii', overwrite=True)
                 colormaps = [cmap(i) for i in numpy.linspace(0, 1, 21)]
             else:
                 cluster_range = len(current_cluster)
                 colormaps = [cmap(i) for i in
                              numpy.linspace(0, 1, cluster_range+1)]
+
+            clustertab = (
+                Table(data=(zip(*current_cluster)[3],
+                            zip(*current_cluster)[2]),
+                      names=('Channel', 'Pearson Coefficient')))
+            plot7_list = '%s_CLUSTER_LIST-%s.txt' % (
+                re_delim.sub('_', str(currentchan))
+                        .replace('_', '-', 1),
+                gpsstub)
+            clustertab.write(plot7_list, format='ascii', overwrite=True)
+
             line = ax.plot(
                 hour_axis,
                 scale(currentts.value)*numpy.sign(input_[1][1]),


### PR DESCRIPTION
Following one of the paper referee's good ideas, I have made a few changes: 
I have re-scaled all plots that have the primary channel and another channel to be scaled to the primary channel and in the primary channel's units.
I have changed the primary channel's color to black and added an option to change the line width of the channel.

 [example](https://ldas-jobs.ligo-la.caltech.edu/~jeffrey.bidler/detchar/lasso-tests/lasso-test-suite/suitev0.10/RTD/)

I also removed 
from scipy.stats import spearmanr
because we don't use it anymore

from commit 2: added a line width option for auxiliary channels changed colormap to tab20 for more colors