### PR TITLE
Omega scan config documentation

### DIFF
--- a/bin/gwdetchar-omega
+++ b/bin/gwdetchar-omega
@@ -17,7 +17,31 @@
 # You should have received a copy of the GNU General Public License
 # along with GW DetChar.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Compute an omega scan for a list of channels around a given GPS time.
+"""Compute an Omega scan for a list of channels around a given GPS time
+
+This utility can be used to process an arbitrary list of detector channels
+with minimal effort in finding data. The input should be an INI-formatted
+configuration file that lists processing options and channels in contextual
+blocks, e.g.:
+
+```ini
+[GW]
+name = Gravitational Wave Strain
+q-range = 3.3166,150
+frequency-range = 4,2048
+resample = 4096
+frametype = H1_HOFT_C00
+state-flag = H1:DMT-GRD_ISC_LOCK_NOMINAL:1
+duration = 64
+fftlength = 8
+max-mismatch = 0.2
+snr-threshold = 5
+always-plot = True
+plot-time-durations = 1,4,16
+channels = H1:GDS-CALIB_STRAIN
+```
+
+For more information, see gwdetchar.omega.config.
 """
 
 from __future__ import division

--- a/gwdetchar/omega/config.py
+++ b/gwdetchar/omega/config.py
@@ -17,11 +17,98 @@
 # along with GW DetChar.  If not, see <http://www.gnu.org/licenses/>.
 
 """
-Configuration files for Omega Scans
+Configuration files for Omega scans
 ###################################
 
 How to write a configuration file
 =================================
+
+`gwdetchar-omega` can be used to process an arbitrary list of channels,
+including primary gravitational wave strain channels and auxiliary sensors,
+with arbitrary units and sample rates. Channels can be organized in contextual
+blocks using an INI-formatted configuration file that must be passed at
+runtime, which must include processing options for individual blocks. In a
+given block, the following keywords are supported:
+
+[blockkey]
+-------
+
+=======================  ======================================================
+``name``                 The full name of this channel block, which will
+                         appear as a section header on the output page
+                         (optional)
+``parent``               The `blockkey` of a section that the current block
+                         should appear on the output page with (optional)
+``q-range``              Range of quality factors (or Q) to search (required)
+``frequency-range``      Range of frequencies to search (required)
+``resample``             A sample rate (in Hz) to resample the input data to,
+                         must be different from the original sample rate
+                         (optional)
+``frametype``            The type of frame files to read data from (will be
+                         superceded by `source`, required if `source` is not
+                         specified)
+``source``               Path to a LAL-format cache pointing to frame files
+``state-flag``           A data quality flag to require to be active before
+                         processing this block (can be superceded by passing
+                         ``--ignore-state-flags`` on the command line;
+                         optional)
+``duration``             The duration of data to process in this block
+                         (required)
+``fftlength``            The FFT length to use in computing an ASD for
+                         whitening with an overlap of `fftlength/2` (required)
+``max-mismatch``         The maximum mismatch in time-frequency tiles
+                         (optional)
+``snr-threshold``        Threshold on SNR for plotting eventgrams (optional)
+``always-plot``          Always analyze this block regardless of channel
+                         significance (optional; will be superceded by
+                         `state-flag` unless `--ignore-state-flags` is passed)
+``plot-time-durations``  Time-axis durations of Omega scan plots (required)
+``channels``             Full list of channels which appear in this block
+                         (required)
+=======================  ======================================================
+
+.. code-block:: ini
+
+  [GW]
+  ; name of this block, which contains h(t)
+  name = Gravitational Wave Strain
+  q-range = 3.3166,150.0
+  frequency-range = 4.0,2048
+  resample = 4096
+  frametype = L1_HOFT_C00
+  state-flag = L1:DMT-GRD_ISC_LOCK_NOMINAL:1
+  duration = 64
+  fftlength = 8
+  max-mismatch = 0.2
+  snr-threshold = 5
+  always-plot = True
+  plot-time-durations = 1,4,16
+  channels = L1:GDS-CALIB_STRAIN
+
+  [CAL]
+  ; a sub-block of channels with different options, but which should appear
+  ; together with the block `GW` on the output page
+  parent = GW
+  q-range = 3.3166,150
+  frequency-range = 4.0,Inf
+  resample = 4096
+  frametype = L1_R
+  state-flag = L1:DMT-GRD_ISC_LOCK_NOMINAL:1
+  duration = 64
+  fftlength = 8
+  max-mismatch = 0.35
+  snr-threshold = 5.5
+  always-plot = True
+  plot-time-durations = 1,4,16
+  channels = L1:CAL-DELTAL_EXTERNAL_DQ
+
+  .. note::
+  The `blockkey` will appear in the navbar to identify channel blocks on the
+  output page, with a scrollable dropdown list of channels in that block for
+  ease of navigation.
+
+  If running on a LIGO Data Grid (LDG) computer cluster,
+  the `~detchar` account houses default configurations organized by subsystem.
 """
 
 try:  # python 3.x

--- a/gwdetchar/omega/html.py
+++ b/gwdetchar/omega/html.py
@@ -774,13 +774,15 @@ def write_summary(
     return page()
 
 
-def write_block(block, context, tableclass='table table-condensed table-hover '
-                                           'table-bordered table-responsive '
-                                           'desktop-only'):
+def write_block(blockkey, block, context,
+                tableclass='table table-condensed table-hover table-bordered '
+                           'table-responsive desktop-only'):
     """Write the HTML summary for a specific block of channels
 
     Parameters
     ----------
+    blockkey: `str`
+        the key labeling the channel block
     block : `dict` of `OmegaChannel`
         a list of channels and their analysis attributes
     context : `str`
@@ -809,7 +811,7 @@ def write_block(block, context, tableclass='table table-condensed table-hover '
         page.a("<small>[top]</small>", href='#', class_='text-%s' % context)
     page.div.close()  # pull-right
     # heading
-    page.h3(block['name'], class_='panel-title')
+    page.h3(': '.join([blockkey, block['name']]), class_='panel-title')
     page.div.close()  # panel-heading
 
     # -- make body
@@ -921,8 +923,8 @@ def write_qscan_page(blocks, context):
     page.div(class_='banner')
     page.h2('Channel details')
     page.div.close()  # banner
-    for block in blocks.values():
-        page.add(write_block(block, context))
+    for key, block in blocks.items():
+        page.add(write_block(key, block, context))
     write_summary_table(blocks)
     return page
 


### PR DESCRIPTION
Documentation for omega scan configurations; label channel blocks with config key and block name. An example scan under these changes is available [here](https://ldas-jobs.ligo-la.caltech.edu/~aurban/pyomega-test/L1_170817_withparent/) (requires `LIGO.ORG` credentials).

This fixes #182.