### PR TITLE
wdq-batch: use pycondor instead of glue.pipeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ script:
   - .travis/test-exe.sh gwdetchar-scattering --help
   - .travis/test-exe.sh gwdetchar-overflow --help
   - .travis/test-exe.sh gwdetchar-omega --help
+  - .travis/test-exe.sh wdq --help
+  - .travis/test-exe.sh wdq-batch --help
 
 after_success:
   - coveralls

--- a/bin/wdq-batch
+++ b/bin/wdq-batch
@@ -30,10 +30,13 @@ Submitting the workflow to Condor will result in the scans being processed
 in parallel, or you can just run the `.sh` script to process in serial.
 """
 
+from __future__ import print_function
+
 import os
+import subprocess
 from getpass import getuser
 
-from glue import pipeline
+from pycondor import (Dagman, Job)
 
 from gwdetchar import (omega, cli, condor)
 
@@ -99,6 +102,11 @@ pargs.add_argument('-v', '--verbose', action='store_true', default=False,
 cargs = parser.add_argument_group('Condor options')
 cargs.add_argument('-u', '--universe', default='vanilla', type=str,
                    help='universe for condor processing')
+cargs.add_argument('--submit', action='store_true', default=False,
+                   help='submit DAG directly to condor queue')
+cargs.add_argument('--monitor', action='store_true', default=False,
+                   help='monitor the DAG progress after submission; '
+                        'only used with --submit')
 cargs.add_argument('--condor-accounting-group',
                    default=CONDOR_ACCOUNTING_GROUP,
                    help='accounting_group for condor submission on the LIGO '
@@ -159,85 +167,85 @@ elif not args.colormap:
 
 # -- generate workflow --------------------------------------------------------
 
-tag = 'wdq-batch'
-
 # generate directories
 logdir = os.path.join(outdir, 'logs')
 subdir = os.path.join(outdir, 'condor')
-for d in [outdir, logdir, subdir]:
-    if not os.path.isdir(d):
-        os.makedirs(d)
-
-# start workflow
-dag = pipeline.CondorDAG(os.path.join(logdir, '%s.log' % tag))
-dag.set_dag_file(os.path.join(subdir, tag))
-dagfile = dag.get_dag_file()
-
-# configure wdq job
-job = pipeline.CondorDAGJob(args.universe, args.wdq)
-job.set_sub_file('%s.sub' % os.path.splitext(dagfile)[0])
-logstub = os.path.join(logdir, '%s-$(cluster)-$(process)' % tag)
-job.set_log_file('%s.log' % logstub)
-job.set_stdout_file('%s.out' % logstub)
-job.set_stderr_file('%s.err' % logstub)
 
 # add custom condor commands, using defaults
-condorcmds = {
-    'getenv': True,
-    'accounting_group': args.condor_accounting_group,
-    'accounting_group_user': args.condor_accounting_group_user,
-}
-if args.universe != 'local':
-    condorcmds['request_memory'] = 4096
+condorcmds = [
+    "accounting_group = {}".format(args.condor_accounting_group),
+    "accounting_group_user = {}".format(args.condor_accounting_group_user),
+]
 if args.condor_timeout:
-    condorcmds['periodic_remove'] = (
-        'CurrentTime-EnteredCurrentStatus > %d' % (3600 * args.condor_timeout))
-for cmd_ in args.condor_command:
-    key, value = cmd_.split('=', 1)
-    condorcmds[key.rstrip().lower()] = value.strip()
-for key, val in condorcmds.items():
-    job.add_condor_cmd(key, val)
+    condorcmds.append("periodic_remove = {}".format(
+        'CurrentTime-EnteredCurrentStatus > %d' % (3600 * args.condor_timeout),
+    ))
+condorcmds.extend(args.condor_command)
+
+# generate dagman
+tag = 'wdq-batch'
+dagman = Dagman(
+    name=tag,
+    submit=subdir,
+)
+
+# create condor job
+job = Job(
+    dag=dagman,
+    name=os.path.basename(args.wdq),
+    executable=args.wdq,
+    universe=args.universe,
+    submit=subdir,
+    error=logdir,
+    output=logdir,
+    getenv=True,
+    request_memory=4096 if args.universe != "local" else None,
+    extra_lines=condorcmds,
+)
 
 # add common wdq options
-job.add_opt('wpipeline', args.wpipeline)
-job.add_opt('colormap', args.colormap)
-job.add_opt('ifo', args.ifo)
+arguments = [
+    "--wpipeline", args.wpipeline,
+    "--colormap", args.colormap,
+    "--ifo", args.ifo,
+]
 if args.config_file is not None:
-    job.add_opt('config-file', os.path.abspath(args.config_file))
+    arguments.extend(("--config-file", os.path.abspath(args.config_file)))
 if args.wpipeline.endswith('wpipeline'):
-    job.add_opt('condor', '')
+    arguments.append("--condor")
     if args.cache_file is not None:
-        job.add_opt('cache-file', args.cache_file)
+        arguments.extent(("--cache-file", args.cache_file))
 else:
-    job.add_opt('far-threshold', str(args.far_threshold))
-    job.add_opt('nproc', str(args.nproc))
+    arguments.extend(("--far-threshold", str(args.far_threshold)))
+    arguments.extend(("--nproc", str(args.nproc)))
     if args.disable_correlation:
-        job.add_opt('disable-correlation', '')
+        arguments.append("--disable-correlation")
     if args.ignore_state_flags:
-        job.add_opt('ignore-state-flags', '')
+        arguments.append("--ignore-state-flags")
     if args.verbose:
-        job.add_opt('verbose', '')
+        arguments.append("--verbose")
 
 # make node in workflow for each time
 for t in times:
-    node = pipeline.CondorDAGNode(job)
-    node.set_category('wdq')
-    node.set_retry(1)
-    node.add_var_arg(str(t))
-    node.add_var_opt('output-dir', os.path.join(outdir, str(t)))
-    dag.add_node(node)
+    cmd = " ".join([str(t)] + arguments)
+    job.add_arg(cmd, name=str(t).replace(".", "_"))
 
 # write DAG
-dag.write_sub_files()
-dag.write_dag()
-dag.write_script()
-
-# print instructions for the user
-shfile = '%s.sh' % os.path.splitext(dagfile)[0]
-print("Workflow generated for %d times" % len(times))
-print("Run in the current shell via:\n\n$ %s\n" % shfile)
-if os.path.isfile('%s.rescue001' % dagfile):
-    print("Or, submit to condor via:\n\n$ condor_submit_dag -force %s"
-          % dagfile)
+dagman.build(fancyname=False)
+print("Workflow generated for {} times".format(len(times)))
+if args.submit:
+    dagman.submit_dag(submit_options="-force")
 else:
-    print("Or, submit to condor via:\n\n$ condor_submit_dag %s" % dagfile)
+    print(
+        "Submit to condor via:\n\n"
+        "$ condor_submit_dag {0.submit_file}".format(dagman),
+    )
+
+if args.submit and args.monitor:
+    print("Monitoring progress of {0.submit_file}".format(dagman))
+    try:
+        subprocess.check_call(
+            ["pycondor", "monitor", dagman.submit_file],
+        )
+    except KeyboardInterrupt:
+        pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ lxml
 gwtrigfind
 sklearn
 gwdatafind
+pycondor

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ install_requires = [
     'gwtrigfind',
     'sklearn',
     'gwdatafind',
+    'pycondor',
 ]
 
 # test


### PR DESCRIPTION
This PR reworks `wdq-batch` to use `pycondor` instead of `glue.pipeline`, which is better maintained, and more coupled to condor itself.

This also adds the following command line options:

- `--submit` to directly submit the DAG to condor
- `--monitor` to then show a progress bar indicating how things are going (only used when `--submit` is given)