### PR TITLE
Explicitly overwrite omega scan summary tables, if they already exist

### DIFF
--- a/gwdetchar/omega/html.py
+++ b/gwdetchar/omega/html.py
@@ -535,9 +535,9 @@ def write_summary_table(blocks, base=os.path.curdir):
     if not os.path.exists(datadir):
         os.makedirs(datadir)
     fname = os.path.join(datadir, 'summary')
-    data.write(fname + '.txt', format='ascii')
-    data.write(fname + '.csv', format='csv')
-    data.write(fname + '.tex', format='latex')
+    data.write(fname + '.txt', format='ascii', overwrite=True)
+    data.write(fname + '.csv', format='csv', overwrite=True)
+    data.write(fname + '.tex', format='latex', overwrite=True)
 
 
 def write_footer(about=None, date=None):


### PR DESCRIPTION
This resolves a `DeprecationWarning` when writing tables with `gwpy.table.Table.write()`, which wraps around Astropy table objects. The kwarg is supported in all versions of astropy, near as I can tell. [Here](https://ldas-jobs.ligo-la.caltech.edu/~aurban/pyomega-test/Network_170817/) is the output page of a job run successfully with `overwrite=True`.