### PR TITLE
Patch to gwdetchar-software-saturations

### DIFF
--- a/bin/gwdetchar-software-saturations
+++ b/bin/gwdetchar-software-saturations
@@ -358,7 +358,7 @@ for suffix, clist in zip(['LIMEN', 'SWSTAT'], channels):
         while cset[-1] is None:
             cset.pop(-1)
         for seg in segs:
-            cache2 = cache.sieve(segment=seg)
+            cache2 = cache.sieve(segmentlist=SegmentList([seg]))
             if not len(cache2):
                 continue
             saturated = is_saturated(cset, cache2, seg[0], seg[1],


### PR DESCRIPTION
This PR is a workaround for a bug in `glue.lal.Cache.sieve()`, very much akin to @tjma12's patch for `gwdetchar-overflow` in #161. I am running with these changes on the Hanford cluster and they are running to completion.