### PR TITLE
Omega scan spectral density estimation

### DIFF
--- a/bin/gwdetchar-omega
+++ b/bin/gwdetchar-omega
@@ -180,11 +180,10 @@ if not args.disable_correlation:
     print('Processing primary channel')
     duration = primary.duration
     fftlength = primary.fftlength
-    pad = max(1, fftlength/4.)
     # process `duration` seconds of data centered on gps
     name = primary.channel.name
     correlate = get_data(
-        [name], gps, duration, pad, frametype=primary.frametype,
+        [name], gps, duration, pad=1, frametype=primary.frametype,
         source=primary.source, nproc=args.nproc,
         verbose=args.verbose)[name]
     correlate = omega.primary(
@@ -205,16 +204,15 @@ for block in blocks.values():
     # get configuration
     duration = block.duration
     fftlength = block.fftlength
-    pad = max(1, fftlength/4.)
     # check that analysis flag is active for all of `duration`
     if block.flag and (not args.ignore_state_flags):
         if args.verbose:
             print('Querying state flag %s' % block.flag)
-        if not check_flag(block.flag, gps, duration, pad):
+        if not check_flag(block.flag, gps, duration, pad=1):
             print('%s not active, skipping block' % block.flag)
             continue
     # read in `duration` seconds of data centered on gps
-    data = get_data(chans, gps, duration, pad, frametype=block.frametype,
+    data = get_data(chans, gps, duration, pad=1, frametype=block.frametype,
                     source=block.source, nproc=args.nproc,
                     verbose=args.verbose)
 
@@ -223,7 +221,7 @@ for block in blocks.values():
         try:
             print('Scanning channel %s' % channel.name)
             series = omega.scan(
-                gps, channel, data[channel.name], fftlength,
+                gps, channel, data[channel.name].astype('float64'), fftlength,
                 resample=block.resample, fthresh=args.far_threshold,
                 search=block.search)
         except Exception:

--- a/gwdetchar/io/datafind.py
+++ b/gwdetchar/io/datafind.py
@@ -26,11 +26,6 @@ import warnings
 
 from six import string_types
 
-try:  # python 3.x
-    from urllib.parse import urlparse
-except ImportError:  # python 2.x
-    from urlparse import urlparse
-
 import gwdatafind
 
 from ..const import DEFAULT_SEGMENT_SERVER
@@ -42,46 +37,7 @@ __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 __credits__ = 'Alex Urban <alexander.urban@ligo.org>'
 
 
-def find_frames(site, frametype, gpsstart, gpsend, urltype='file', **kwargs):
-    """Find frames for given site and frametype
-    """
-    warnings.warn("this function is deprecated, use `gwdatafind.find_urls` "
-                  "directly", DeprecationWarning)
-    return gwdatafind.find_urls(site[0], frametype, gpsstart, gpsend,
-                                urltype=urltype, **kwargs)
-
-
-def write_omega_cache(cache, fobj):
-    """Write a :class:`~glue.lal.Cache` of files to file in Omega format
-
-    The Omega pipeline expects a file cache in a specific, custom format:
-
-    {observatory} {frametype} {gpsstart} {gpsend} {fileduration} {directory}
-    """
-    # open filepath
-    if isinstance(fobj, string_types):
-        with open(fobj, 'w') as f:
-            return write_omega_cache(cache, f)
-
-    # convert to omega cache format
-    wcache = {}
-    for e in cache:
-        dir_ = os.path.split(e.path)[0]
-        if dir_ in wcache:
-            l = wcache[dir_]
-            if l[2] > int(e.segment[0]):
-                wcache[dir_][2] = e.segment[0]
-            if l[3] < int(e.segment[1]):
-                wcache[dir_][3] = e.segment[1]
-        else:
-            wcache[dir_] = [e.observatory, e.description,
-                            int(e.segment[0]), int(e.segment[1]),
-                            int(abs(e.segment)), dir_]
-
-    # write to file
-    for item in wcache:
-        print(' '.join(map(str, wcache[item])), file=fobj)
-
+# -- utilities ----------------------------------------------------------------
 
 def check_flag(flag, gpstime, duration, pad):
     """Check that a state flag is active during an entire analysis segment
@@ -90,10 +46,13 @@ def check_flag(flag, gpstime, duration, pad):
     ----------
     flag : `str`
         state flag to check
+
     gpstime : `float`
         GPS time of required data
+
     duration : `float`
         duration (in seconds) of required data
+
     pad : `float`
         amount of extra data to read in at the start and end for filtering
 
@@ -116,37 +75,42 @@ def check_flag(flag, gpstime, duration, pad):
     return True
 
 
-def get_data(channels, gpstime, duration, pad, frametype=None, source=None,
-             dtype='float64', nproc=1, verbose=False):
+def get_data(channels, gpstime, duration, pad, frametype=None,
+             source=None, nproc=1, verbose=False):
     """Retrieve data for a given channel, centered at a given time
 
     Parameters
     ----------
     channels : `list`
         required data channels
+
     gpstime : `float`
         GPS time of required data
+
     duration : `float`
         duration (in seconds) of required data
+
     pad : `float`
         amount of extra data to read in at the start and end for filtering
+
     frametype : `str`, optional
         name of frametype in which this channel is stored, by default will
         search for all required frame types
+
     source : `str`, `list`, optional
         `str` path of a LAL-format cache file or single data file, will
         supercede `frametype` if given, defaults to `None`
-    dtype : `str` or `dtype`, optional
-        typecode or data-type to which the output `TimeSeries` is cast
+
     nproc : `int`, optional
         number of parallel processes to use, uses serial process by default
+
     verbose : `bool`, optional
         print verbose output about NDS progress, default: False
 
     See Also
     --------
-    gwpy.timeseries.TimeSeries.get
-        for the underlying method to read from frames or NDS
+    gwpy.timeseries.TimeSeries.fetch
+        for the underlying method to read from an NDS server
     gwpy.timeseries.TimeSeries.read
         for the underlying method to read from a local file cache
     """
@@ -155,12 +119,10 @@ def get_data(channels, gpstime, duration, pad, frametype=None, source=None,
     end = gpstime + duration/2. + pad
     # construct file cache if none is given
     if source is None:
-        cache = gwdatafind.find_urls(frametype[0], frametype, start, end)
-        source = [urlparse(fileobj).path for fileobj in cache]
+        source = gwdatafind.find_urls(frametype[0], frametype, start, end)
     # read from frames or NDS
     if source:
         return TimeSeriesDict.read(
             source, channels, start=start, end=end, nproc=nproc,
-            verbose=verbose, dtype=dtype)
-    return TimeSeriesDict.fetch(channels, start, end, verbose=verbose,
-                                dtype=dtype)
+            verbose=verbose)
+    return TimeSeriesDict.fetch(channels, start, end, verbose=verbose)

--- a/gwdetchar/omega/core.py
+++ b/gwdetchar/omega/core.py
@@ -76,8 +76,8 @@ def highpass(series, f_low, order=12, analog=False, ftype='sos'):
     return hpseries
 
 
-def whiten(series, fftlength, overlap=None, method='lal_median_mean',
-           window='hann', detrend='linear'):
+def whiten(series, fftlength, overlap=None, method='median', window='hann',
+           detrend='linear'):
     """Whiten a `TimeSeries` against its own ASD
 
     Parameters
@@ -92,8 +92,7 @@ def whiten(series, fftlength, overlap=None, method='lal_median_mean',
         seconds of overlap between FFTs, defaults to half the FFT length
 
     method : `str`, optional
-        FFT-averaging method, default: ``'scipy-welch'``,
-        see *Notes* for more details
+        FFT-averaging method, default: ``'median'``,
 
     window : `str`, `numpy.ndarray`, optional
         window function to apply to timeseries prior to FFT,

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ numpy >= 1.10
 pandas
 pycondor
 scikit-learn
-scipy >= 0.18.1
+scipy >= 1.2.0
 setuptools
 six
 pathlib ; python_version < '3'

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ install_requires = [
     'pandas',
     'pycondor',
     'scikit-learn',
-    'scipy>=0.18.1',
+    'scipy>=1.2.0',
     'setuptools',
     'six',
     'pathlib ; python_version < \'3\'',


### PR DESCRIPTION
This PR includes a couple of changes:

* Remove deprecated functions from `gwdetchar.io.datafind`
* Remove `dtype` kwarg from `gwdetchar.io.datafind.get_data`, and use `astype` instead
* Change omega scans' default spectral method to `median` and require scipy-1.2.0, which supports median power spectral density estimation
* Since we're no longer using `lal_median_mean`, we don't need to pad input data by half the FFT length

I have tested this against scipy-1.2.0 and the head of the development branch of `gwpy`, output is [**here**](https://ldas-jobs.ligo-la.caltech.edu/~aurban/pyomega-test/L1_170817_cividis/) (requires `LIGO.ORG` credentials).

cc @duncanmmacleod 