### PR TITLE
Use gwdatafind for data access

### DIFF
--- a/bin/gwdetchar-mct
+++ b/bin/gwdetchar-mct
@@ -28,17 +28,19 @@ import sys
 from matplotlib import use
 use('agg')
 
+import gwdatafind
+
 from glue.ligolw.utils import write_fileobj
 
 from gwpy.segments import (DataQualityFlag, DataQualityDict,
                            Segment, SegmentList)
 
 from gwpy.timeseries import (TimeSeries, TimeSeriesDict)
-from gwpy.io.cache import cache_segments
+from gwpy.io.cache import (cache_segments, sieve as sieve_cache)
 from gwpy.utils import gprint
 
 from gwdetchar import (const, cli, cds, __version__)
-from gwdetchar.io import (datafind, ligolw, html as htmlio)
+from gwdetchar.io import (ligolw, html as htmlio)
 from gwdetchar.daq import find_crossings
 
 __author__ = 'TJ Massinger <thomas.massinger@ligo.org>'
@@ -91,7 +93,7 @@ for thresh in args.threshold:
            int(args.gpsstart), duration))
 
 # get frame cache
-cache = datafind.find_frames(args.ifo[0], args.frametype,
+cache = gwdatafind.find_urls(args.ifo[0], args.frametype,
                              int(args.gpsstart), int(args.gpsend))
 
 cachesegs = statea & cache_segments(cache)
@@ -109,9 +111,9 @@ for thresh in args.threshold:
 # sngl_burst table
 for seg in cachesegs:
     gprint('Processing segment %d - %d' % (seg[0],seg[1]))
-    c = cache.sieve(segment=seg)
+    c = sieve_cache(cache, segment=seg)
     data = TimeSeries.read(c, args.channel, nproc=args.nproc,
-                               start=seg[0], end=seg[1])
+                           start=seg[0], end=seg[1])
     for thresh in args.threshold:
         times = find_crossings(data,thresh)
         gprint('Found %d crossings for threshold %d' % (len(times),thresh))

--- a/bin/gwdetchar-overflow
+++ b/bin/gwdetchar-overflow
@@ -31,17 +31,19 @@ import tqdm
 from matplotlib import use
 use('agg')
 
+import gwdatafind
+
 from glue.ligolw.utils import write_fileobj
 
 from gwpy.segments import (DataQualityFlag, DataQualityDict,
                            Segment, SegmentList)
 from gwpy.time import to_gps
 from gwpy.timeseries import (TimeSeries, TimeSeriesDict)
-from gwpy.io.cache import cache_segments
+from gwpy.io.cache import (cache_segments, sieve as sieve_cache)
 from gwpy.utils import gprint
 
 from gwdetchar import (cds, cli, const, daq, __version__)
-from gwdetchar.io import (datafind, ligolw, html as htmlio)
+from gwdetchar.io import (ligolw, html as htmlio)
 
 try:
     from LDAStools import frameCPP
@@ -74,7 +76,7 @@ def get_data(channels, start, end, cache=None, ndsconnection=None, **kwargs):
         return series_class.fetch(channels, start, end,
                                   connection=ndsconnection, **kwargs)
     kwargs.update(readkwargs)
-    cache = cache.sieve(segment=Segment(start, end))
+    cache = sieve_cache(cache, segment=Segment(start, end))
     return series_class.read(cache, channels, start=start, end=end, **kwargs)
 
 
@@ -219,7 +221,7 @@ if args.nds:
             int(args.gpsstart), int(args.gpsend),
         )
 else:  # get frame cache
