### PR TITLE
Support omega scan sub-blocks

### DIFF
--- a/bin/gwdetchar-omega
+++ b/bin/gwdetchar-omega
@@ -23,6 +23,7 @@
 from __future__ import division
 
 import os
+import sys
 import ast
 import numpy
 from scipy.signal import butter
@@ -122,11 +123,11 @@ class OmegaChannel(Channel):
         pranges = [int(t) for t in params.get('plot-time-durations',
                                               None).split(',')]
         always_plot = ast.literal_eval(params.get('always-plot', 'False'))
-        super(OmegaChannel, self).__init__(channelname, frametype=frametype,
-                                           frange=frange, qrange=qrange,
-                                           mismatch=mismatch, pranges=pranges,
-                                           snrthresh=snrthresh,
-                                           always_plot=always_plot)
+        super(OmegaChannel, self).__init__(
+            channelname, frametype=frametype, frange=frange, qrange=qrange,
+            mismatch=mismatch, pranges=pranges, snrthresh=snrthresh,
+            always_plot=always_plot
+        )
         self.plots = {}
         for plottype in ['timeseries_raw', 'timeseries_highpassed',
                          'timeseries_whitened', 'qscan_raw',
@@ -140,16 +141,18 @@ class OmegaChannel(Channel):
 
 
 class OmegaChannelList(object):
-    def __init__(self, **params):
+    def __init__(self, key, **params):
+        self.key = key
+        self.parent = params.get('parent', None)
         self.name = params.get('name', None)
-        self.key = self.name.lower().replace(' ', '-')
         self.duration = int(params.get('duration', 32))
         self.fftlength = int(params.get('fftlength', 2))
         self.resample = int(params.get('resample', 0))
         self.source = params.get('source', None)
         self.frametype = params.get('frametype', None)
         chans = params.get('channels', None).split('\n')
-        self.channels = [OmegaChannel(c, self.name, **params) for c in chans]
+        section = self.parent if self.parent else self.key
+        self.channels = [OmegaChannel(c, section, **params) for c in chans]
         self.params = params.copy()
 
 
@@ -314,7 +317,7 @@ def eventgram(time, data, search=0.5, frange=(0, numpy.inf),
     table = EventTable([central_times, central_freqs, durations,
                        bandwidths, energies],
                        names=('central_time', 'central_freq', 'duration',
-                       'bandwidth', 'energy'))
+                              'bandwidth', 'energy'))
 
     # get parameters and return
     table.q = peakplane.q
@@ -332,26 +335,34 @@ def eventgram(time, data, search=0.5, frange=(0, numpy.inf),
 # make subdirectories
 plotdir = 'plots'
 aboutdir = 'about'
-for d in [plotdir, aboutdir]:
+datadir = 'data'
+for d in [plotdir, aboutdir, datadir]:
     if not os.path.isdir(d):
         os.makedirs(d)
 
 # determine channel blocks
 try:  # python 3.x
-    blocks = [OmegaChannelList(**cp[s]) for s in cp.sections()]
+    blocks = [OmegaChannelList(s, **cp[s]) for s in cp.sections()]
 except:  # python 2.x
-    blocks = [OmegaChannelList(**dict(cp.items(s))) for s in cp.sections()]
+    blocks = [OmegaChannelList(s, **dict(cp.items(s))) for s in cp.sections()]
+
+# set up analyzed channel dict
+if sys.version_info >= (3, 7):  # python 3.7+
+    analyzed = {}
+else:
+    from collections import OrderedDict
+    analyzed = OrderedDict()
 
 # set up html output
 gprint('Setting up HTML at %s/index.html...' % outdir)
-html.write_qscan_page(ifo, gps, blocks, **htmlv)
+html.write_qscan_page(ifo, gps, analyzed, **htmlv)
 
 # launch omega scans
 gprint('Launching Omega scans...')
 
 # range over blocks
-for block in blocks[:]:
-    gprint('Processing block %s' % block.name)
+for block in blocks:
+    gprint('Processing block %s' % block.key)
     chans = [c.name for c in block.channels]
     # read in `duration` seconds of data centered on gps
     duration = block.duration
@@ -361,7 +372,7 @@ for block in blocks[:]:
                     source=block.source, nproc=args.nproc,
                     verbose=args.verbose)
     # compute qscans
-    for c in block.channels[:]:
+    for c in block.channels:
         if args.verbose:
             gprint('Computing omega scans for channel %s...' % c.name)
 
@@ -391,14 +402,12 @@ for block in blocks[:]:
             if args.verbose:
                 gprint('Channel is misbehaved, removing it from the analysis')
             del series, hpseries, wseries, asd
-            block.channels.remove(c)
             continue
         if table.Z < table.engthresh and not c.always_plot:
             if args.verbose:
                 gprint('Channel not significant at white noise false alarm '
                        'rate %s Hz' % far)
             del series, hpseries, wseries, asd, table
-            block.channels.remove(c)
             continue
         Q = table.q
         rtable = eventgram(gps, hpseries, frange=table.frange, qrange=(Q, Q),
@@ -467,8 +476,14 @@ for block in blocks[:]:
         c.t = table.tc
         c.f = table.fc
 
+        # update analyzed dict
+        try:
+            analyzed[c.section]['channels'].append(c)
+        except KeyError:
+            analyzed[c.section] = {'name': block.name, 'channels': [c]}
+
         # update HTML output
-        html.write_qscan_page(ifo, gps, blocks, **htmlv)
+        html.write_qscan_page(ifo, gps, analyzed, **htmlv)
 
         # delete intermediate data products
         del qscan, rqscan, table, rtable, series, hpseries, wseries, asd
@@ -476,12 +491,8 @@ for block in blocks[:]:
     # delete data
     del data
 
-    # if the entire block is unprocessed, delete it
-    if not block.channels:
-        blocks.remove(block)
-
     # update HTML output
-    html.write_qscan_page(ifo, gps, blocks, **htmlv)
+    html.write_qscan_page(ifo, gps, analyzed, **htmlv)
 
 
 # -- Prepare HTML -------------------------------------------------------------
@@ -489,5 +500,5 @@ for block in blocks[:]:
 # write HTML page and finish
 gprint('Finalizing HTML at %s/index.html...' % outdir)
 htmlv['refresh'] = False  # turn off auto-refresh
-html.write_qscan_page(ifo, gps, blocks, **htmlv)
+html.write_qscan_page(ifo, gps, analyzed, **htmlv)
 gprint("-- index.html written, all done --")


### PR DESCRIPTION
This PR makes two substantive changes:

* Add support for a `parent` Omega scan INI kwarg, which allows contextual channel blocks with different analysis attributes to be linked to each other so that they are analyzed separately, but appear in one block together on the output page.
* Ensure that the list of analyzed channels is built from the bottom up, rather than from the top down

[**Here**](https://ldas-jobs.ligo-la.caltech.edu/~aurban/pyomega-test/L1_170817_withparent/) is an example output page which places `L1:GDS-CALIB_STRAIN` and `L1:CAL-DELTAL_EXTERNAL_DQ` in the same contextual block on the output page (requires `LIGO.ORG` credentials). These channels have different frame types, so I used the `parent` argument to configure them to appear together.

This fixes #146.