### PR TITLE
Support gwdetchar-omega in wdq and wdq-batch

### DIFF
--- a/bin/gwdetchar-omega
+++ b/bin/gwdetchar-omega
@@ -63,7 +63,7 @@ from gwpy.detector import (Channel, ChannelList)
 from gwpy.segments import (Segment, DataQualityFlag)
 from gwpy.signal.qtransform import QTiling
 
-from gwdetchar import (cli, __version__)
+from gwdetchar import (cli, const, __version__)
 from gwdetchar.omega import (config, plot, html)
 
 __author__ = 'Alex Urban <alexander.urban@ligo.org>'
@@ -82,13 +82,13 @@ parser.add_argument('-o', '--output-directory',
 parser.add_argument('-f', '--config-file', action='append', default=None,
                     help='path to configuration file to use, can be given '
                          'multiple times (files read in order), default: '
-                         'None')
+                         'choose a standard one based on IFO and GPS time')
 parser.add_argument('-s', '--ignore-state-flags', action='store_true',
                     default=False, help='ignore state flag definitions in '
                                         'the configuration, default: False')
 parser.add_argument('-t', '--far-threshold', type=float, default=1e-10,
-                    help='White noise false alarm rate threshold for '
-                         'processing channels; default: %(default)s Hz')
+                    help='white noise false alarm rate threshold for '
+                         'processing channels, default: %(default)s Hz')
 parser.add_argument('-c', '--colormap', default='viridis',
                     help='name of colormap to use, default: %(default)s')
 cli.add_nproc_option(parser)
@@ -108,15 +108,33 @@ far = args.far_threshold
 print("----------------------------------------------\n"
       "Creating %s omega scan at GPS second %s..." % (ifo, gps))
 
-# parse configuration file
-config_files = [os.path.abspath(f) for f in args.config_file]
+if args.config_file is None:
+    # find epoch
+    epoch = const.gps_epoch(gps, default=const.latest_epoch())
+    gprint('Identified epoch as %r' % epoch)
+
+    # find and parse configuration file
+    if ifo == 'Network':
+        args.config_file = [os.path.expanduser(
+            '~detchar/etc/omega/{epoch}/Network.ini'.format(epoch=epoch))]
+    else:
+        args.config_file = [os.path.expanduser(
+            '~detchar/etc/omega/{epoch}/{obs}-{ifo}_R-selected.ini'.format(
+                epoch=epoch, obs=ifo[0], ifo=ifo))]
+
+# parse configuration files
+args.config_file = [os.path.abspath(f) for f in args.config_file]
+if args.verbose:
+    gprint('Parsing the following configuration files:')
+    for fname in args.config_file:
+        gprint(''.join(['\t', fname]))
 cp = config.OmegaConfigParser(ifo=ifo)
-cp.read(config_files)
+cp.read(args.config_file)
 
 # prepare html variables
 htmlv = {
     'title': '%s Qscan | %s' % (ifo, gps),
-    'config': config_files,
+    'config': args.config_file,
     'refresh': True,
 }
 

--- a/bin/wdq
+++ b/bin/wdq
@@ -25,7 +25,8 @@ from __future__ import print_function
 import os.path
 import shutil
 import sys
-from subprocess import (Popen, PIPE, CalledProcessError)
+import subprocess
+import warnings
 
 from glue.lal import Cache
 
@@ -36,7 +37,8 @@ from gwdetchar import (cli, omega, const)
 from gwdetchar.io import datafind
 
 parser = cli.create_parser(description=__doc__)
