### PR TITLE
Adjust the size of Q-transform spectrograms

### DIFF
--- a/bin/gwdetchar-omega
+++ b/bin/gwdetchar-omega
@@ -33,6 +33,7 @@ use('agg')  # nopep8
 from gwpy.utils import gprint
 from gwpy.time import tconvert
 from gwpy.table import EventTable
+from gwpy.segments import Segment
 from gwpy.timeseries import TimeSeriesDict
 from gwpy.detector import (Channel, ChannelList)
 from gwpy.signal.qtransform import QTiling
@@ -356,14 +357,15 @@ for block in blocks[:]:
                            snrthresh=c.snrthresh, mismatch=c.mismatch)
 
         # compute Q-transforms
+        outseg = Segment(gps - max(c.pranges)/2., gps + max(c.pranges)/2.)
         tres = min(c.pranges) / 500
         fres = c.frange[0] / 5
-        qscan = wseries.q_transform(qrange=(Q, Q), frange=c.frange,
-                                    tres=tres, fres=fres, gps=gps,
-                                    search=0.25, whiten=False)
+        qscan = wseries.q_transform(qrange=(Q, Q), frange=c.frange, tres=tres,
+                                    fres=fres, gps=gps, search=0.25,
+                                    whiten=False, outseg=outseg)
         rqscan = hpseries.q_transform(qrange=(Q, Q), frange=c.frange,
                                       tres=tres, fres=fres, gps=gps,
-                                      search=0.25, whiten=False)
+                                      search=0.25, whiten=False, outseg=outseg)
 
         # prepare plots
         if args.verbose:

--- a/bin/gwdetchar-omega
+++ b/bin/gwdetchar-omega
@@ -356,10 +356,10 @@ for block in blocks[:]:
         rtable = eventgram(gps, hpseries, frange=table.frange, qrange=(Q, Q),
                            snrthresh=c.snrthresh, mismatch=c.mismatch)
 
-        # compute Q-transforms
+        # compute Q-transform spectrograms
         outseg = Segment(gps - max(c.pranges)/2., gps + max(c.pranges)/2.)
         tres = min(c.pranges) / 500
-        fres = c.frange[0] / 5
+        fres = c.frange[0] / 20
         qscan = wseries.q_transform(qrange=(Q, Q), frange=c.frange, tres=tres,
                                     fres=fres, gps=gps, search=0.25,
                                     whiten=False, outseg=outseg)


### PR DESCRIPTION
This PR includes two changes to `gwdetchar-omega`:

* Use the `outseg` keyword argument to `TimeSeries.q_transform()` to reduce the length of the time axis of Q-transform spectrograms to the duration of the longest plot, rather than the full length of data analyzed. For 16k channels, which are typically configured to read in 64 seconds of data but plot at most 16 seconds, this reduces the total size by a factor of 4. (The reduction factor will be larger for slower channels.)
* Increase the frequency resolution of Q-transform spectrograms to `flow / 20`, where `flow` is the lowest frequency analyzed for a given channel. This replaces the previous value of `flow / 5`, which was insufficient and led to choppiness in the plots at low frequency.

For 16k channels, these two changes effectively cancel each other out in terms of total number of array elements. However, slower channels which require analyzing more data will see a factor > 1 reduction in array size.

This fixes #141.