### PR TITLE
Resolve a longstanding issue with wdq-batch input files that contain only one event time

### DIFF
--- a/bin/wdq-batch
+++ b/bin/wdq-batch
@@ -126,7 +126,7 @@ if len(times) == 1:
         times = [float(times[0])]
     except (TypeError, ValueError):  # otherwise read as file
         import numpy
-        times = numpy.loadtxt(times[0], dtype=float)
+        times = numpy.loadtxt(times[0], dtype=float, ndmin=1)
 else:
     times = map(float, times)
 


### PR DESCRIPTION
This fixes #65.

cc @hkqcap, @dethodav