-parser.add_argument('gpstime', type=str, help='GPS time of scan')
+parser.add_argument('gpstime', type=to_gps,
+                    help='GPS time or datestring to scan')
 cli.add_ifo_option(parser)
 parser.add_argument('-o', '--output-directory',
                     help='output directory for scan, '
@@ -44,32 +46,80 @@ parser.add_argument('-o', '--output-directory',
 parser.add_argument(
     '-f', '--config-file',
     help='path to configuration file to use, default: '
-         '~detchar/etc/omega/{epoch}/{OBS}-{IFO}_R-selected.txt')
-parser.add_argument(
+         'choose based on observatory, epoch, and pipeline')
+parser.add_argument('-w', '--wpipeline', default=omega.WPIPELINE,
+                    required=omega.WPIPELINE is None,
+                    help='path to Matlab wpipeline binary, can also choose '
+                         'the Python version with string "gwdetchar-omega", '
+                         'default: %(default)s')
+parser.add_argument('--colormap', default=None,
+                    help='name of colormap to use (supported either in Python '
+                         'or in Matlab omega > r3449), default: choose based '
+                         'on wpipeline')
+
+margs = parser.add_argument_group('Matlab options')
+margs.add_argument('--condor', action='store_true', default=False,
+                   help='indicates this job is running under condor, '
+                        'only use when running as part of a workflow')
+margs.add_argument(
     '-c', '--cache-file',
     help='path to data cache file, if not given, data locations '
          'are found using the datafind server, must be in LAL cache format')
-parser.add_argument('-w', '--wpipeline', default=omega.WPIPELINE,
-                    required=omega.WPIPELINE is None,
-                    help='path to wpipeline binary, default: %(default)s')
-parser.add_argument('--condor', action='store_true', default=False,
-                    help='indicates this job is running under condor, '
-                         'only use when running as part of a workflow')
 
-oargs = parser.add_argument_group('Omega options')
-oargs.add_argument('--colormap', default='parula',
-                   help='name of colormap to use (only supported for '
-                        'omega > r3449)')
+pargs = parser.add_argument_group('Python options')
+pargs.add_argument('-t', '--far-threshold', type=float, default=1e-10,
+                   help='white noise false alarm rate threshold for '
+                        'processing channels, default: %(default)s Hz')
+pargs.add_argument('-s', '--ignore-state-flags', action='store_true',
+                   default=False, help='ignore state flag definitions in '
+                                       'the configuration, default: False')
+cli.add_nproc_option(pargs)
+pargs.add_argument('-v', '--verbose', action='store_true', default=False,
+                   help='print verbose output, default: False')
 
 args = parser.parse_args()
-
-print("----------------------------------------------\n"
-      "Creating omega scan for %s..." % args.gpstime)
 
 gps = args.gpstime
 gpstime = float(gps)
 ifo = args.ifo
 obs = args.ifo[0]
+
+# set colormap default
+if args.colormap is None:
+    if args.wpipeline.endswith('wpipeline'):
+        args.colormap = 'parula'  # matlab
+    else:
+        args.colormap = 'viridis'  # python
+
+# if requested, wrap around gwdetchar-omega
+if 'gwdetchar-omega' in args.wpipeline:
+    wpipeline = os.path.join(os.path.dirname(__file__), 'gwdetchar-omega')
+    cmd = [wpipeline, '-t', str(args.far_threshold), '-j', str(args.nproc),
+           '-c', args.colormap, '-i', ifo, str(gps)]
+    if args.output_directory is not None:
+        cmd.extend(['-o', args.output_directory])
+    if args.config_file is not None:
+        cmd.extend(['-f', args.config_file])
+    if args.ignore_state_flags:
+        cmd.extend(['-s'])
+    if args.verbose:
+        cmd.extend(['-v'])
+    process = subprocess.check_call(cmd)
+    sys.exit(0)
+
+# else, wrap around the Matlab code and throw a deprecation warning
+warnings.simplefilter('always', DeprecationWarning)
+warnings.warn('Since the Matlab omega scan code is reaching end-of-life, '
+              '`wdq` will soon be deprecated in favor of `gwdetchar-omega`. '
+              'We are in the first stage of this process, where `wdq` '
+              'supports `gwdetchar-omega` but still runs the Matlab code '
+              'by default. A future version will set `gwdetchar-omega` as '
+              'default, and before O3, `wdq` will be removed entirely and '
+              '`wdq-batch` will become `gwdetchar-omega-batch`.',
+              DeprecationWarning)
+
+print("----------------------------------------------\n"
+      "Creating omega scan for %s..." % args.gpstime)
 
 # set output directory
 outdir = args.output_directory
@@ -87,7 +137,7 @@ if args.config_file is None:
     # find and parse configuration file
     args.config_file = os.path.expanduser(
         '~detchar/etc/omega/{epoch}/{obs}-{ifo}_R-selected.txt'.format(
-        epoch=epoch, obs=obs, ifo=ifo))
+            epoch=epoch, obs=obs, ifo=ifo))
 config = omega.OmegaChannelList.read(args.config_file)
 print("Successfully parsed config file %s" % args.config_file)
 

