### PR TITLE
Resample Q-transform spectrograms along the time axis

### DIFF
--- a/bin/gwdetchar-omega
+++ b/bin/gwdetchar-omega
@@ -320,13 +320,11 @@ for block in blocks.values():
         except UnboundLocalError:
             if args.verbose:
                 gprint('Channel is misbehaved, removing it from the analysis')
-            del series, hpseries, wseries, asd
             continue
         if table.Z < table.engthresh and not c.always_plot:
             if args.verbose:
                 gprint('Channel not significant at white noise false alarm '
                        'rate %s Hz' % far)
-            del series, hpseries, wseries, asd, table
             continue
         Q = table.q
         rtable = eventgram(gps, hpseries, frange=table.frange, qrange=(Q, Q),
@@ -405,12 +403,6 @@ for block in blocks.values():
 
         # update HTML output
         html.write_qscan_page(ifo, gps, analyzed, **htmlv)
-
-        # delete intermediate data products
-        del qscan, rqscan, table, rtable, series, hpseries, wseries, asd
-
-    # delete data
-    del data
 
 
 # -- Prepare HTML -------------------------------------------------------------


### PR DESCRIPTION
This PR introduces resampling of Q-transform spectrograms along the time axis to save time and memory. The resampling is done in `gwdetchar.omega.plot()` by slicing along the time axis.

This PR also removes explicit deletion of objects in the main loop in `gwdetchar-omega`, because these have no impact on the overall memory usage.

cc @areeda, @duncanmmacleod