### PR TITLE
Set absolute paths to output directories and configuration files

### DIFF
--- a/bin/gwdetchar-omega
+++ b/bin/gwdetchar-omega
@@ -141,7 +141,9 @@ htmlv = {
 # set output directory
 outdir = args.output_directory
 if outdir is None:
-    outdir = os.path.expanduser('~/public_html/wdq/%s_%s' % (ifo, gps))
+    outdir = os.path.expanduser('~/public_html/wdq/{ifo}_{gps}'.format(
+        ifo=ifo, gps=gps))
+outdir = os.path.abspath(outdir)
 if not os.path.isdir(outdir):
     os.makedirs(outdir)
 os.chdir(outdir)

--- a/bin/wdq
+++ b/bin/wdq
@@ -84,6 +84,10 @@ gpstime = float(gps)
 ifo = args.ifo
 obs = args.ifo[0]
 
+# get absolute path to config
+if args.config_file is not None:
+    args.config_file = os.path.abspath(args.config_file)
+
 # set colormap default
 if not args.colormap and args.wpipeline.endswith('wpipeline'):
     args.colormap = 'parula'  # matlab
@@ -124,6 +128,7 @@ print("----------------------------------------------\n"
 outdir = args.output_directory
 if outdir is None:
     outdir = os.path.expanduser('~/public_html/wdq/%s_%s' % (ifo, gps))
+outdir = os.path.abspath(outdir)
 if not os.path.isdir(outdir):
     os.makedirs(outdir)
 print("Ouput directory created as %s" % outdir)

--- a/bin/wdq-batch
+++ b/bin/wdq-batch
@@ -204,7 +204,7 @@ job.add_opt('wpipeline', args.wpipeline)
 job.add_opt('colormap', args.colormap)
 job.add_opt('ifo', args.ifo)
 if args.config_file is not None:
-    job.add_opt('config-file', args.config_file)
+    job.add_opt('config-file', os.path.abspath(args.config_file))
 if args.wpipeline.endswith('wpipeline'):
     job.add_opt('condor', '')
     if args.cache_file is not None:


### PR DESCRIPTION
This pull request sets absolute paths to output directories and configuration files related to the new Omega scan code. See [**here**](https://ldas-jobs.ligo-la.caltech.edu/~aurban/pyomega-test/Network_170817/) for example output with these changes.

cc @tjma12 