### PR TITLE
Patched gwdetchar-overflow

### DIFF
--- a/bin/gwdetchar-overflow
+++ b/bin/gwdetchar-overflow
@@ -178,7 +178,7 @@ for dcuid in args.dcuid:
                 dcuid, args.ifo, args.frametype, gpstime=span[-1])
         gprint("    %d channels found" % len(channel))
     for seg in cachesegs:
-        c = cache.sieve(segment=seg)
+        c = cache.sieve(segmentlist=SegmentList([seg]))
         gprint("    Reading ACCUM_OVERFLOW data for %d-%d..." % seg, end=' ')
         data = TimeSeries.read(c, channel, nproc=args.nproc,
                                start=seg[0], end=seg[1], **readkwargs)


### PR DESCRIPTION
Glue doesn't seem to like using the `glue.lal.Cache.sieve()` method on individual segments, so I modified the script to use a single element `SegmentList` instead. Tested at CIT and the executable worked.