### PR TITLE
Reproduce GWPY_TEX_RCPARAMS for use with gwpy-0.13+

### DIFF
--- a/bin/gwdetchar-lasso-correlation
+++ b/bin/gwdetchar-lasso-correlation
@@ -31,7 +31,7 @@ import warnings
 import numpy
 from scipy.interpolate import UnivariateSpline
 
-from matplotlib import use
+from matplotlib import (use, rcParams)
 use('agg')  # nopep8
 from matplotlib import cm as mcm
 
@@ -49,6 +49,7 @@ from gwpy.io import nds2 as io_nds2
 
 from gwdetchar import (cli, lasso as gwlasso)
 from gwdetchar.io import html
+from gwdetchar.misc import get_gwpy_tex_settings
 
 try:
     from LDAStools import frameCPP
@@ -180,6 +181,10 @@ lsig.add_argument('-l', '--line-size-aux', default=0.75, type=float,
                   help='line width of auxilary channel')
 
 args = parser.parse_args()
+
+# set TeX settings
+tex_settings = get_gwpy_tex_settings()
+rcParams.update(tex_settings)
 
 start = int(args.gpsstart)
 end = int(args.gpsend)

--- a/bin/gwdetchar-mct
+++ b/bin/gwdetchar-mct
@@ -25,7 +25,7 @@ import numpy
 import os
 import sys
 
-from matplotlib import use
+from matplotlib import (use, rcParams)
 use('agg')
 
 import gwdatafind
@@ -42,6 +42,7 @@ from gwpy.utils import gprint
 from gwdetchar import (const, cli, cds, __version__)
 from gwdetchar.io import (ligolw, html as htmlio)
 from gwdetchar.daq import find_crossings
+from gwdetchar.misc import get_gwpy_tex_settings
 
 __author__ = 'TJ Massinger <thomas.massinger@ligo.org>'
 __credits__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
@@ -84,6 +85,10 @@ else:
     statea = SegmentList([span])
 
 duration = abs(span)
+
+# set TeX settings
+tex_settings = get_gwpy_tex_settings()
+rcParams.update(tex_settings)
 
 # initialize output files for each threshold and store them in a dict
 outfiles = {}

--- a/bin/gwdetchar-overflow
+++ b/bin/gwdetchar-overflow
@@ -44,6 +44,7 @@ from gwpy.utils import gprint
 
 from gwdetchar import (cds, cli, const, daq, __version__)
 from gwdetchar.io import (ligolw, html as htmlio)
+from gwdetchar.misc import get_gwpy_tex_settings
 
 try:
     from LDAStools import frameCPP
@@ -162,6 +163,10 @@ if args.ifo == 'L1':
         simulink = 'https://llocds.ligo-la.caltech.edu/daq/simulink/'
 
 span = Segment(args.gpsstart, args.gpsend)
+
+# set rcParams
+tex_settings = get_gwpy_tex_settings()
+rcParams.update(tex_settings)
 
 # get segments
 if args.state_flag:

--- a/bin/gwdetchar-scattering
+++ b/bin/gwdetchar-scattering
@@ -49,6 +49,7 @@ from gwpy.segments import (DataQualityFlag, DataQualityDict,
 
 from gwdetchar import (cli, const, scattering, __version__)
 from gwdetchar.io import html as htmlio
+from gwdetchar.misc import get_gwpy_tex_settings
 
 try:
     from LDAStools import frameCPP
@@ -60,6 +61,8 @@ else:
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
 # update rcParams
+tex_settings = get_gwpy_tex_settings()
+rcParams.update(tex_settings)
 rcParams.update({
     'axes.labelsize': 20,
     'figure.subplot.bottom': 0.17,

--- a/bin/gwdetchar-slow-correlation
+++ b/bin/gwdetchar-slow-correlation
@@ -28,7 +28,7 @@ import numpy
 from scipy.stats import spearmanr
 from scipy.interpolate import UnivariateSpline
 
-from matplotlib import use
+from matplotlib import (use, rcParams)
 use('agg')
 import matplotlib.pyplot as plt
 
@@ -41,6 +41,7 @@ from gwpy.io import nds2 as io_nds2
 
 from gwdetchar import cli
 from gwdetchar.io import html
+from gwdetchar.misc import get_gwpy_tex_settings
 
 from sklearn import linear_model, preprocessing, datasets
 from sklearn.metrics import mean_squared_error, r2_score
@@ -125,6 +126,10 @@ def remove_outliers(ts, N):
             print("%d outliers remain" % len(outliers))
             c += 1
 
+
+# set TeX settings
+tex_settings = get_gwpy_tex_settings()
+rcParams.update(tex_settings)
 
 # load data
 print("-- Loading range data")

--- a/bin/gwdetchar-software-saturations
+++ b/bin/gwdetchar-software-saturations
@@ -48,6 +48,7 @@ from gwpy.timeseries import (TimeSeries, TimeSeriesDict, StateTimeSeries)
 from gwdetchar import (__version__, cli, const)
 from gwdetchar.io import html as htmlio
 from gwdetchar.saturation import find_saturations
+from gwdetchar.misc import get_gwpy_tex_settings
 
 try:
     from LDAStools import frameCPP
@@ -288,6 +289,10 @@ args = parser.parse_args()
 ifo = args.ifo.upper()
 site = ifo[0]
 frametype = args.frametype or '%s_R' % ifo
+
+# set TeX settings
+tex_settings = get_gwpy_tex_settings()
+rcParams.update(tex_settings)
 
 # get segments
 span = Segment(args.gpsstart, args.gpsend)

--- a/gwdetchar/misc.py
+++ b/gwdetchar/misc.py
@@ -21,6 +21,9 @@
 
 import numpy
 
+from matplotlib import rcParams
+from gwpy.plot.tex import MACROS as GWPY_TEX_MACROS
+
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
 
@@ -41,3 +44,28 @@ def find_timeseries_value_changes(timeseries):
     diff = numpy.diff(timeseries.value)
     times = timeseries.times.value[1:]
     return times[diff > 0]
+
+
+def get_gwpy_tex_settings():
+    """Return a dict of rcParams similar to GWPY_TEX_RCPARAMS
+
+    Returns
+    -------
+    rcParams : `dict`
+        a dictionary of matplotlib rcParams
+    """
+    return {
+        # reproduce GWPY_TEX_PARAMS
+        'text.usetex': True,
+        'text.latex.preamble': (
+            rcParams.get('text.latex.preamble', []) + GWPY_TEX_MACROS),
+        'font.family': ['serif'],
+        'axes.formatter.use_mathtext': False,
+        # custom GW-DetChar formatting
+        'font.size': 10,
+        'xtick.labelsize': 18,
+        'ytick.labelsize': 18,
+        'axes.labelsize': 20,
+        'axes.titlesize': 24,
+        'grid.alpha': 0.5,
+    }


### PR DESCRIPTION
This PR reproduces the `GWPY_TEX_RCPARAMS` settings so that various plots are rendered with LaTeX, as before. Note, this **does not** include `gwdetchar-omega`, which is by design. (TeX rendering both slows down omega scans and leads to matplotlib lock errors.)

[**Here**](https://ldas-jobs.ligo-la.caltech.edu/~aurban/overflows/day/20190211/) is an example `gwdetchar-overflow` output rendered under the proposed changes.

cc @duncanmmacleod, @macedo22, @areeda, @jrsmith02, @olipatane, @tjma12 