### PR TITLE
Use urlparse to expedite frame reading

### DIFF
--- a/bin/gwdetchar-omega
+++ b/bin/gwdetchar-omega
@@ -186,7 +186,7 @@ if not args.disable_correlation:
     correlate = get_data(
         [name], gps, duration, pad, frametype=primary.frametype,
         source=primary.source, nproc=args.nproc,
-        verbose=args.verbose)[name].astype('float64')
+        verbose=args.verbose)[name]
     correlate = omega.primary(
         gps, primary.length, correlate, fftlength, resample=primary.resample,
         f_low=primary.flow, name=name)

--- a/gwdetchar/io/datafind.py
+++ b/gwdetchar/io/datafind.py
@@ -26,6 +26,11 @@ import warnings
 
 from six import string_types
 
+try:  # python 3.x
+    from urllib.parse import urlparse
+except ImportError:  # python 2.x
+    from urlparse import urlparse
+
 import gwdatafind
 
 from ..const import DEFAULT_SEGMENT_SERVER
@@ -150,7 +155,8 @@ def get_data(channels, gpstime, duration, pad, frametype=None, source=None,
     end = gpstime + duration/2. + pad
     # construct file cache if none is given
     if source is None:
-        source = gwdatafind.find_urls(frametype[0], frametype, start, end)
+        cache = gwdatafind.find_urls(frametype[0], frametype, start, end)
+        source = [urlparse(fileobj).path for fileobj in cache]
     # read from frames or NDS
     if source:
         return TimeSeriesDict.read(


### PR DESCRIPTION
This pull request saves time (and possibly memory) by not downloading frame files before reading them. Instead, parse the path to frame files on local disk and read them directly, as was done before #222. Note, this affects only the `get_data` utility in `gwdetchar.io.datafind` and is python 3 compliant.

This PR also removes a redundant call to `TimeSeries.astype`.

cc @duncanmmacleod