### PR TITLE
Improved epoch utilities in gwdetchar.const and usage in wdq scripts

### DIFF
--- a/bin/wdq
+++ b/bin/wdq
@@ -81,23 +81,8 @@ print("Ouput directory created as %s" % outdir)
 
 if args.config_file is None:
     # find epoch
-    epoch = None
-    epochs = sorted(const.EPOCH.items(), key=lambda x: x[1].start)
-    for i, (epoch_, segment) in enumerate(epochs):
-        if gpstime in segment:
-            epoch = epoch_
-            break
-        elif (i == 0 and gpstime < segment.start):
-            epoch = epoch_
-            break
-        elif gpstime < segment.start:
-            epoch = epochs[i-1][0]
-            break
-    if epoch is None:
-        epoch = epochs[-1]
-        print("GPS time not identified in any epoch, defaulting to %r" % epoch)
-    else:
-        print("Identified epoch as %r" % epoch)
+    epoch = const.gps_epoch(gpstime, default=const.latest_epoch())
+    print("Identified epoch as %r" % epoch)
 
     # find and parse configuration file
     args.config_file = os.path.expanduser(

--- a/bin/wdq-batch
+++ b/bin/wdq-batch
@@ -35,7 +35,7 @@ from getpass import getuser
 
 from glue import pipeline
 
-from gwdetchar import (omega, cli)
+from gwdetchar import (omega, cli, condor)
 
 # attempt to get WDQ path
 WDQ = os.path.join(os.path.dirname(__file__), 'wdq')
@@ -44,7 +44,7 @@ if not os.path.isfile(WDQ):
 
 # set default accounting information
 CONDOR_ACCOUNTING_GROUP = os.getenv(
-    '_CONDOR_ACCOUNTING_GROUP', 'ligo.dev.o2.detchar.user_req.omegascan')
+    '_CONDOR_ACCOUNTING_GROUP', 'ligo.dev.{epoch}.detchar.user_req.omegascan')
 CONDOR_ACCOUNTING_USER = os.getenv(
     '_CONDOR_ACCOUNTING_USER', getuser())
 
