### PR TITLE
Remove channels with bad data, no try/catch

### DIFF
--- a/bin/gwdetchar-lasso-correlation
+++ b/bin/gwdetchar-lasso-correlation
@@ -290,16 +290,13 @@ print('{0} channels remaining'.format(len(auxdata)))
 
 # -- remove bad data
 
-try:
-    data = numpy.array([scale(ts.value) for ts in auxdata.values()]).T
-except ValueError:
-    print("Nan or Inf found in data, removing bad channels...")
-    nbefore = len(auxdata)
-    gwlasso.remove_bad(auxdata)
-    nafter = len(auxdata)
-    print('Removed {0} channels with bad data'.format(nbefore - nafter))
-    print('{0} channels remaining'.format(nafter))
-    data = numpy.array([scale(ts.value) for ts in auxdata.values()]).T
+print("Removing any channels with bad data...")
+nbefore = len(auxdata)
+gwlasso.remove_bad(auxdata)
+nafter = len(auxdata)
+print('Removed {0} channels with bad data'.format(nbefore - nafter))
+print('{0} channels remaining'.format(nafter))
+data = numpy.array([scale(ts.value) for ts in auxdata.values()]).T
 
 # -- perform lasso regression -------------------------------------------------
 


### PR DESCRIPTION
Removes the try/catch block surrounding the block of code that: tries to scale the auxiliary channel data and catches any `ValueError` thrown. In the `except` block, auxiliary channels consisting of any data point values that are `Nan` or `Inf` are removed from the data being scaled and used to create the lasso model. This change removes the try/catch altogether - instead of attempting to scale and handling any `ValueError`, channels will be checked for the bad data cases above each time. 

Inspiration for this change: Using the same environment, channel lists, etc., without this change, I was getting `ValueError`s thrown when `gwlasso.fit` was called. From the output, it seems that there was no `ValueError` thrown when trying to scale the data, so 0 "bad data channels" were removed. With the included change, it found and removed ~900 channels with bad data! For some reason, it seems that this change solves it and is stabler.

Reference trace before the change:
```-- Pre-processing auxiliary channel data
Removed 169748 channels with flat data
35674 channels remaining
-- Fitting data to target
Traceback (most recent call last):
  File "/home/detchar/opt/gwpysoft-2.7/bin/gwdetchar-lasso-correlation", line 309, in <module>
    model = gwlasso.fit(data, target, alpha=args.alpha)
  File "/home/detchar/opt/gwpysoft-2.7/lib/python2.7/site-packages/gwdetchar/lasso.py", line 52, in fit
    alpha = find_alpha(data, target)
  File "/home/detchar/opt/gwpysoft-2.7/lib/python2.7/site-packages/gwdetchar/lasso.py", line 68, in find_alpha
    model = fit(data, target, alpha=alpha)
  File "/home/detchar/opt/gwpysoft-2.7/lib/python2.7/site-packages/gwdetchar/lasso.py", line 54, in fit
    return model.fit(data, target)
  File "/home/detchar/opt/gwpysoft-2.7/lib/python2.7/site-packages/sklearn/linear_model/coordinate_descent.py", line 712, in fit
    copy=X_copied, multi_output=True, y_numeric=True)
  File "/home/detchar/opt/gwpysoft-2.7/lib/python2.7/site-packages/sklearn/utils/validation.py", line 747, in check_X_y
    estimator=estimator)
  File "/home/detchar/opt/gwpysoft-2.7/lib/python2.7/site-packages/sklearn/utils/validation.py", line 568, in check_array
    allow_nan=force_all_finite == 'allow-nan')
  File "/home/detchar/opt/gwpysoft-2.7/lib/python2.7/site-packages/sklearn/utils/validation.py", line 56, in _assert_all_finite
    raise ValueError(msg_err.format(type_err, X.dtype))
ValueError: Input contains NaN, infinity or a value too large for dtype('float64').```