### PR TITLE
Update scipy requirement to 0.18.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ libsass
 # run
 six
 numpy >= 1.10
-scipy >= 0.16
+scipy >= 0.18.1
 matplotlib >= 2.0.0
 astropy >= 1.2
 gwpy >= 0.12.0

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup_requires = [
 install_requires = [
     'six',
     'numpy>=1.10',
-    'scipy>=0.16',
+    'scipy>=0.18.1',
     'matplotlib>=2.0.0',
     'astropy>=1.2',
     'gwpy>=0.12.0',


### PR DESCRIPTION
cc @duncanmmacleod
 
Note, [**scipy-0.18.0**](https://docs.scipy.org/doc/scipy/reference/release.0.18.0.html) introduced forward-backward filtering with `scipy.signal.sosfiltfilt`, but [**scipy-0.18.1**](https://docs.scipy.org/doc/scipy/reference/release.0.18.1.html) is the next point release with a number of bug fixes.