### PR TITLE
Modified gwdetchar-omega to use Helvetica Neue font (not Lato)

### DIFF
--- a/gwdetchar/omega/html.py
+++ b/gwdetchar/omega/html.py
@@ -86,7 +86,6 @@ body {
 		margin-bottom: 120px;
 		min-height: 100%;
 		font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
-		font-weight: 300;
 		-webkit-font-smoothing: antialiased;
 }
 .navbar {
@@ -626,11 +625,9 @@ def write_summary(
            'channels for a given interferometer and GPS time. Time-frequency '
            'maps are computed using the <a '
            'href="https://gwpy.github.io/docs/stable/examples/timeseries/'
-           'qscan.html" target="_blank">Q-transform</a>.',
-           style="font-size:18px;")
-    page.p("This analysis is based on the following run arguments.",
-           style="font-size:18px;")
-    page.table(class_=tableclass, style="font-size:18px;")
+           'qscan.html" target="_blank">Q-transform</a>.')
+    page.p("This analysis is based on the following run arguments.")
+    page.table(class_=tableclass)
     # make table body
     page.tbody()
     page.tr()
@@ -666,8 +663,7 @@ def write_toc(blocks):
     page.ul()
     for i, block in enumerate(blocks):
         page.li()
-        page.a('%s' % block.name, href='#block-%s' % block.key,
-               style="font-size:18px;")
+        page.a('%s' % block.name, href='#block-%s' % block.key)
         page.li.close()
     page.ul.close()
     page.div.close()
@@ -708,7 +704,7 @@ def write_block(block, context, tableclass='table table-condensed table-hover '
         page.a("<small>[top]</small>", href='#', class_='text-%s' % context)
     page.div.close()  # pull-right
     # heading
-    page.h3('%s' % block.name, class_='panel-title', style="font-size:18px;")
+    page.h3('%s' % block.name, class_='panel-title')
     page.div.close()  # panel-heading
 
     # -- make body
@@ -720,7 +716,7 @@ def write_block(block, context, tableclass='table table-condensed table-hover '
             channel.energy
         except AttributeError:
             continue
-        page.pre('%s' % cis_link(channel.name), style="font-size:14px;")
+        page.pre('%s' % cis_link(channel.name))
         page.div(class_="container")
         # summary information
         chanstring = channel.name.replace('-', '_').replace(':', '-')
@@ -826,7 +822,7 @@ def write_qscan_page(blocks, context):
     page.add(write_toc(blocks))
     page.h2('Results')
     page.p('The following blocks of channels were scanned for interesting '
-           'time-frequency morphology:', style="font-size:18px;")
+           'time-frequency morphology:')
     for block in blocks:
         page.add(write_block(block, context))
     return page

--- a/gwdetchar/omega/html.py
+++ b/gwdetchar/omega/html.py
@@ -73,11 +73,7 @@ FANCYBOX_CSS = (
 FANCYBOX_JS = (
     "//cdnjs.cloudflare.com/ajax/libs/fancybox/2.1.5/jquery.fancybox.min.js")
 
-FONT_LATO_CSS = (
-    "//fonts.googleapis.com/css?family=Lato:300,700"
-)
-
-CSS_FILES = [BOOTSTRAP_CSS, FANCYBOX_CSS, FONT_LATO_CSS]
+CSS_FILES = [BOOTSTRAP_CSS, FANCYBOX_CSS]
 JS_FILES = [JQUERY_JS, BOOTSTRAP_JS, FANCYBOX_JS]
 
 OMEGA_CSS = """
@@ -89,7 +85,7 @@ body {
 		padding-top: 75px;
 		margin-bottom: 120px;
 		min-height: 100%;
-		font-family: "Lato", "Helvetica Neue", Helvetica, Arial, sans-serif;
+		font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
 		font-weight: 300;
 		-webkit-font-smoothing: antialiased;
 }


### PR DESCRIPTION
This PR modifies the `gwdetchar.omega` module such that `gwdetchar-omega` now produces HTML that uses the Helvetica Neue font, and not Lato. IMO this is more accessible, since its a little easier to read.

I also made some font modifications (make font smaller, a bit).

See the example [here](https://ldas-jobs.ligo.caltech.edu/~duncan.macleod/gwdetchar/testing/1126259462.4-font/).