### PR TITLE
Support for multi-IFO omega scans

### DIFF
--- a/bin/gwdetchar-omega
+++ b/bin/gwdetchar-omega
@@ -48,8 +48,9 @@ __credits__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 # -- parse command line -------------------------------------------------------
 
 parser = cli.create_parser(description=__doc__)
-parser.add_argument('ifo', type=str, help='IFO prefix for this analysis')
 parser.add_argument('gpstime', type=str, help='GPS time of scan')
+parser.add_argument('-i', '--ifo', type=str,
+                    help='IFO prefix for this analysis, default: None')
 parser.add_argument('-o', '--output-directory',
                     help='output directory for the omega scan, '
                          'default: ~/public_html/wdq/{IFO}_{gpstime}')
@@ -71,14 +72,16 @@ cli.add_nproc_option(parser)
 
 args = parser.parse_args()
 
-print("----------------------------------------------\n"
-      "Creating %s omega scan at GPS second %s..." % (args.ifo, args.gpstime))
-
-gpstime = args.gpstime
-gps = float(gpstime)
-ifo = args.ifo
-obs = ifo[0]
+# get run parameters
+if args.ifo:
+    ifo = args.ifo
+else:
+    ifo = 'Network'
+gps = float(args.gpstime)
 far = args.far_threshold
+
+print("----------------------------------------------\n"
+      "Creating %s omega scan at GPS second %s..." % (ifo, gps))
 
 # parse configuration file
 config_files = [os.path.abspath(f) for f in args.config_file]

--- a/gwdetchar/omega/html.py
+++ b/gwdetchar/omega/html.py
@@ -67,9 +67,15 @@ OBSERVATORY_MAP = {
     },
     'V1': {
         'name': 'Virgo',
-        'context': 'primary'
+        'context': 'default'
+    },
+    'Network': {
+        'name': 'Multi-IFO',
+        'context': 'default'
     }
 }
+
+GW_OBSERVATORY_COLORS['Network'] = '#668888'
 
 # -- set up default JS and CSS files
 


### PR DESCRIPTION
cc @duncanmmacleod @areeda

This PR addresses the need for multi-interferometer Omega scans and includes the following changes:

* Replace `gwdetchar-omega`'s `ifo` positional command line argument with an optional `--ifo` flag
* Use the default bootstrap context and the same color banner as the network DetChar summary pages (timeseries plots are still color-coded by IFO)
* Update Virgo's bootstrap context to `default`

Note, the first item above makes this PR backwards incompatible. I don't think there's any clean way around this, unfortunately.

A network scan of Livingston, Hanford, and Virgo may be found [**here**](https://ldas-jobs.ligo.caltech.edu/~alexander.urban/pyomega/Network_170817/) (requires `LIGO.ORG` credentials). To illustrate the last change, a Virgo-only example is [**here**](https://ldas-jobs.ligo.caltech.edu/~alexander.urban/pyomega/V1_170817/).

This fixes #89.