--- a/bin/wdq
+++ b/bin/wdq
@@ -85,11 +85,10 @@ ifo = args.ifo
 obs = args.ifo[0]
 
 # set colormap default
-if args.colormap is None:
-    if args.wpipeline.endswith('wpipeline'):
-        args.colormap = 'parula'  # matlab
-    else:
-        args.colormap = 'viridis'  # python
+if not args.colormap and args.wpipeline.endswith('wpipeline'):
+    args.colormap = 'parula'  # matlab
+elif not args.colormap:
+    args.colormap = 'viridis'  # python
 
 # if requested, wrap around gwdetchar-omega
 if 'gwdetchar-omega' in args.wpipeline:

--- a/bin/wdq-batch
+++ b/bin/wdq-batch
@@ -149,11 +149,10 @@ if not valid:
                          args.condor_accounting_group, listtags))
 
 # set colormap default
-if args.colormap is None:
-    if args.wpipeline.endswith('wpipeline'):
-        args.colormap = 'parula'  # matlab
-    else:
-        args.colormap = 'viridis'  # python
+if not args.colormap and args.wpipeline.endswith('wpipeline'):
+    args.colormap = 'parula'  # matlab
+elif not args.colormap:
+    args.colormap = 'viridis'  # python
 
 # -- generate workflow --------------------------------------------------------
 

