### PR TITLE
Use absolute https URLs for HTML resources

### DIFF
--- a/gwdetchar/io/html.py
+++ b/gwdetchar/io/html.py
@@ -27,12 +27,12 @@ from glue import markup
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
-JQUERY_JS = "//code.jquery.com/jquery-1.11.2.min.js"
+JQUERY_JS = "https://code.jquery.com/jquery-1.11.2.min.js"
 
 BOOTSTRAP_CSS = (
-    "//maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css")
+    "https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css")
 BOOTSTRAP_JS = (
-    "//maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js")
+    "https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js")
 
 
 def new_bootstrap_page(*args, **kwargs):

--- a/gwdetchar/omega/html.py
+++ b/gwdetchar/omega/html.py
@@ -114,14 +114,13 @@ OBSERVATORY_MAP = {
 
 # -- set up default JS and CSS files
 
-FANCYBOX_CSS = (
-    "//cdnjs.cloudflare.com/ajax/libs/fancybox/2.1.5/jquery.fancybox.min.css")
-JQUERY_JS = (
-    "//code.jquery.com/jquery-1.12.3.min.js")
+_FANCYBOX_CDN = "https://cdnjs.cloudflare.com/ajax/libs/fancybox/2.1.5"
+
+FANCYBOX_CSS = "{0}/jquery.fancybox.min.css".format(_FANCYBOX_CDN)
+JQUERY_JS = "https://code.jquery.com/jquery-1.12.3.min.js"
 MOMENT_JS = (
-    "//cdnjs.cloudflare.com/ajax/libs/moment.js/2.13.0/moment.min.js")
-FANCYBOX_JS = (
-    "//cdnjs.cloudflare.com/ajax/libs/fancybox/2.1.5/jquery.fancybox.min.js")
+    "https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.13.0/moment.min.js")
+FANCYBOX_JS = "{0}/jquery.fancybox.min.js".format(_FANCYBOX_CDN)
 
 OMEGA_CSS = resource_filename('gwdetchar', '_static/gwdetchar-omega.min.css')
 LIGO_CSS = resource_filename('gwdetchar', '_static/bootstrap-ligo.min.css')


### PR DESCRIPTION
This PR updates the URLs in `gwdetchar.io.html` to include the `https` prefix, so that when you run pages locally (with file: scheme), the results link correctly.