### PR TITLE
Use fixed random seed in tests

### DIFF
--- a/gwdetchar/tests/test_io_ligolw.py
+++ b/gwdetchar/tests/test_io_ligolw.py
@@ -43,6 +43,7 @@ def test_new_table():
 
 
 def test_sngl_burst_from_times():
+    numpy.random.seed(0)
     times = numpy.random.random(4) * 100.
     tab = io_ligolw.sngl_burst_from_times(times)
     assert isinstance(tab, lsctables.SnglBurstTable)


### PR DESCRIPTION
This PR adds a call to `numpy.random.seed` in the one test that uses `numpy.random` to prevent edge-case failures like [this](https://travis-ci.org/gwdetchar/gwdetchar/jobs/453990778).