### PR TITLE
Misc. formatting improvements for gwdetchar-omega

### DIFF
--- a/bin/gwdetchar-omega
+++ b/bin/gwdetchar-omega
@@ -374,8 +374,7 @@ for block in blocks[:]:
         if args.verbose:
             gprint('Plotting omega scans for channel %s...' % c.name)
         # work out figure size
-        width = min(16 / len(c.pranges), 8)
-        figsize = [width, 5]
+        figsize = [8, 5]
         for span, png1, png2, png3, png4, png5, png6, png7, png8, png9 in zip(
             c.pranges, c.plots['qscan_whitened'],
             c.plots['qscan_autoscaled'], c.plots['qscan_raw'],

--- a/bin/gwdetchar-omega
+++ b/bin/gwdetchar-omega
@@ -422,6 +422,9 @@ for block in blocks[:]:
         c.t = table.tc
         c.f = table.fc
 
+        # update HTML output
+        html.write_qscan_page(ifo, gps, blocks, **htmlv)
+
         # delete intermediate data products
         del qscan, rqscan, table, rtable, series, hpseries, wseries, asd
 
@@ -432,7 +435,7 @@ for block in blocks[:]:
     if not block.channels:
         blocks.remove(block)
 
-    # update html output
+    # update HTML output
     html.write_qscan_page(ifo, gps, blocks, **htmlv)
 
 

--- a/gwdetchar/omega/html.py
+++ b/gwdetchar/omega/html.py
@@ -688,7 +688,40 @@ def write_block(block, context, tableclass='table table-condensed table-hover '
             continue
         page.li(class_='list-group-item')
         page.div(class_="container")
+
+        page.div(class_='row', style='margin-top:6pt; width:98%')
+
+        # channel name
+        page.div(class_='col-md-7')
         page.h4(cis_link(channel.name))
+        page.div.close()  # col-md-7
+
+        # plot toggle buttons
+        page.div(class_='col-md-5')
+        page.div(class_='btn-group', role='group')
+        for ptitle, pclass, ptypes in [
+            ('Timeseries', 'timeseries', ('raw', 'highpassed', 'whitened')),
+            ('Q-transform', 'qscan', ('raw', 'whitened', 'autoscaled')),
+            ('Eventgram', 'eventgram', ('raw', 'whitened', 'autoscaled')),
+        ]:
+            _id = 'btnGroup{0}{1}'.format(pclass.title(), i)
+            page.div(class_='btn-group', role='group')
+            page.button(id_=_id, type='button',
+                        class_='btn btn-%s dropdown-toggle' % context,
+                        style='opacity:0.8;', **{'data-toggle': 'dropdown'})
+            page.add('{0} view <span class="caret"></span>'.format(ptitle))
+            page.button.close()
+            page.ul(class_='dropdown-menu', role='menu',
+                    **{'aria-labelledby': _id})
+            for ptype in ptypes:
+                page.li(toggle_link('{0}_{1}'.format(pclass, ptype), channel,
+                                    channel.pranges))
+            page.ul.close()  # dropdown-menu
+            page.div.close()  # btn-group
+        page.div.close()  # btn-group
+        page.div.close()  # col-md-5
+
+        page.div.close()  # row
 
         page.div(class_='row')
 
@@ -712,35 +745,10 @@ def write_block(block, context, tableclass='table table-condensed table-hover '
 
         # plots
         page.div(class_='col-md-9')
-
-        # buttons first
-        page.div(class_='btn-group', role='group')
-        for ptitle, pclass, ptypes in [
-            ('Timeseries', 'timeseries', ('raw', 'highpassed', 'whitened')),
-            ('Q-transform', 'qscan', ('raw', 'whitened', 'autoscaled')),
-            ('Eventgram', 'eventgram', ('raw', 'whitened', 'autoscaled')),
-        ]:
-            _id = 'btnGroup{0}{1}'.format(pclass.title(), i)
-            page.div(class_='btn-group', role='group')
-            page.button(id_=_id, type='button',
-                        class_='btn btn-%s dropdown-toggle' % context,
-                        style='opacity:0.6;', **{'data-toggle': 'dropdown'})
-            page.add('{0} view <span class="caret"></span>'.format(ptitle))
-            page.button.close()
-            page.ul(class_='dropdown-menu', role='menu',
-                    **{'aria-labelledby': _id})
-            for ptype in ptypes:
-                page.li(toggle_link('{0}_{1}'.format(pclass, ptype), channel,
-                                    channel.pranges))
-            page.ul.close()  # dropdown-menu
-            page.div.close()  # btn-group
-        page.div.close()  # btn-group
-
-        # plots
         page.add(scaffold_plots(channel.plots['qscan_whitened'],
                  nperrow=min(len(channel.pranges), 2)))
-
         page.div.close()  # col-md-9
+
         page.div.close()  # row
         page.div.close()  # container
         page.li.close()

--- a/gwdetchar/omega/html.py
+++ b/gwdetchar/omega/html.py
@@ -247,7 +247,7 @@ def init_page(ifo, gpstime, css=None, script=None, base=os.path.curdir,
              style='background-color:%s;' % GW_OBSERVATORY_COLORS[ifo])
     page.div(class_='container')
     page.h4('%s Omega Scan <span style="float:right;">%s</span>'
-            % (ifo, gpstime), style="text-align:left;")
+            % (ifo, gpstime), style="text-align:left; font-weight:normal;")
     page.div.close()  # container
     page.div.close()  # navbar
 
@@ -590,7 +590,7 @@ def write_summary(
     """
     utc = tconvert(gpstime)
     page = markup.page()
-    page.h2(header)
+    page.h2(header, style='font-weight:normal;')
     page.p('This page shows time-frequency maps of a user-configured list of '
            'channels for a given interferometer and GPS time. Time-frequency '
            'maps are computed using the <a '
@@ -629,7 +629,7 @@ def write_toc(blocks):
     """
     page = markup.page()
     page.div(class_="container")
-    page.h2('Table of Contents')
+    page.h2('Table of Contents', style='font-weight:normal;')
     page.ul()
     for i, block in enumerate(blocks):
         page.li()
@@ -674,7 +674,8 @@ def write_block(block, context, tableclass='table table-condensed table-hover '
         page.a("<small>[top]</small>", href='#', class_='text-%s' % context)
     page.div.close()  # pull-right
     # heading
-    page.h3('%s' % block.name, class_='panel-title')
+    page.h3('%s' % block.name, class_='panel-title',
+            style='font-weight:normal;')
     page.div.close()  # panel-heading
 
     # -- make body
@@ -693,7 +694,7 @@ def write_block(block, context, tableclass='table table-condensed table-hover '
 
         # channel name
         page.div(class_='col-md-7')
-        page.h4(cis_link(channel.name))
+        page.h4(cis_link(channel.name), style='font-weight:normal;')
         page.div.close()  # col-md-7
 
         # plot toggle buttons
@@ -787,7 +788,7 @@ def write_qscan_page(blocks, context):
     """
     page = markup.page()
     page.add(write_toc(blocks))
-    page.h2('Results')
+    page.h2('Results', style='font-weight:normal;')
     page.p('The following blocks of channels were scanned for interesting '
            'time-frequency morphology:')
     for block in blocks:
@@ -847,10 +848,10 @@ def write_about_page(configfiles):
         the path of the HTML written for this analysis
     """
     page = markup.page()
-    page.h2('On the command line')
+    page.h2('On the command line', style='font-weight:normal;')
     page.p('This page was generated with the command line call shown below.')
     page.pre(' '.join(sys.argv))
-    page.h2('Configuration file')
+    page.h2('Configuration file', style='font-weight:normal;')
     page.p('Omega scans are configured through INI-format files. The files '
            'used for this analysis are reproduced below in full.')
     for configfile in configfiles:

--- a/gwdetchar/omega/html.py
+++ b/gwdetchar/omega/html.py
@@ -463,7 +463,7 @@ def fancybox_img(img, linkparams=dict(), **params):
     return str(page)
 
 
-def scaffold_plots(plots, nperrow=2):
+def scaffold_plots(plots, nperrow=3):
     """Embed a `list` of images in a bootstrap scaffold
 
     Parameters
@@ -692,8 +692,32 @@ def write_block(block, context, tableclass='table table-condensed table-hover '
         page.div(class_='row')
 
         # channel name
-        page.div(class_='col-md-7')
         page.h4(cis_link(channel.name))
+
+        page.div(class_='row')
+
+        # summary table
+        page.div(class_='col-md-7')
+        page.p("Properties of the most significant time-frequency tile")
+        page.table(class_=tableclass)
+        columns = ['GPS Time', 'Frequency', 'Q Factor', 'Normalized Energy',
+                   'SNR']
+        entries = ['%.3f' % channel.t, '%.1f Hz' % channel.f,
+                   '%.1f' % channel.Q, '%.1f' % channel.energy,
+                   '%.1f' % channel.snr]
+        page.thead()
+        page.tr()
+        for column in columns:
+            page.th(column, scope='col')
+        page.tr.close()
+        page.thead.close()
+        page.tbody()
+        page.tr()
+        for entry in entries:
+            page.td(entry)
+        page.tr.close()
+        page.tbody.close()
+        page.table.close()
         page.div.close()  # col-md-7
 
         # plot toggle buttons
@@ -723,33 +747,12 @@ def write_block(block, context, tableclass='table table-condensed table-hover '
 
         page.div.close()  # row
 
-        page.div(class_='row')
-
-        # summary table
-        page.div(class_='col-md-3')
-        page.p("Properties of the most significant time-frequency tile")
-        page.table(class_=tableclass)
-        header = ['GPS Time', 'Frequency', 'Q Factor', 'Energy', 'SNR']
-        entry = ['%.3f' % channel.t, '%.1f Hz' % channel.f,
-                 '%.1f' % channel.Q, '%.1f' % channel.energy,
-                 '%.1f' % channel.snr]
-        page.tbody()
-        for h, ent in zip(header, entry):
-            page.tr()
-            page.td('<b>%s</b>' % h)
-            page.td(ent)
-            page.tr.close()
-        page.tbody.close()
-        page.table.close()
-        page.div.close()  # col-md-3
-
         # plots
-        page.div(class_='col-md-9')
+        page.div(class_='row')
         page.add(scaffold_plots(channel.plots['qscan_whitened'],
-                 nperrow=min(len(channel.pranges), 2)))
-        page.div.close()  # col-md-9
-
+                 nperrow=min(len(channel.pranges), 3)))
         page.div.close()  # row
+
         page.div.close()  # container
         page.li.close()
 

--- a/gwdetchar/omega/html.py
+++ b/gwdetchar/omega/html.py
@@ -247,7 +247,7 @@ def init_page(ifo, gpstime, css=None, script=None, base=os.path.curdir,
              style='background-color:%s;' % GW_OBSERVATORY_COLORS[ifo])
     page.div(class_='container')
     page.h4('%s Omega Scan <span style="float:right;">%s</span>'
-            % (ifo, gpstime), style="text-align:left; font-weight:normal;")
+            % (ifo, gpstime), style="text-align:left;")
     page.div.close()  # container
     page.div.close()  # navbar
 
@@ -483,7 +483,7 @@ def scaffold_plots(plots, nperrow=2):
     # scaffold plots
     for i, p in enumerate(plots):
         if i % nperrow == 0:
-            page.div(class_='row', style="width:96%;")
+            page.div(class_='row')
         page.div(class_='col-sm-%d' % x)
         page.add(fancybox_img(p))
         page.div.close()  # col
@@ -590,7 +590,7 @@ def write_summary(
     """
     utc = tconvert(gpstime)
     page = markup.page()
-    page.h2(header, style='font-weight:normal;')
+    page.h2(header)
     page.p('This page shows time-frequency maps of a user-configured list of '
            'channels for a given interferometer and GPS time. Time-frequency '
            'maps are computed using the <a '
@@ -629,7 +629,7 @@ def write_toc(blocks):
     """
     page = markup.page()
     page.div(class_="container")
-    page.h2('Table of Contents', style='font-weight:normal;')
+    page.h2('Table of Contents')
     page.ul()
     for i, block in enumerate(blocks):
         page.li()
@@ -674,7 +674,7 @@ def write_block(block, context, tableclass='table table-condensed table-hover '
         page.a("<small>[top]</small>", href='#', class_='text-%s' % context)
     page.div.close()  # pull-right
     # heading
-    page.h3(block.name, class_='panel-title', style='font-weight:normal;')
+    page.h3(block.name, class_='panel-title')
     page.div.close()  # panel-heading
 
     # -- make body
@@ -689,11 +689,11 @@ def write_block(block, context, tableclass='table table-condensed table-hover '
         page.li(class_='list-group-item')
         page.div(class_="container")
 
-        page.div(class_='row', style='margin-top:6pt; width:98%')
+        page.div(class_='row')
 
         # channel name
         page.div(class_='col-md-7')
-        page.h4(cis_link(channel.name), style='font-weight:normal;')
+        page.h4(cis_link(channel.name))
         page.div.close()  # col-md-7
 
         # plot toggle buttons
@@ -708,7 +708,7 @@ def write_block(block, context, tableclass='table table-condensed table-hover '
             page.div(class_='btn-group', role='group')
             page.button(id_=_id, type='button',
                         class_='btn btn-%s dropdown-toggle' % context,
-                        style='opacity:0.8;', **{'data-toggle': 'dropdown'})
+                        **{'data-toggle': 'dropdown'})
             page.add('{0} view <span class="caret"></span>'.format(ptitle))
             page.button.close()
             page.ul(class_='dropdown-menu', role='menu',
@@ -728,7 +728,7 @@ def write_block(block, context, tableclass='table table-condensed table-hover '
         # summary table
         page.div(class_='col-md-3')
         page.p("Properties of the most significant time-frequency tile")
-        page.table(class_=tableclass, style='width: 95%;')
+        page.table(class_=tableclass)
         header = ['GPS Time', 'Frequency', 'Q Factor', 'Energy', 'SNR']
         entry = ['%.3f' % channel.t, '%.1f Hz' % channel.f,
                  '%.1f' % channel.Q, '%.1f' % channel.energy,
@@ -787,7 +787,7 @@ def write_qscan_page(blocks, context):
     """
     page = markup.page()
     page.add(write_toc(blocks))
-    page.h2('Results', style='font-weight:normal;')
+    page.h2('Results')
     page.p('The following blocks of channels were scanned for interesting '
            'time-frequency morphology:')
     for block in blocks:
@@ -847,10 +847,10 @@ def write_about_page(configfiles):
         the path of the HTML written for this analysis
     """
     page = markup.page()
-    page.h2('On the command line', style='font-weight:normal;')
+    page.h2('On the command line')
     page.p('This page was generated with the command line call shown below.')
     page.pre(' '.join(sys.argv))
-    page.h2('Configuration file', style='font-weight:normal;')
+    page.h2('Configuration file')
     page.p('Omega scans are configured through INI-format files. The files '
            'used for this analysis are reproduced below in full.')
     for configfile in configfiles:

--- a/gwdetchar/omega/html.py
+++ b/gwdetchar/omega/html.py
@@ -391,7 +391,7 @@ def toggle_link(plottype, channel, pranges):
     chanstring = channel.name.replace('-', '_').replace(':', '-')
     captions = [p.caption for p in channel.plots[plottype]]
     return markup.oneliner.a(
-        '%s' % text, class_='dropdown-item',
+        text, class_='dropdown-item',
         onclick="showImage('{0}', [{1}], '{2}', {3});".format(
             chanstring, ','.join(pstrings), plottype, captions))
 
@@ -633,7 +633,7 @@ def write_toc(blocks):
     page.ul()
     for i, block in enumerate(blocks):
         page.li()
-        page.a('%s' % block.name, href='#block-%s' % block.key)
+        page.a(block.name, href='#block-%s' % block.key)
         page.li.close()
     page.ul.close()
     page.div.close()
@@ -674,8 +674,7 @@ def write_block(block, context, tableclass='table table-condensed table-hover '
         page.a("<small>[top]</small>", href='#', class_='text-%s' % context)
     page.div.close()  # pull-right
     # heading
-    page.h3('%s' % block.name, class_='panel-title',
-            style='font-weight:normal;')
+    page.h3(block.name, class_='panel-title', style='font-weight:normal;')
     page.div.close()  # panel-heading
 
     # -- make body

--- a/gwdetchar/omega/html.py
+++ b/gwdetchar/omega/html.py
@@ -568,7 +568,7 @@ def write_config_html(filepath, format='ini'):
 # -- Qscan HTML ---------------------------------------------------------------
 
 def write_summary(
-        ifo, gpstime, header='Analysis Summary',
+        ifo, gpstime, header='Summary',
         tableclass='table table-condensed table-hover table-responsive'):
     """Write the Qscan analysis summary HTML
 
@@ -591,21 +591,16 @@ def write_summary(
     utc = tconvert(gpstime)
     page = markup.page()
     page.h2(header)
-    page.p('This page shows time-frequency maps of a user-configured list of '
-           'channels for a given interferometer and GPS time. Time-frequency '
-           'maps are computed using the <a '
-           'href="https://gwpy.github.io/docs/stable/examples/timeseries/'
-           'qscan.html" target="_blank">Q-transform</a>.')
     page.p("This analysis is based on the following run arguments.")
-    page.table(class_=tableclass)
+    page.table(class_=tableclass, style='width:40%;')
     # make table body
     page.tbody()
     page.tr()
-    page.td("<b>Interferometer</b>")
+    page.td("<b>Interferometer</b>", scope='row')
     page.td("%s (%s)" % (OBSERVATORY_MAP[ifo]['name'], ifo))
     page.tr.close()
     page.tr()
-    page.td("<b>UTC Time</b>")
+    page.td("<b>UTC Time</b>", scope='row')
     page.td("%s" % utc)
     page.tr.close()
     page.tbody.close()
@@ -641,7 +636,7 @@ def write_toc(blocks):
 
 
 def write_block(block, context, tableclass='table table-condensed table-hover '
-                                           'table-responsive'):
+                                           'table-bordered table-responsive'):
     """Write the HTML summary for a specific block of channels
 
     Parameters
@@ -700,8 +695,8 @@ def write_block(block, context, tableclass='table table-condensed table-hover '
         page.div(class_='col-md-7')
         page.p("Properties of the most significant time-frequency tile")
         page.table(class_=tableclass)
-        columns = ['GPS Time', 'Frequency', 'Q Factor', 'Normalized Energy',
-                   'SNR']
+        columns = ['GPS Time', 'Frequency', 'Quality Factor',
+                   'Normalized Energy', 'SNR']
         entries = ['%.3f' % channel.t, '%.1f Hz' % channel.f,
                    '%.1f' % channel.Q, '%.1f' % channel.energy,
                    '%.1f' % channel.snr]
@@ -790,9 +785,7 @@ def write_qscan_page(blocks, context):
     """
     page = markup.page()
     page.add(write_toc(blocks))
-    page.h2('Results')
-    page.p('The following blocks of channels were scanned for interesting '
-           'time-frequency morphology:')
+    page.h2('Channel details')
     for block in blocks:
         page.add(write_block(block, context))
     return page

--- a/gwdetchar/omega/html.py
+++ b/gwdetchar/omega/html.py
@@ -380,8 +380,6 @@ def toggle_link(plottype, channel, pranges):
         the channel object corresponding to the plots shown
     pranges : `list` of `int`s
         a list of ranges for the time axis of each plot
-    context : `str`
-        the Bootstrap context that controls color-coding
 
     Returns
     -------
@@ -393,7 +391,7 @@ def toggle_link(plottype, channel, pranges):
     chanstring = channel.name.replace('-', '_').replace(':', '-')
     captions = [p.caption for p in channel.plots[plottype]]
     return markup.oneliner.a(
-        '<b>%s</b>' % text, class_='dropdown-item',
+        '%s' % text, class_='dropdown-item',
         onclick="showImage('{0}', [{1}], '{2}', {3});".format(
             chanstring, ','.join(pstrings), plottype, captions))
 
@@ -725,8 +723,8 @@ def write_block(block, context, tableclass='table table-condensed table-hover '
             _id = 'btnGroup{0}{1}'.format(pclass.title(), i)
             page.div(class_='btn-group', role='group')
             page.button(id_=_id, type='button',
-                        class_='btn btn-info dropdown-toggle',
-                        **{'data-toggle': 'dropdown'})
+                        class_='btn btn-%s dropdown-toggle' % context,
+                        style='opacity:0.6;', **{'data-toggle': 'dropdown'})
             page.add('{0} view <span class="caret"></span>'.format(ptitle))
             page.button.close()
             page.ul(class_='dropdown-menu', role='menu',

--- a/gwdetchar/omega/html.py
+++ b/gwdetchar/omega/html.py
@@ -591,7 +591,6 @@ def write_summary(
     utc = tconvert(gpstime)
     page = markup.page()
     page.h2(header)
-    page.p("This analysis is based on the following run arguments.")
     page.table(class_=tableclass, style='width:40%;')
     # make table body
     page.tbody()
@@ -720,7 +719,7 @@ def write_block(block, context, tableclass='table table-condensed table-hover '
         page.div(class_='btn-group', role='group')
         for ptitle, pclass, ptypes in [
             ('Timeseries', 'timeseries', ('raw', 'highpassed', 'whitened')),
-            ('Q-transform', 'qscan', ('raw', 'whitened', 'autoscaled')),
+            ('Spectrogram', 'qscan', ('raw', 'whitened', 'autoscaled')),
             ('Eventgram', 'eventgram', ('raw', 'whitened', 'autoscaled')),
         ]:
             _id = 'btnGroup{0}{1}'.format(pclass.title(), i)

--- a/gwdetchar/omega/plot.py
+++ b/gwdetchar/omega/plot.py
@@ -30,13 +30,13 @@ __author__ = 'Alex Urban <alexander.urban@ligo.org>'
 __credits__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
 rcParams.update({
-    'axes.labelsize': 20,
     'figure.subplot.bottom': 0.17,
     'figure.subplot.left': 0.1,
     'figure.subplot.right': 0.9,
     'figure.subplot.top': 0.90,
-    'axes.labelsize': 24,
-    'axes.labelpad': 2,
+    'axes.labelsize': 20,
+    'axes.labelpad': 10,
+    'axes.titlesize': 14,
     'grid.color': 'gray',
 })
 
@@ -75,13 +75,12 @@ def omega_plot(series, gps, span, channel, output, colormap='viridis',
     chan = channel.replace('_', r'\_')
     if (qscan or eventgram):
         ax.set_yscale('log')
-        ax.set_title('%s at %.3f with $Q=%.1f$' % (chan, gps, series.q),
-                     fontsize=12)
+        ax.set_title('%s at %.3f with $Q=%.1f$' % (chan, gps, series.q))
         plot.add_colorbar(cmap=colormap, clim=clim,
                           label='Normalized energy')
     else:
         ax.set_yscale('linear')
-        ax.set_title('%s at %.3f' % (chan, gps), fontsize=12)
+        ax.set_title('%s at %.3f' % (chan, gps))
     if ylabel:
         ax.set_ylabel(ylabel)
     if eventgram:

--- a/share/sass/gwdetchar-omega.scss
+++ b/share/sass/gwdetchar-omega.scss
@@ -27,6 +27,43 @@ body {
 		margin-bottom: 120px;
 		min-height: 100%;
 		font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+		font-weight: 300;
+}
+
+h1 {
+		font-weight: normal;
+}
+
+h2 {
+		font-weight: normal;
+}
+
+h3 {
+		font-weight: normal;
+}
+
+h4 {
+		font-weight: normal;
+}
+
+h5 {
+		font-weight: normal;
+}
+
+h6 {
+		font-weight: normal;
+}
+
+.container{
+		@media (min-width: 992px) {
+				width: 97%;
+				max-width: 1100px;
+		}
+
+		@media (min-width: 1200px) {
+				width: 97%;
+				max-width: 1400px;
+		}
 }
 
 .navbar {
@@ -63,6 +100,12 @@ body {
 		}
 }
 
+.btn {
+		opacity: 0.8;
+}
+
 .btn-group {
-		margin-bottom: 10px;
+		margin-top: 3px;
+		margin-bottom: 5px;
+		float: right;
 }

--- a/share/sass/gwdetchar-omega.scss
+++ b/share/sass/gwdetchar-omega.scss
@@ -54,7 +54,7 @@ h6 {
 		font-weight: normal;
 }
 
-.container{
+.container {
 		@media (min-width: 992px) {
 				width: 97%;
 				max-width: 1100px;
@@ -105,7 +105,7 @@ h6 {
 }
 
 .btn-group {
-		margin-top: 20px;
+		margin-top: 15px;
 		margin-bottom: 5px;
 		float: right;
 }

--- a/share/sass/gwdetchar-omega.scss
+++ b/share/sass/gwdetchar-omega.scss
@@ -30,27 +30,7 @@ body {
 		font-weight: 300;
 }
 
-h1 {
-		font-weight: normal;
-}
-
-h2 {
-		font-weight: normal;
-}
-
-h3 {
-		font-weight: normal;
-}
-
-h4 {
-		font-weight: normal;
-}
-
-h5 {
-		font-weight: normal;
-}
-
-h6 {
+h1, h2, h3, h4, h5, h6 {
 		font-weight: normal;
 }
 

--- a/share/sass/gwdetchar-omega.scss
+++ b/share/sass/gwdetchar-omega.scss
@@ -105,7 +105,7 @@ h6 {
 }
 
 .btn-group {
-		margin-top: 3px;
+		margin-top: 20px;
 		margin-bottom: 5px;
 		float: right;
 }


### PR DESCRIPTION
@duncanmmacleod, this PR contains a few formatting enhancements for `gwdetchar-omega` output pages, including:

* Restoring IFO-specific context highlighting in plot toggle buttons
* Expand `container` width and adapt its size for different screens
* Reorganizing the channel information display so that the channel name is on its own line, plot toggle buttons are flushed right on the same line as the loudest-tile table (which is now horizontal), and up to three plots are shown on a single line beneath the table
* De-bolden section headings (which will need to be done more gracefully once #90 is addressed)
* Update the output page after every channel has been analyzed, as well as after every channel block, and once again at the very end

Examples may be found here (requires `LIGO.ORG` credentials):

IFO | Scan time | Results
-- | -- | --
Hanford | 1187020580.44 |[results](https://ldas-jobs.ligo-la.caltech.edu/~aurban/pyomega-test/H1_1187020580.44/)
Livingston | 1172489783.070 | [results](https://ldas-jobs.ligo-la.caltech.edu/~aurban/pyomega-test/L1_1172489783.07/)
GEO | 1186970418.0 | [results](https://ldas-jobs.ligo.caltech.edu/~alexander.urban/for_borja/pyomega/G1_1186970418.0/)

This fixes #122.