### PR TITLE
Add scikit-learn as a dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ jsmin
 libsass
 # run
 six
+scikit-learn
 numpy >= 1.10
 scipy >= 0.16
 matplotlib >= 2.0.0

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ setup_requires = [
 # run
 install_requires = [
     'six',
+    'scikit-learn',
     'numpy>=1.10',
     'scipy>=0.16',
     'matplotlib>=2.0.0',


### PR DESCRIPTION
`scikit-learn` has been added to `install_requirements` in `setup.py` and to `requirements.txt`