### PR TITLE
Add links to the simulink models from overflow summary pages

### DIFF
--- a/bin/gwdetchar-overflow
+++ b/bin/gwdetchar-overflow
@@ -108,9 +108,25 @@ parser.add_argument('-s', '--segment-end-pad', type=float, default=1.0,
 parser.add_argument('-m', '--html', help='path to write html output')
 parser.add_argument('-v', '--plot', action='store_true', default=None,
                     help='make plots of all overflows, defaul: %(default)s')
-parser.add_argument('-c', '--fec-map', help='URL of human-readable FEC map')
+parser.add_argument('-c', '--fec-map', help='URL of human-readable FEC map, '
+                                            'default: infer from IFO')
+parser.add_argument('-u', '--simulink', help='URL of human-readable Simulink '
+                                             'model, default: infer from IFO')
 
 args = parser.parse_args()
+
+fec_map = args.fec_map
+simulink = args.simulink
+if args.ifo == 'H1':
+    if not fec_map:
+        fec_map = 'https://lhocds.ligo-wa.caltech.edu/exports/detchar/fec/'
+    if not simulink:
+        simulink = 'https://lhocds.ligo-wa.caltech.edu/daq/simulink/'
+if args.ifo == 'L1':
+    if not fec_map:
+        fec_map = 'https://llocds.ligo-la.caltech.edu/exports/detchar/fec/'
+    if not simulink:
+        simulink = 'https://llocds.ligo-la.caltech.edu/daq/simulink/'
 
 span = Segment(args.gpsstart, args.gpsend)
 
@@ -351,10 +367,14 @@ if args.html:
     write_param('State flag', args.state_flag)
     write_param('DCUIDs', ' '.join(map(str, args.dcuid)))
 
-    if args.fec_map:
+    if (fec_map or simulink):
         page.h2('Links')
+    if fec_map:
         write_param('FEC map', '<a href="{0}" target="_blank" title="{1} FEC '
-                               'map">{0}</a>'.format(args.fec_map, args.ifo))
+                               'map">{0}</a>'.format(fec_map, args.ifo))
+    if simulink:
+        write_param('Simulink models', '<a href="{0}" target="_blank" title="{1} '
+            'Simulink models">{0}</a>'.format(simulink, args.ifo))
 
     # -- close and write
     page.div.close()


### PR DESCRIPTION
Example output is running and will appear [**here**](https://ldas-jobs.ligo-wa.caltech.edu/~aurban/summary/overflows/) (requires `LIGO.ORG` credentials). Note, the link to simulink models should appear at the bottom of the page, in the "Links" section.

This fixes #168.

cc @jrsmith02, @tjma12 