@@ -88,7 +88,9 @@ cargs.add_argument('-u', '--universe', default='vanilla', type=str,
 cargs.add_argument('--condor-accounting-group',
                    default=CONDOR_ACCOUNTING_GROUP,
                    help='accounting_group for condor submission on the LIGO '
-                        'Data Grid')
+                        'Data Grid, include \'{epoch}\' (with curly brackets) '
+                        'to auto-substitute the appropriate epoch based on '
+                        'the GPS times')
 cargs.add_argument('--condor-accounting-group-user',
                    default=CONDOR_ACCOUNTING_USER,
                    help='accounting_group_user for condor submission on the '
@@ -109,6 +111,24 @@ if len(times) == 1:
         times = numpy.loadtxt(times[0], dtype=float)
 else:
     times = map(float, times)
+
+# finalise accounting tag based on run
+if '{epoch}' in args.condor_accounting_group:
+    gpsepoch = max(times)
+    epoch = condor.accounting_epoch(gpsepoch)
+    args.condor_accounting_group = args.condor_accounting_group.format(
+        epoch=epoch.lower())
+
+# valid the accounting tag up-front
+try:
+    valid = condor.validate_accounting_tag(args.condor_accounting_group)
+except EnvironmentError:
+    valid = True  # failed to load condor tags, not important
+if not valid:
+    listtags = 'cat {0} | json_pp | less'.format(condor.ACCOUNTING_GROUPS_FILE)
+    raise ValueError("condor accounting tag {0!r} recognised, to see the list "
+                     "of valid groups, run `{1}`".format(
+                         args.condor_accounting_group, listtags))
 
 # -- generate workflow --------------------------------------------------------
 

--- a/gwdetchar/condor.py
+++ b/gwdetchar/condor.py
@@ -1,0 +1,68 @@
+# coding=utf-8
+# Copyright (C) Duncan Macleod (2018)
+#
+# This file is part of the GW DetChar python package.
+#
+# GW DetChar is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GW DetChar is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GW DetChar.  If not, see <http://www.gnu.org/licenses/>.
+
+"""HTCondor utilities for `gwdetchar`
+"""
+
+import json
+import re
+
+from . import const
+
+OBS_RUN_REGEX = re.compile('[OS][0-9]*', re.I)
+ACCOUNTING_GROUPS_FILE = '/etc/condor/accounting_groups.json'
+
+
+def accounting_epoch(gpstime):
+    """Return the appropriate epoch for condor accounting tags
+
+    Examples
+    --------
+    >>> from gwdetchar.condor import accounting_epoch
+    >>> print(accounting_epoch(1126259462))  # GW150914
+    'O1'
+    """
+    for epoch in filter(OBS_RUN_REGEX.match, const.EPOCH):
+        # if gpstime falls before the _end_ of this run, use it
+        if float(gpstime) < const.EPOCH[epoch][1]:
+            return epoch
+    # gpstime falls _after_ the end of the last known epoch, use it
+    return epoch
+
+
+def validate_accounting_tag(tag, path=ACCOUNTING_GROUPS_FILE):
+    """Validate a given accounting tag
+
+    This loads the list of known accounting tags from ``path`` and
+    checks for ``tag`` in that list.
+
+    Returns
+    -------
+    True
+        if ``tag`` is found in the list of tags
+    False
+        if ``tag`` is **not** found in the list of tags
+    """
+    return tag in load_accounting_tags(path=path)
+
+
+def load_accounting_tags(path=ACCOUNTING_GROUPS_FILE):
+    """Load the list of known accounting tags
+    """
+    with open(path, 'r') as fobj:
+        return json.load(fobj)['groups']

--- a/gwdetchar/const.py
+++ b/gwdetchar/const.py
@@ -46,3 +46,50 @@ EPOCH = OrderedDict([
     ('O2', Segment(1164499217, 1187733618)),
     ('O3', Segment(1187733618, 2000000000)),
 ])
+
+
+def latest_epoch():
+    """Returns the name of the latest known epoch
+    """
+    epochs = sorted(EPOCH.items(), key=lambda x: x[1][0])
+    return epochs[-1][0]
+
+
+def gps_epoch(gpstime, default=None):
+    """Returns the epoch name containing the given GPS time
+
+    Parameters
+    ----------
+    gpstime : `float`, `int`
+        the GPS time to match
+
+    default : `str`, optional
+        the epoch to return if ``gpstime`` doesn't match any
+        known epoch, default is to raise `ValueError`
+
+    Returns
+    -------
+    epoch : `str`
+        the name of the containing epoch, or ``default`` if given
+
+    Raises
+    ------
+    ValueError
+        if ``gpstime`` doesn't match any known epoch, and ``default``
+        was not given
+
+    Examples
+    --------
+    >>> from gwdetchar.const import gps_epoch
+    >>> print(gps_epoch(1126259462))
+    'O1'
+    >>> print(gps_epoch(0, default='ER0')
+    'ER0'
+    """
+    for epoch in EPOCH:
+        if float(gpstime) in EPOCH[epoch]:
+            return epoch
+    if default:
+        return default
+    raise ValueError("failed to match GPS time {0} to any "
+                     "known epoch".format(gpstime))

--- a/gwdetchar/const.py
+++ b/gwdetchar/const.py
@@ -20,6 +20,7 @@
 """
 
 import os
+from collections import OrderedDict
 
 from gwpy.segments import Segment
 
@@ -34,11 +35,14 @@ S6_SEGMENT_SERVER = os.getenv('S6_SEGMENT_SERVER',
                               'https://segdb.ligo.caltech.edu')
 
 # -- Run epochs ---------------------------------------------------------------
-EPOCH = {
-    'ER7': Segment(1117400416, 1118329216),
-    'ER8': Segment(1123858817, 1126623617),
-    'O1': Segment(1126623617, 1136649617),
-    'ER9': Segment(1152136817, 1152255617),
-    'ER10': Segment(1161907217, 1164499217),
-    'O2': Segment(1164499217, 2000000000),
-}
+
+EPOCH = OrderedDict([
+    ('S6', Segment(931035615, 971622015)),
+    ('ER7', Segment(1117400416, 1118329216)),
+    ('ER8', Segment(1123858817, 1126623617)),
+    ('O1', Segment(1126623617, 1136649617)),
+    ('ER9', Segment(1152136817, 1152255617)),
+    ('ER10', Segment(1161907217, 1164499217)),
+    ('O2', Segment(1164499217, 1187733618)),
+    ('O3', Segment(1187733618, 2000000000)),
+])

--- a/gwdetchar/tests/test_condor.py
+++ b/gwdetchar/tests/test_condor.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Joshua Smith (2016-)
+#
+# This file is part of the GW DetChar python package.
+#
+# gwdetchar is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# gwdetchar is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with gwdetchar.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Test suite for `gwdetchar.condor`
+"""
+
+import json
+import os
+import tempfile
+
+import pytest
+
+from .. import (condor, const)
+
+LAST_CONDOR_EPOCH = filter(
+    condor.OBS_RUN_REGEX.match,
+    zip(*sorted(const.EPOCH.items(), key=lambda x: x[1].start))[0],
+)[-1]
+
+
+@pytest.mark.parametrize('gps, epoch', [
+    (0, 'S6'),  # earlier than first run, pin to first
+    (1126259462, 'O1'),  # in a run
+    (2e50, LAST_CONDOR_EPOCH),  # beyond last run, pin to latest
+])
+def test_accounting_epoch(gps, epoch):
+    assert condor.accounting_epoch(gps) == epoch
+
+
+@pytest.fixture
+def tagfile():
+    name = tempfile.mktemp()
+    with open(name, 'w') as tmp:
+        json.dump({'groups': ['tag1', 'tag2', 'tag3']}, tmp)
+    try:
+        yield name
+    finally:
+        os.remove(name)
+
+
+@pytest.mark.parametrize('tag, result', [
+    ('tag1', True),
+    ('something else', False),
+])
+def test_validate_accounting_tag(tagfile, tag, result):
+    assert condor.validate_accounting_tag(tag, path=tagfile) == result

--- a/gwdetchar/tests/test_const.py
+++ b/gwdetchar/tests/test_const.py
@@ -54,3 +54,25 @@ def test_const(const, env):
         assert const.IFO is None
         assert const.ifo is None
     assert const.site is None
+
+
+@pytest.mark.parametrize('gps, default, epoch', [
+    (1126259462, None, 'ER8'),
+    (1187008882.43, None, 'O2'),
+    (-1, 'test', 'test'),
+])
+def test_gps_epoch(gps, default, epoch):
+    assert _const.gps_epoch(gps, default=default) == epoch
+
+
+def test_gps_epoch_valueerror():
+    with pytest.raises(ValueError):
+        _const.gps_epoch(-1, default=None)
+
+
+def test_latest_epoch(const):
+    const.EPOCH = {
+        'test1': (0, 10),
+        'test2': (10, 20),
+    }
+    assert const.latest_epoch() == 'test2'


### PR DESCRIPTION
This PR improves the EPOCH handling utilities in `gwdetchar.const`, and the usage of epochs in `wdq` and `wdq-batch`. Changes amount to

- `gwdetchar.const.EPOCH` is not an `OrderedDict`
- new `gwdetchar.const.gps_epoch` function (used in `wdq`)
- new `gwdetchar.condor` module with accounting tag epoch utilities and tag validation (used in `wdq-batch`)