-    cache = datafind.find_frames(args.ifo[0], args.frametype,
+    cache = gwdatafind.find_urls(args.ifo[0], args.frametype,
                                  int(args.gpsstart), int(args.gpsend))
     cachesegs = statea & cache_segments(cache)
 

--- a/bin/gwdetchar-software-saturations
+++ b/bin/gwdetchar-software-saturations
@@ -34,8 +34,11 @@ from six.moves import StringIO
 from matplotlib import use
 use('agg')
 
+import gwdatafind
+
 from glue import markup
 
+from gwpy.io.cache import sieve as sieve_cache
 from gwpy.io.gwf import get_channel_names
 from gwpy.segments import (Segment, SegmentList,
                            DataQualityFlag, DataQualityDict)
@@ -44,7 +47,6 @@ from gwpy.timeseries import (TimeSeries, TimeSeriesDict, StateTimeSeries)
 
 from gwdetchar import (__version__, cli, const)
 from gwdetchar.io import html as htmlio
-from gwdetchar.io.datafind import find_frames
 from gwdetchar.saturation import find_saturations
 
 try:
@@ -213,7 +215,7 @@ def is_saturated(channel, cache, start=None, end=None,
     else:
         iokwargs = {'format': 'gwf'}
     data = TimeSeriesDict.read(
-        cache[0].path, indicators, start=start, end=start+1, **iokwargs)
+        cache[0], indicators, start=start, end=start+1, **iokwargs)
     if indicator.upper() == 'LIMEN':
         active = dict((c, data[indicators[i]].value[0]) for
                       i, c in enumerate(channels))
@@ -301,10 +303,7 @@ else:
     segs = SegmentList([Segment(args.gpsstart, args.gpsend)])
 
 # find frames
-cache = find_frames(site, frametype,
-                    int(args.gpsstart), int(args.gpsend))
-tcache = find_frames(site, '%s_T' % ifo, int(args.gpsstart),
-                     int(args.gpsend))
+cache = gwdatafind.find_urls(site, frametype, int(args.gpsstart), int(args.gpsend))
 
 # find channels
 if not os.getenv('LIGO_DATAFIND_SERVER'):
@@ -316,7 +315,7 @@ else:
         raise RuntimeError("No frames recovered for %s in interval [%s, %s)" %
                            (frametype, int(args.gpsstart),
                             int(args.gpsend)))
-    allchannels = get_channel_names(cache[0].path)
+    allchannels = get_channel_names(cache[0])
     print("   Found %d channels in frame" % len(allchannels))
     sys.stdout.flush()
     channels = find_limit_channels(allchannels, skip=args.skip)
@@ -354,7 +353,7 @@ for suffix, clist in zip(['LIMEN', 'SWSTAT'], channels):
         while cset[-1] is None:
             cset.pop(-1)
         for seg in segs:
-            cache2 = cache.sieve(segment=seg)
+            cache2 = sieve_cache(cache, segment=seg)
             if not len(cache2):
                 continue
             saturated = is_saturated(cset, cache2, seg[0], seg[1],

--- a/gwdetchar/daq.py
+++ b/gwdetchar/daq.py
@@ -25,12 +25,13 @@ from operator import attrgetter
 
 import numpy
 
+from gwdatafind import find_urls
+
 from gwpy.io.gwf import get_channel_names
 from gwpy.time import to_gps
 from gwpy.timeseries import StateTimeSeries
 
 from . import const
-from .io.datafind import find_frames
 from .utils import natural_sort
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
@@ -196,7 +197,7 @@ def _ligo_model_overflow_channels_nds(dcuid, ifo, gpstime, host):
 
 def _ligo_model_overflow_channels_gwf(dcuid, ifo, frametype, gpstime):
     try:
-        framefile = find_frames(ifo[0], frametype, gpstime, gpstime)[0].path
+        framefile = find_urls(ifo[0], frametype, gpstime, gpstime)[0]
     except IndexError as e:
         e.args = ('No %s-%s frames found at GPS %d'
                   % (ifo[0], frametype, gpstime),)

--- a/gwdetchar/io/datafind.py
+++ b/gwdetchar/io/datafind.py
@@ -22,10 +22,11 @@
 from __future__ import print_function
 
 import os.path
+import warnings
 
 from six import string_types
 
-from glue import datafind
+import gwdatafind
 
 from ..const import DEFAULT_SEGMENT_SERVER
 
@@ -36,23 +37,13 @@ __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 __credits__ = 'Alex Urban <alexander.urban@ligo.org>'
 
 
-def find_frames(site, frametype, gpsstart, gpsend, **kwargs):
+def find_frames(site, frametype, gpsstart, gpsend, urltype='file', **kwargs):
     """Find frames for given site and frametype
     """
-    # connect
-    host = kwargs.pop('host', None)
-    port = kwargs.pop('port', None)
-    port = port and int(port)
-    if port is not None and port != 80:
-        cert, key = datafind.find_credential()
-        connection = datafind.GWDataFindHTTPSConnection(
-            host=host, port=port, cert_file=cert, key_file=key)
-    else:
-        connection = datafind.GWDataFindHTTPConnection(host=host, port=port)
-    # find frames
-    kwargs.setdefault('urltype', 'file')
-    return connection.find_frame_urls(site[0], frametype, gpsstart, gpsend,
-                                      **kwargs)
+    warnings.warn("this function is deprecated, use `gwdatafind.find_urls` "
+                  "directly", DeprecationWarning)
+    return gwdatafind.find_urls(site[0], frametype, gpsstart, gpsend,
+                                urltype=urltype, **kwargs)
 
 
 def write_omega_cache(cache, fobj):
@@ -159,12 +150,11 @@ def get_data(channels, gpstime, duration, pad, frametype=None, source=None,
     end = gpstime + duration/2. + pad
     # construct file cache if none is given
     if source is None:
-        source = find_frames(frametype[0], frametype, start, end)
+        source = gwdetchar.find_urls(frametype[0], frametype, start, end)
     # read from frames or NDS
     if source:
         return TimeSeriesDict.read(
             source, channels, start=start, end=end, nproc=nproc,
             verbose=verbose, dtype=dtype)
-    else:
-        return TimeSeriesDict.fetch(channels, start, end, verbose=verbose,
-                                    dtype=dtype)
+    return TimeSeriesDict.fetch(channels, start, end, verbose=verbose,
+                                dtype=dtype)

--- a/gwdetchar/tests/test_daq.py
+++ b/gwdetchar/tests/test_daq.py
@@ -74,7 +74,7 @@ def test_ligo_accum_overflow_channel():
         'X1:FEC-4_ACCUM_OVERFLOW')
 
 
-@mock.patch('gwdetchar.daq.find_frames')
+@mock.patch('gwdetchar.daq.find_urls')
 @mock.patch('gwdetchar.daq.get_channel_names')
 def test_ligo_model_overflow_channels(get_names, find_frames):
     get_names.return_value = CHANNELS

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ beautifulsoup4
 lxml
 gwtrigfind
 sklearn
+gwdatafind

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ install_requires = [
     'lscsoft-glue>=1.60.0',
     'gwtrigfind',
     'sklearn',
+    'gwdatafind',
 ]
 
 # test


### PR DESCRIPTION
This PR updates `gwdetchar` to directly call out to `gwdatafind.find_urls`, rather than having its own wrapper of `glue.datafind`.