### PR TITLE
Modified plot toggle display in gwdetchar-omega

### DIFF
--- a/share/sass/gwdetchar-omega.scss
+++ b/share/sass/gwdetchar-omega.scss
@@ -57,3 +57,12 @@ body {
 		background: white;
 }
 
+.dropdown-menu {
+		a {
+				cursor: pointer
+		}
+}
+
+.btn-group {
+		margin-bottom: 10px;
+}


### PR DESCRIPTION
This PR modifies the plot toggle menu in `gwdetchar-omega` to use a single `btn-group` with dropdowns for each plot type (`timeseries`, etc). That element has been moved into the same `div` as the plots themselves, slightly reducing the whitespace for each channel block.