### PR TITLE
Set Omega scan plot font to Arial, and turn off use of LaTeX

### DIFF
--- a/gwdetchar/omega/plot.py
+++ b/gwdetchar/omega/plot.py
@@ -30,6 +30,9 @@ __author__ = 'Alex Urban <alexander.urban@ligo.org>'
 __credits__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
 rcParams.update({
+    'text.usetex': 'false',
+    'font.family': 'sans-serif',
+    'font.sans-serif': 'Arial',
     'figure.subplot.bottom': 0.17,
     'figure.subplot.left': 0.1,
     'figure.subplot.right': 0.9,
@@ -68,14 +71,14 @@ def omega_plot(series, gps, span, channel, output, colormap='viridis',
     ax.set_xlim(gps-span/2, gps+span/2)
     ax.set_xlabel('Time [seconds]')
     # set y-axis properties
-    chan = channel.replace('_', r'\_')
     if (qscan or eventgram):
         ax.set_yscale('log')
-        ax.set_title('%s at %.3f with $Q=%.1f$' % (chan, gps, series.q))
+        title = '%s at %.3f with $Q=%.1f$' % (channel, gps, series.q)
         ax.colorbar(cmap=colormap, clim=clim, label='Normalized energy')
     else:
         ax.set_yscale('linear')
-        ax.set_title('%s at %.3f' % (chan, gps))
+        title = '%s at %.3f' % (channel, gps)
+    ax.set_title(title, y=1.05)
     if ylabel:
         ax.set_ylabel(ylabel)
     if eventgram:


### PR DESCRIPTION
cc @duncanmmacleod, @areeda 

This PR adds padding to figure titles to prevent cutting off the axis labels, and sets the font to Arial to be more consistent with the output webpage. It also resolves a transient issue with matplotlib lock files by switching off use of LaTeX to format plot text or axis labels. An example full scan on a glitch from earlier today is available [**here**](https://ldas-jobs.ligo-la.caltech.edu/~aurban/wdq/20181118/1226620045.92/) (requires `LIGO.ORG` credentials).