### PR TITLE
Miscellaneous Omega scan formatting tweaks

### DIFF
--- a/bin/gwdetchar-omega
+++ b/bin/gwdetchar-omega
@@ -102,7 +102,7 @@ if args.ifo:
     ifo = args.ifo
 else:
     ifo = 'Network'
-gps = float(args.gpstime)
+gps = numpy.around(float(args.gpstime), 3)
 far = args.far_threshold
 
 print("----------------------------------------------\n"
@@ -422,12 +422,8 @@ if sys.version_info >= (3, 7):  # python 3.7+
     analyzed = {}
 else:
     from collections import OrderedDict
-    try:  # python 3.x
-        blocks = OrderedDict([(s, OmegaChannelList(s, **cp[s]))
-                              for s in cp.sections()])
-    except:  # python 2.x
-        blocks = OrderedDict([(s, OmegaChannelList(s, **dict(cp.items(s))))
-                              for s in cp.sections()])
+    blocks = OrderedDict([(s, OmegaChannelList(s, **dict(cp.items(s))))
+                          for s in cp.sections()])
     analyzed = OrderedDict()
 
 # set up html output
@@ -555,11 +551,11 @@ for block in blocks.values():
                             figsize=figsize)
 
         # save parameters
-        c.Q = Q
-        c.energy = table.Z
-        c.snr = table.snr
-        c.t = table.tc
-        c.f = table.fc
+        c.Q = numpy.around(Q, 1)
+        c.energy = numpy.around(table.Z, 1)
+        c.snr = numpy.around(table.snr, 1)
+        c.t = numpy.around(table.tc, 3)
+        c.f = numpy.around(table.fc, 1)
 
         # update analyzed dict
         try:

--- a/gwdetchar/omega/config.py
+++ b/gwdetchar/omega/config.py
@@ -31,7 +31,7 @@ runtime, which must include processing options for individual blocks. In a
 given block, the following keywords are supported:
 
 [blockkey]
--------
+----------
 
 =======================  ======================================================
 ``name``                 The full name of this channel block, which will
@@ -103,6 +103,7 @@ given block, the following keywords are supported:
   channels = L1:CAL-DELTAL_EXTERNAL_DQ
 
   .. note::
+
   The `blockkey` will appear in the navbar to identify channel blocks on the
   output page, with a scrollable dropdown list of channels in that block for
   ease of navigation.

--- a/gwdetchar/omega/html.py
+++ b/gwdetchar/omega/html.py
@@ -515,7 +515,8 @@ def cis_link(channel, **params):
     """
     kwargs = {
         'title': "CIS entry for %s" % channel,
-        'style': "font-family: Monaco, \"Courier New\", monospace;",
+        'style': "font-family: Monaco, \"Courier New\", monospace; "
+                 "color: black;",
     }
     kwargs.update(params)
     return html_link("https://cis.ligo.org/channel/byname/%s" % channel,

--- a/gwdetchar/omega/plot.py
+++ b/gwdetchar/omega/plot.py
@@ -65,6 +65,7 @@ def omega_plot(series, gps, span, channel, output, colormap='viridis',
     ax = plot.gca()
     # set time axis units
     ax.set_xscale('seconds', epoch=gps)
+    ax.set_xlim(gps-span/2, gps+span/2)
     ax.set_xlabel('Time [seconds]')
     # set y-axis properties
     chan = channel.replace('_', r'\_')
@@ -81,7 +82,6 @@ def omega_plot(series, gps, span, channel, output, colormap='viridis',
         cmap = cm.get_cmap(colormap)
         rgba = cmap(0)
         ax.set_facecolor(rgba)
-        ax.set_xlim(gps-span/2, gps+span/2)
         ax.set_yscale('log')
         ax.set_ylabel('Frequency [Hz]')
     ax.grid(True, axis='y', which='both')


### PR DESCRIPTION
This PR includes a number of lightweight formatting changes to `gwdetchar-omega`, including:

* Restrict the number of significant figures reported in properties of the loudest time-frequency tile
* Convert all `configparser` items to a dict, regardless of python version
* Format `gwdetchar.omega.config` docstring in a slightly friendlier way
* Configure all CIS links to explicitly appear with black text
* Explicitly set the time axis range on all plots