### PR TITLE
Setting plot titles to be the same as Matlab and DMT Omega

### DIFF
--- a/gwdetchar/omega/plot.py
+++ b/gwdetchar/omega/plot.py
@@ -73,7 +73,7 @@ def omega_plot(series, gps, span, channel, output, colormap='viridis',
     # set y-axis properties
     if (qscan or eventgram):
         ax.set_yscale('log')
-        title = '%s at %.3f with $Q=%.1f$' % (channel, gps, series.q)
+        title = '%s at %.3f with $Q$ of %.1f' % (channel, gps, series.q)
         ax.colorbar(cmap=colormap, clim=clim, label='Normalized energy')
     else:
         ax.set_yscale('linear')


### PR DESCRIPTION
This PR is a minor tweak to the titles of `gwdetchar-omega` spectrogram and eventgrams plots to make them more consistent with the Matlab and DMT-Omega versions.