### PR TITLE
Python 3 compliance for a map object in wdq-batch

### DIFF
--- a/bin/wdq-batch
+++ b/bin/wdq-batch
@@ -131,7 +131,7 @@ if len(times) == 1:
         import numpy
         times = numpy.loadtxt(times[0], dtype=float, ndmin=1)
 else:
-    times = map(float, times)
+    times = list(map(float, times))
 
 # finalise accounting tag based on run
 if '{epoch}' in args.condor_accounting_group:


### PR DESCRIPTION
This pull request fixes the only python-3.x compliance issue I could find under the omega scan infrastructure, namely:

```python
times = list(map(float, times))
```

Map objects are iterable but do not support indices in python 3.7.

cc @duncanmmacleod 