### PR TITLE
Minor tweaks to omega scan plotting

### DIFF
--- a/bin/gwdetchar-omega
+++ b/bin/gwdetchar-omega
@@ -56,6 +56,9 @@ from gwpy.time import to_gps
 from gwpy.segments import Segment
 from gwpy.signal.qtransform import q_scan
 
+from matplotlib import use
+use('agg')  # nopep8
+
 from gwdetchar import (cli, __version__)
 from gwdetchar.omega import (config, plot, html)
 from gwdetchar.io.datafind import (check_flag, get_data)

--- a/gwdetchar/omega/plot.py
+++ b/gwdetchar/omega/plot.py
@@ -21,9 +21,7 @@
 
 from __future__ import division
 
-from matplotlib import (use, cm, rcParams)
-use('agg')  # nopep8
-
+from matplotlib import (cm, rcParams)
 from gwpy.plot.colors import GW_OBSERVATORY_COLORS
 
 __author__ = 'Alex Urban <alexander.urban@ligo.org>'
@@ -35,7 +33,7 @@ rcParams.update({
     'axes.labelsize': 20,
     'axes.labelpad': 12,
     'axes.titlesize': 15,
-    'grid.alpha': 0.6,
+    'grid.alpha': 0.5,
 })
 
 


### PR DESCRIPTION
This PR moves the backend declaration out of `gwdetchar.omega.plot` to make that module more consistent with matplotlib defaults, and reduces the grid alpha to 0.5.