### PR TITLE
Require lscsoft-glue >= 1.60.0

### DIFF
--- a/bin/gwdetchar-software-saturations
+++ b/bin/gwdetchar-software-saturations
@@ -354,7 +354,7 @@ for suffix, clist in zip(['LIMEN', 'SWSTAT'], channels):
         while cset[-1] is None:
             cset.pop(-1)
         for seg in segs:
-            cache2 = cache.sieve(segmentlist=SegmentList([seg]))
+            cache2 = cache.sieve(segment=seg)
             if not len(cache2):
                 continue
             saturated = is_saturated(cset, cache2, seg[0], seg[1],

--- a/gwdetchar/io/ligolw.py
+++ b/gwdetchar/io/ligolw.py
@@ -69,7 +69,7 @@ def sngl_burst_from_times(times, **params):
 
 
 def sngl_burst_from_segments(segs, **params):
-    """Create a `SnglBurstTable from a `~glue.segments.segmentlist`
+    """Create a `SnglBurstTable from a `~ligo.segments.segmentlist`
     """
     table = new_table('sngl_burst', columns=params.keys())
     next_id = table.next_id

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ matplotlib >= 2.0.0
 astropy >= 1.2
 gwpy >= 0.12.0
 lalsuite
-lscsoft-glue
+lscsoft-glue >= 1.60.0
 dqsegdb
 beautifulsoup4
 lxml

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ install_requires = [
     'matplotlib>=2.0.0',
     'astropy>=1.2',
     'gwpy>=0.12.0',
-    'lscsoft-glue',
+    'lscsoft-glue>=1.60.0',
     'gwtrigfind',
     'sklearn',
 ]


### PR DESCRIPTION
cc @duncanmmacleod 

This PR formally requires lscsoft-glue >= 1.60.0, and reverts a related emergency fix for `gwdetchar-software-saturations`. Test output pages produced with these changes are available for the [**software saturations**](https://ldas-jobs.ligo-wa.caltech.edu/~aurban/summary/software-saturations/) tool (requires `LIGO.ORG` credentials).

This fixes #166.