### PR TITLE
Render channel names in a code-like font

### DIFF
--- a/gwdetchar/omega/plot.py
+++ b/gwdetchar/omega/plot.py
@@ -153,7 +153,7 @@ def timeseries_plot(data, gps, span, channel, output, ylabel=None,
     ax.set_yscale('linear')
     ax.set_ylabel(ylabel)
     # set title
-    title = '%s at %.3f' % (channel, gps)
+    title = r'$\mathtt{%s}$ at %.3f' % (channel.replace('_', '\_'), gps)
     ax.set_title(title, y=1.1)
     # save plot and close
     plot.savefig(output, bbox_inches='tight')
@@ -222,7 +222,8 @@ def spectral_plot(data, gps, span, channel, output, ylabel=None,
     # set colorbar properties
     _format_color_axis(ax, colormap=colormap, clim=clim, norm=norm)
     # set title
-    title = '%s at %.3f with $Q$ of %.1f' % (channel, gps, Q)
+    title = r'$\mathtt{%s}$ at %.3f with $Q$ of %.1f' \
+            % (channel.replace('_', '\_'), gps, Q)
     ax.set_title(title, y=1.05)
     # save plot and close
     plot.savefig(output, bbox_inches='tight')


### PR DESCRIPTION
This PR renders omega scan channel names in a code syntax-like font, as such:

![l1-gds_calib_strain-qscan_whitened-16](https://user-images.githubusercontent.com/5273800/52135247-fdbc1100-260a-11e9-9ed2-429db3b7ad9e.png)
