### PR TITLE
Reduce default false alarm rate threshold to 1e-10 Hz

### DIFF
--- a/bin/gwdetchar-omega
+++ b/bin/gwdetchar-omega
@@ -63,7 +63,7 @@ parser.add_argument('-f', '--config-file', action='append', default=None,
                     help='path to configuration file to use, can be given '
                          'multiple times (files read in order), default: '
                          'None')
-parser.add_argument('-t', '--far-threshold', type=float, default=1e-3,
+parser.add_argument('-t', '--far-threshold', type=float, default=1e-10,
                     help='White noise false alarm rate threshold for '
                          'processing channels; default: %(default)s')
 parser.add_argument('--condor', action='store_true', default=False,


### PR DESCRIPTION
Note, users wanting to use a different threshold can still specify that using the command line option `--far-threshold`.

This fixes #125.