### PR TITLE
Deleting a line referring to figure objects that no longer exist

### DIFF
--- a/bin/gwdetchar-omega
+++ b/bin/gwdetchar-omega
@@ -424,7 +424,6 @@ for block in blocks[:]:
         c.f = table.fc
 
         # delete intermediate data products
-        del fig1, fig2, fig3, fig4, fig5, fig6
         del qscan, rqscan, table, rtable, series, hpseries, wseries, asd
 
     # delete data


### PR DESCRIPTION
I missed a line in the previous pull request (#131) which will cause `gwdetchar-omega` to fail. This pull request corrects that mistake.