### PR TITLE
Navigation enhancements for gwdetchar-omega

### DIFF
--- a/gwdetchar/omega/html.py
+++ b/gwdetchar/omega/html.py
@@ -436,13 +436,9 @@ def wrap_html(func):
                      context=OBSERVATORY_MAP[ifo]['context']))
             kwargs['context'] = OBSERVATORY_MAP[ifo]['context']
         # write content
-        contentf = os.path.join(outdir, '_inner.html')
-        with open(contentf, 'w') as f:
-            f.write(str(func(*args, **kwargs)))
-        # embed content
         page.div(id_='main')
-        page.div('', id_='content')
-        page.script("$('#content').load('%s');" % contentf)
+        # insert inner html directly
+        page.add(str(func(*args, **kwargs)))
         page.div.close()  # main
         # close page
         index = os.path.join(outdir, 'index.html')

--- a/gwdetchar/omega/html.py
+++ b/gwdetchar/omega/html.py
@@ -821,14 +821,14 @@ def write_block(block, context, tableclass='table table-condensed table-hover '
 
     # -- range over channels in this block
     for i, channel in enumerate(block['channels']):
-        chanid = channel.name.lower().replace(':', '-')
-        page.li(class_='list-group-item anchor', id_=chanid)
+        page.li(class_='list-group-item')
         page.div(class_='container')
 
         page.div(class_='row')
 
         # channel name
-        page.h4(cis_link(channel.name))
+        chanid = channel.name.lower().replace(':', '-')
+        page.h4(cis_link(channel.name), id_=chanid)
 
         page.div(class_='row')
 

--- a/share/sass/gwdetchar-omega.scss
+++ b/share/sass/gwdetchar-omega.scss
@@ -34,7 +34,16 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 h4 {
-		word-break:break-all;
+		word-break: break-all;
+}
+
+h4::before {
+		display: block;
+		content: "";
+		margin-top: -70px;
+		height: 70px;
+		visibility: hidden;
+		pointer-events: none;
 }
 
 a {
@@ -58,11 +67,6 @@ a {
 .panel {
 		box-shadow: 0 1px 10px rgba(0, 0, 0, 0.23), 0 1px 10px rgba(0, 0, 0, 0.16);
 		margin-bottom: 35px;
-}
-
-.anchor {
-		display: block;
-		position: relative;
 }
 
 .with-margin {


### PR DESCRIPTION
This PR contains a couple of navigation enhancements for Omega scans:

* Refactor the output page so that HTML is in a single file, rather than load `_inner.html`, so that the scroll position is remembered upon refresh
* Specify a CSS pseudo-element so that anchor links to individual channels do not cut off the channel name header

[**Here**](https://ldas-jobs.ligo-la.caltech.edu/~aurban/pyomega-test/Network_170817/) is example output based on GW170817.

This fixes #171.