### PR TITLE
Bug fixes and formatting enhancements for gwdetchar-omega

### DIFF
--- a/bin/gwdetchar-omega
+++ b/bin/gwdetchar-omega
@@ -119,7 +119,14 @@ cp.read(args.config_file)
 
 # parse primary channel
 if not args.disable_correlation:
-    primary = config.OmegaChannelList('primary', **dict(cp.items('primary')))
+    try:
+        primary = config.OmegaChannelList(
+            'primary', **dict(cp.items('primary')))
+    except Exception:
+        import warnings
+        warnings.warn(
+            'No primary configured, continuing without cross-correlation')
+        args.disable_correlation = True
 cp.remove_section('primary')
 
 # get contextual channel blocks
@@ -182,7 +189,7 @@ if not args.disable_correlation:
         verbose=args.verbose)[name].astype('float64')
     correlate = omega.primary(
         gps, primary.length, correlate, fftlength, resample=primary.resample,
-        f_low=primary.channel.frange[0], name=name)
+        f_low=primary.flow, name=name)
     plot.timeseries_plot(correlate, gps, primary.length, name,
                          'plots/primary.png', ylabel='Whitened Amplitude')
     # prepare HTML output
@@ -217,7 +224,8 @@ for block in blocks.values():
             print('Scanning channel %s' % channel.name)
             series = omega.scan(
                 gps, channel, data[channel.name], fftlength,
-                resample=block.resample, fthresh=args.far_threshold)
+                resample=block.resample, fthresh=args.far_threshold,
+                search=block.search)
         except Exception:
             traceback.print_exc()
             print('Problem encountered, skipping channel %s' % channel.name)
@@ -232,7 +240,8 @@ for block in blocks.values():
         if correlate is not None:
             print('Cross-correlating channel %s' % channel.name)
             correlation = omega.cross_correlate(series[2], correlate)
-            channel.save_loudest_tile_features(series[3], correlation, gps)
+            channel.save_loudest_tile_features(
+                series[3], correlation, gps=gps, dt=block.dt)
         else:
             channel.save_loudest_tile_features(series[3])
 

--- a/gwdetchar/io/datafind.py
+++ b/gwdetchar/io/datafind.py
@@ -150,7 +150,7 @@ def get_data(channels, gpstime, duration, pad, frametype=None, source=None,
     end = gpstime + duration/2. + pad
     # construct file cache if none is given
     if source is None:
-        source = gwdetchar.find_urls(frametype[0], frametype, start, end)
+        source = gwdatafind.find_urls(frametype[0], frametype, start, end)
     # read from frames or NDS
     if source:
         return TimeSeriesDict.read(

--- a/gwdetchar/omega/core.py
+++ b/gwdetchar/omega/core.py
@@ -219,9 +219,6 @@ def primary(gps, length, hoft, fftlength, resample=None, f_low=None,
     name : `str`, optional
         name of the channel this data corresponds to
 
-    filename : `str`, optional
-        name of an output file for a plot of `xoft`
-
     **kwargs : `dict`
         additional keyword arguments to `omega.conditioner`
 
@@ -265,7 +262,7 @@ def cross_correlate(xoft, hoft):
 
 
 def scan(gps, channel, xoft, fftlength, resample=None, fthresh=1e-10,
-         nt=1400, nf=700, **kwargs):
+         search=0.5, nt=1400, nf=700, **kwargs):
     """Scan a channel for evidence of transients
 
     Parameters
@@ -289,6 +286,10 @@ def scan(gps, channel, xoft, fftlength, resample=None, fthresh=1e-10,
     fthresh : `float`, optional
         threshold on false alarm rate (Hz) for this channel to be considered
         interesting, default: 1e-10
+
+    search : `float`, optional
+        time window (seconds) around `gps` in which to find peak energies,
+        default: 0.5
 
     nt : `int`, optional
         number of points on the time axis of the interpolated `Spectrogram`,
@@ -314,7 +315,7 @@ def scan(gps, channel, xoft, fftlength, resample=None, fthresh=1e-10,
     wxoft, hpxoft, xoft = conditioner(
         xoft, fftlength, resample=resample, f_low=channel.frange[0], **kwargs)
     # compute whitened Q-gram
-    search = Segment(gps - 0.25, gps + 0.25)
+    search = Segment(gps - search/2, gps + search/2)
     qgram, far = q_scan(
         wxoft, mismatch=channel.mismatch, qrange=channel.qrange,
         frange=channel.frange, search=search)

--- a/gwdetchar/omega/html.py
+++ b/gwdetchar/omega/html.py
@@ -1008,9 +1008,9 @@ def write_block(blockkey, block, context,
         page.div(class_='btn-group', role='group')
         for ptitle, pclass, ptypes in [
             ('Timeseries', 'timeseries', ('raw', 'highpassed', 'whitened')),
-            ('Spectrogram', 'qscan', ('raw', 'whitened', 'autoscaled')),
+            ('Spectrogram', 'qscan', ('highpassed', 'whitened', 'autoscaled')),
             ('Eventgram', 'eventgram', (
-                'raw', 'whitened', 'autoscaled')),
+                'highpassed', 'whitened', 'autoscaled')),
         ]:
             _id = 'btnGroup{0}{1}'.format(pclass.title(), i)
             page.div(class_='btn-group', role='group')

--- a/gwdetchar/omega/plot.py
+++ b/gwdetchar/omega/plot.py
@@ -248,9 +248,9 @@ def write_qscan_plots(gps, channel, series, colormap='viridis'):
     fnames = channel.plots
     for span, png1, png2, png3, png4, png5, png6, png7, png8, png9 in zip(
         channel.pranges, fnames['qscan_whitened'],
-        fnames['qscan_autoscaled'], fnames['qscan_raw'],
+        fnames['qscan_autoscaled'], fnames['qscan_highpassed'],
         fnames['timeseries_raw'], fnames['timeseries_highpassed'],
-        fnames['timeseries_whitened'], fnames['eventgram_raw'],
+        fnames['timeseries_whitened'], fnames['eventgram_highpassed'],
         fnames['eventgram_whitened'], fnames['eventgram_autoscaled']
     ):
         # plot whitened qscan


### PR DESCRIPTION
This pull request features the following bug fixes and enhancements:

* Correct a typo in `gwdetchar/io/datafind.py` introduced by #222
* Correctly label "raw" Q-transform plots as "highpassed"
* Allow configurable search windows for Q-sans and cross-correlation
* Remove an unused kwarg from a docstring
* If a primary channel is not configured, simply disable cross-correlation to prevent the code failing

cc @duncanmmacleod, @areeda 