### PR TITLE
Reduce the data duration read in from frames

### DIFF
--- a/bin/gwdetchar-omega
+++ b/bin/gwdetchar-omega
@@ -308,11 +308,11 @@ gprint('Launching Omega scans...')
 for block in blocks[:]:
     gprint('Processing block %s' % block.name)
     chans = [c.name for c in block.channels]
-    # read in fftlength seconds of data
-    # centered on gps
+    # read in `duration` seconds of data centered on gps
     duration = block.duration
     fftlength = block.fftlength
-    data = TimeSeriesDict.get(chans, gps-256-fftlength/4, gps+256+fftlength/4,
+    pad = max(1, fftlength/4.)
+    data = TimeSeriesDict.get(chans, gps-duration-pad, gps+duration+pad,
                               frametype=block.frametype, nproc=args.nproc,
                               verbose=args.verbose)
     # compute qscans


### PR DESCRIPTION
Now that we require gwpy-0.12+, we should only read in as much data per channel as is requested by the user. This fixes #151.