### PR TITLE
Strip whitespace from channels when reading configuration file in gwdetchar-omega

### DIFF
--- a/bin/gwdetchar-omega
+++ b/bin/gwdetchar-omega
@@ -147,7 +147,7 @@ class OmegaChannelList(object):
         self.resample = int(params.get('resample', 0))
         self.source = params.get('source', None)
         self.frametype = params.get('frametype', None)
-        chans = params.get('channels', None).split('\n')
+        chans = params.get('channels', None).strip().split('\n')
         section = self.parent if self.parent else self.key
         self.channels = [OmegaChannel(c, section, **params) for c in chans]
         self.params = params.copy()


### PR DESCRIPTION
This PR modifies the parsing of channels from the configuration file in `gwdetchar-omega` to enable leading whitespace in the config. This allows users to write something like this in their config:

```ini
[section]
channels =
    X1:CHANNEL1
    X2:CHANNEL2
```

Previously the leading line return would cause `gwdetchar-omega` to fail.