--- a/bin/wdq-batch
+++ b/bin/wdq-batch
@@ -51,10 +51,7 @@ CONDOR_ACCOUNTING_USER = os.getenv(
 
 # -- parse command line -------------------------------------------------------
 
-parser = cli.create_parser(
-    description=__doc__,
-    formatter_class=cli.argparse.ArgumentDefaultsHelpFormatter,
-)
+parser = cli.create_parser(description=__doc__)
 
 parser.add_argument('gps-time', nargs='+',
                     help='GPS time(s) to scan, or path to a file '
@@ -66,21 +63,35 @@ parser.add_argument('-o', '--output-dir', default=os.getcwd(),
 parser.add_argument(
     '-f', '--config-file',
     help='path to configuration file to use, default: '
-         '~detchar/etc/omega/{epoch}/{OBS}-{IFO}_R-selected.txt')
-parser.add_argument(
-    '-c', '--cache-file',
-    help='path to data cache file, if not given, data locations '
-         'are found using the datafind server, must be in LAL cache format')
+         'choose based on observatory, epoch, and pipeline')
 parser.add_argument('-q', '--wdq', default=WDQ, required=WDQ is None,
                     help='path to wdq executable')
 parser.add_argument('-w', '--wpipeline', default=omega.WPIPELINE,
                     required=omega.WPIPELINE is None,
-                    help='path to wpipeline binary')
+                    help='path to Matlab wpipeline binary, can also choose '
+                         'the Python version with string "gwdetchar-omega", '
+                         'default: %(default)s')
+parser.add_argument('--colormap', default=None,
+                    help='name of colormap to use (supported either in Python '
+                         'or in Matlab omega > r3449), default: choose based '
+                         'on wpipeline')
 
-oargs = parser.add_argument_group('Omega options')
-oargs.add_argument('--colormap', default='parula',
-                   help='name of colormap to use (only supported for '
-                        'omega > r3449)')
+margs = parser.add_argument_group('Matlab options')
+margs.add_argument(
+    '-c', '--cache-file',
+    help='path to data cache file, if not given, data locations '
+         'are found using the datafind server, must be in LAL cache format')
+
+pargs = parser.add_argument_group('Python options')
+pargs.add_argument('-t', '--far-threshold', type=float, default=1e-10,
+                   help='white noise false alarm rate threshold for '
+                        'processing channels, default: %(default)s Hz')
+pargs.add_argument('-s', '--ignore-state-flags', action='store_true',
+                   default=False, help='ignore state flag definitions in '
+                                       'the configuration, default: False')
+cli.add_nproc_option(pargs)
+pargs.add_argument('-v', '--verbose', action='store_true', default=False,
+                   help='print verbose output, default: False')
 
 cargs = parser.add_argument_group('Condor options')
 cargs.add_argument('-u', '--universe', default='vanilla', type=str,
@@ -137,6 +148,13 @@ if not valid:
                      "of valid groups, run `{1}`".format(
                          args.condor_accounting_group, listtags))
 
+# set colormap default
+if args.colormap is None:
+    if args.wpipeline.endswith('wpipeline'):
+        args.colormap = 'parula'  # matlab
+    else:
+        args.colormap = 'viridis'  # python
+
 # -- generate workflow --------------------------------------------------------
 
 tag = 'wdq-batch'
@@ -172,6 +190,10 @@ if args.universe != 'local':
 if args.condor_timeout:
     condorcmds['periodic_remove'] = (
         'CurrentTime-EnteredCurrentStatus > %d' % (3600 * args.condor_timeout))
+if args.universe != 'local' and args.wpipeline.endswith('wpipeline'):
+    condorcmds['request_memory'] = 4096
+elif args.universe != 'local':
+    condorcmds['request_memory'] = 32768
 for cmd_ in args.condor_command:
     key, value = cmd_.split('=', 1)
     condorcmds[key.rstrip().lower()] = value.strip()
@@ -182,11 +204,19 @@ for key, val in condorcmds.items():
 job.add_opt('wpipeline', args.wpipeline)
 job.add_opt('colormap', args.colormap)
 job.add_opt('ifo', args.ifo)
-job.add_opt('condor', '')
 if args.config_file is not None:
     job.add_opt('config-file', args.config_file)
-if args.cache_file is not None:
-    job.add_opt('cache-file', args.cache_file)
+if args.wpipeline.endswith('wpipeline'):
+    job.add_opt('condor', '')
+    if args.cache_file is not None:
+        job.add_opt('cache-file', args.cache_file)
+else:
+    job.add_opt('far-threshold', str(args.far_threshold))
+    job.add_opt('nproc', str(args.nproc))
+    if args.ignore_state_flags:
+        job.add_opt('ignore-state-flags', '')
+    if args.verbose:
+        job.add_opt('verbose', '')
 
 # make node in workflow for each time
 for t in times:


### PR DESCRIPTION
This pull request modifies the `wdq` and `wdq-batch` tools to support `gwdetchar-omega` as an executable. As of this PR, the default is still the Matlab `wpipeline` script, but a future PR will make `gwdetchar-omega` the default. Before O3 we will remove `wdq` altogether, rename `wdq-batch --> gwdetchar-omega-batch`, and bring the Matlab code to end-of-life.

This PR makes the following changes:

* Support `gwdetchar-omega` as an executable by `wdq`
* Invoke logic to run `gwdetchar-omega` if selected
* Re-organize command line options in `wdq` and `wdq-batch` based on whether they are associated with the Python or Matlab code
* Run `gwdetchar-omega` under condor from `wdq-batch`
* Point to epoch-specific config files on the LDAS clusters in `gwdetchar-omega`, similar to `wdq`
* Update `gwdetchar.const` to end O2 on 2017 Aug 26 and start a `preO3` epoch on 2018 Sept 1

Below are a few test pages, each made using `wdq-batch` to stage workflows for `wdq` under this PR's changes (requires `LIGO.ORG` credentials):

| Executable | Pipeline | IFOs | GPS Time | Link |
| -- | -- | -- | -- | -- |
| `wdq` | `gwdetchar-omega` (Python) | H1, L1 | 1126259462.4 | [**Link**](https://ldas-jobs.ligo-la.caltech.edu/~aurban/pyomega-test/Network_150914/) |
| `wdq-batch` | `gwdetchar-omega` (Python) | H1, L1, V1 | 1187008882 | [**Link**](https://ldas-jobs.ligo-la.caltech.edu/~aurban/pyomega-test/Network_170817/1187008882.0/) |
| `wdq-batch` | `wpipeline` (Matlab) | L1 | 1187008882 | [**Link**](https://ldas-jobs.ligo-la.caltech.edu/~aurban/pyomega-test/Matlab_test/1187008882.0/) |

cc @duncanmmacleod, @areeda 

This fixes #143.