### PR TITLE
In omega scans, read in the correct duration of data

### DIFF
--- a/bin/gwdetchar-omega
+++ b/bin/gwdetchar-omega
@@ -312,7 +312,7 @@ for block in blocks[:]:
     duration = block.duration
     fftlength = block.fftlength
     pad = max(1, fftlength/4.)
-    data = TimeSeriesDict.get(chans, gps-duration-pad, gps+duration+pad,
+    data = TimeSeriesDict.get(chans, gps-duration/2.-pad, gps+duration/2.+pad,
                               frametype=block.frametype, nproc=args.nproc,
                               verbose=args.verbose)
     # compute qscans


### PR DESCRIPTION
PR #152 was missing a factor of 2 in the call to `TimeSeriesDict.get()`, effectively reading in _twice_ the length of data requested by the user. This PR is a simple fix to that mistake.