### PR TITLE
Wrote peak_frequency column to sngl_burst

### DIFF
--- a/bin/gwdetchar-overflow
+++ b/bin/gwdetchar-overflow
@@ -157,7 +157,7 @@ else:
     use_segments = False
     overflows = ligolw.new_table(
         'sngl_burst',
-        columns=['peak_time', 'peak_time_ns', 'event_id', 'channel', 'snr'])
+        columns=['peak_time', 'peak_time_ns', 'peak_frequency', 'event_id', 'channel', 'snr'])
     def find_overflows(timeseries, channel, segment):
         times = daq.find_overflows(timeseries)
         times = times[(times >= float(segment[0])) &


### PR DESCRIPTION
The `peak_frequency` column is already populated in the `table_from_times()` function: https://github.com/gwdetchar/gwdetchar/blob/master/bin/gwdetchar-overflow#L94-L97

but it isn't passed on to the result table that gets written to XML:
https://github.com/gwdetchar/gwdetchar/blob/master/bin/gwdetchar-overflow#L199-L206

This will allow overflow triggers to be read directly into Hveto with SNR=10 and peak_frequency=100.

c.c. @alurban 