### PR TITLE
Responsive navbar table of contents for omega scans

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "bootstrap-ligo"]
+	path = bootstrap-ligo
+	url = https://github.com/duncanmmacleod/bootstrap-ligo

--- a/_setup_utils.py
+++ b/_setup_utils.py
@@ -34,9 +34,12 @@ import versioneer
 CMDCLASS = versioneer.get_cmdclass()
 
 # specify HTML source files
-JS_FILES = [f for f in glob.glob(os.path.join('share', 'js', '*.js')) if
-            not f.endswith('.min.js')]
-SASS_FILES = glob.glob(os.path.join('share', 'sass', '[!_]*.scss'))
+JS_FILES = [
+    f for f in glob.glob(os.path.join('share', 'js', '*.js')) + (
+               glob.glob(os.path.join('bootstrap-ligo', 'js', '*.js')))
+    if not f.endswith('.min.js')]
+SASS_FILES = glob.glob(os.path.join('share', 'sass', '[!_]*.scss')) + (
+    glob.glob(os.path.join('bootstrap-ligo', 'css', '[!_]*.scss')))
 
 
 # -- custom commands ----------------------------------------------------------

--- a/bin/gwdetchar-omega
+++ b/bin/gwdetchar-omega
@@ -201,6 +201,7 @@ def get_data(channels, time, duration, pad, frametype=None, source=None,
     return TimeSeriesDict.get(channels, start, end, frametype=frametype,
                               nproc=nproc, verbose=verbose)
 
+
 def get_fancyplots(channel, plottype, duration, caption=None):
     """Construct FancyPlot objects for output HTML pages
 
@@ -340,17 +341,18 @@ for d in [plotdir, aboutdir, datadir]:
     if not os.path.isdir(d):
         os.makedirs(d)
 
-# determine channel blocks
-try:  # python 3.x
-    blocks = [OmegaChannelList(s, **cp[s]) for s in cp.sections()]
-except:  # python 2.x
-    blocks = [OmegaChannelList(s, **dict(cp.items(s))) for s in cp.sections()]
-
 # set up analyzed channel dict
 if sys.version_info >= (3, 7):  # python 3.7+
+    blocks = {s: OmegaChannelList(s, **cp[s]) for s in cp.sections()}
     analyzed = {}
 else:
     from collections import OrderedDict
+    try:  # python 3.x
+        blocks = OrderedDict([(s, OmegaChannelList(s, **cp[s]))
+                              for s in cp.sections()])
+    except:  # python 2.x
+        blocks = OrderedDict([(s, OmegaChannelList(s, **dict(cp.items(s))))
+                              for s in cp.sections()])
     analyzed = OrderedDict()
 
 # set up html output
@@ -361,7 +363,7 @@ html.write_qscan_page(ifo, gps, analyzed, **htmlv)
 gprint('Launching Omega scans...')
 
 # range over blocks
-for block in blocks:
+for block in blocks.values():
     gprint('Processing block %s' % block.key)
     chans = [c.name for c in block.channels]
     # read in `duration` seconds of data centered on gps
@@ -480,7 +482,9 @@ for block in blocks:
         try:
             analyzed[c.section]['channels'].append(c)
         except KeyError:
-            analyzed[c.section] = {'name': block.name, 'channels': [c]}
+            analyzed[c.section] = {'name': blocks[c.section].name,
+                                   'channels': [c]}
+        htmlv['toc'] = analyzed
 
         # update HTML output
         html.write_qscan_page(ifo, gps, analyzed, **htmlv)
@@ -490,9 +494,6 @@ for block in blocks:
 
     # delete data
     del data
-
-    # update HTML output
-    html.write_qscan_page(ifo, gps, analyzed, **htmlv)
 
 
 # -- Prepare HTML -------------------------------------------------------------

--- a/share/sass/gwdetchar-omega.scss
+++ b/share/sass/gwdetchar-omega.scss
@@ -23,7 +23,6 @@ html {
 }
 
 body {
-		padding-top: 50px;
 		margin-bottom: 166px;
 		min-height: 100%;
 		font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
@@ -34,52 +33,44 @@ h1, h2, h3, h4, h5, h6 {
 		font-weight: normal;
 }
 
+h4 {
+		word-break:break-all;
+}
+
+a {
+		cursor: pointer;
+}
+
 .container {
+		width: 97%;
 		@media (max-width: 991px) {
-				width: 97%;
 				max-width: 991px;
 		}
 		@media (min-width: 992px) {
-				width: 97%;
 				max-width: 1100px;
 		}
 
 		@media (min-width: 1200px) {
-				width: 97%;
 				max-width: 1400px;
 		}
 }
 
-.navbar {
-		color: #eee;
-		padding-top: 6px;
-		padding-bottom: 6px;
+.panel {
 		box-shadow: 0 1px 10px rgba(0, 0, 0, 0.23), 0 1px 10px rgba(0, 0, 0, 0.16);
+		margin-bottom: 35px;
+}
+
+.anchor {
+		display: block;
+		position: relative;
 }
 
 .with-margin {
 		margin-bottom: 15px;
 }
 
-.footer {
-		position: absolute;
-		bottom: 0;
-		width: 100%;
-		height: 148px;
-		color: #eee;
-		background-color: #4c4c4c;
-		padding-top: 20px;
-		padding-bottom: 20px;
-}
-
 .fancybox-skin {
 		background: white;
-}
-
-.dropdown-menu {
-		a {
-				cursor: pointer
-		}
 }
 
 .btn {


### PR DESCRIPTION
@duncanmmacleod, this PR makes the following changes:

* Hook into bootstrap-ligo for omega scan output (fixes #90)
* Move table of contents into a responsive navbar, a la the DetChar summary pages (fixes #94)
* Add a `Links` dropdown with pointers to the About page, summary pages, and aLOGs; add a `Summary` nav button which links to the top of the main Omega scan page
* Show these buttons on the About page, too
* Add a drop shadow to contextual channel blocks to give their appearance some texture

Test output is available for [**multi-IFO**](https://ldas-jobs.ligo-la.caltech.edu/~aurban/pyomega-test/Network_170817/#l1-gds-calib_strain) and [**L1-specific**](https://ldas-jobs.ligo-la.caltech.edu/~aurban/pyomega-test/L1_170817_withparent/#l1-cal-deltal_external_dq) Omega scans during GW170817. (Both examples require `LIGO.ORG` credentials.) For completeness, I recommend viewing these examples on a desktop/laptop and a mobile device.