### PR TITLE
More unit tests to increase coverage and support python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,31 @@
 language: python
 
-python:
-  - '2.7'
-  - '3.5'
-  - '3.6'
+matrix:
+  # bail-out early for failures
+  fast_finish: true
 
-env:
-  matrix:
-    - PIP_FLAGS="--quiet --pre"
-    - PIP_FLAGS="--quiet"
+  include:
+    - python: '2.7'
+      env: PIP_FLAGS="--quiet --pre"
+    - python: '3.5'
+      env: PIP_FLAGS="--quiet --pre"
+    - python: '3.6'
+      env: PIP_FLAGS="--quiet --pre"
+    - python: '3.7'
+      dist: xenial
+      sudo: required
+      env: PIP_FLAGS="--quiet --pre"
+
+    - python: '2.7'
+      env: PIP_FLAGS="--quiet"
+    - python: '3.5'
+      env: PIP_FLAGS="--quiet"
+    - python: '3.6'
+      env: PIP_FLAGS="--quiet"
+    - python: '3.7'
+      dist: xenial
+      sudo: required
+      env: PIP_FLAGS="--quiet"
 
 before_install:
   - python -m pip install ${PIP_FLAGS} --upgrade pip

--- a/gwdetchar/io/html.py
+++ b/gwdetchar/io/html.py
@@ -55,8 +55,11 @@ def new_bootstrap_page(*args, **kwargs):
     return page
 
 
-def write_flag_html(flag, span, id=0, parent='accordion', context='warning',
-                    title=None, plotdir=None, plot_func=None):
+def write_flag_html(flag, span=None, id=0, parent='accordion',
+                    context='warning', title=None, plotdir=None,
+                    plot_func=None):
+    """Write HTML for data quality flags
+    """
     page = markup.page()
     page.div(class_='panel panel-%s' % context)
     page.div(class_='panel-heading')

--- a/gwdetchar/io/tests/__init__.py
+++ b/gwdetchar/io/tests/__init__.py
@@ -1,0 +1,22 @@
+# coding=utf-8
+# Copyright (C) Alex Urban (2019)
+#
+# This file is part of the GW DetChar python package.
+#
+# GW DetChar is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GW DetChar is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GW DetChar.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests for :mod:`gwdetchar.io`
+"""
+
+__author__ = 'Alex Urban <alexander.urban@ligo.org>'

--- a/gwdetchar/io/tests/test_datafind.py
+++ b/gwdetchar/io/tests/test_datafind.py
@@ -1,0 +1,96 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Alex Urban (2019)
+#
+# This file is part of the GW DetChar python package.
+#
+# GW DetChar is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GW DetChar is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with gwdetchar.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests for `gwdetchar.io.datafind`
+"""
+
+import os
+import shutil
+
+import pytest
+
+import numpy
+from numpy import testing as nptest
+
+from gwpy.testing import utils
+from gwpy.testing.compat import mock
+from gwpy.timeseries import (TimeSeries, TimeSeriesDict)
+from gwpy.segments import (Segment, DataQualityFlag)
+
+from .. import datafind
+
+__author__ = 'Alex Urban <alexander.urban@ligo.org>'
+
+
+# global test objects
+
+HOFT = TimeSeries(
+    numpy.random.normal(loc=1, scale=.5, size=16384 * 66),
+    sample_rate=16384, epoch=0, name='X1:TEST-STRAIN')
+
+FLAG = DataQualityFlag(known=[(0, 66)], active=[(0, 66)],
+                       name='X1:TEST-FLAG:1')
+
+
+# -- make sure data can be read -----------------------------------------------
+
+@mock.patch('gwpy.segments.DataQualityFlag.query', return_value=FLAG)
+def test_check_flag(segserver):
+    # attempt to query segments database for an analysis flag
+    gpstime = 0
+    duration = 64
+    pad = 1
+    flag = 'X1:TEST-FLAG:1'
+    assert datafind.check_flag(flag, gpstime, duration, pad) is True
+
+
+@mock.patch('gwpy.timeseries.TimeSeriesDict.fetch',
+            return_value=TimeSeriesDict({'X1:TEST-STRAIN': HOFT}))
+def test_get_data_from_NDS(tsdfetch):
+    # retrieve data
+    gpstime = 33
+    duration = 64
+    pad = 1
+    channels = ['X1:TEST-STRAIN']
+    data = datafind.get_data(channels, gpstime, duration, pad, source=0)
+
+    # test data products
+    assert isinstance(data, TimeSeriesDict)
+    nptest.assert_array_equal(data['X1:TEST-STRAIN'].value, HOFT.value)
+
+
+def test_get_data_from_cache(tmpdir):
+    # set up a data file
+    target = os.path.join(str(tmpdir), 'test.gwf')
+    HOFT.write(target)
+
+    # retrieve test frame
+    gpstime = 33
+    duration = 32
+    pad = 1
+    channels = ['X1:TEST-STRAIN']
+    data = datafind.get_data(channels, gpstime, duration, pad, source=target)
+
+    # test data products
+    assert isinstance(data, TimeSeriesDict)
+    assert data[channels[0]].duration.value == duration + 2*pad
+    assert data[channels[0]].span == Segment(
+        gpstime - duration/2 - pad, gpstime + duration/2 + pad)
+    nptest.assert_array_equal(data[channels[0]].value, HOFT.crop(
+        gpstime - duration/2 - pad, gpstime + duration/2 + pad).value)
+    shutil.rmtree(target, ignore_errors=True)

--- a/gwdetchar/io/tests/test_html.py
+++ b/gwdetchar/io/tests/test_html.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Alex Urban (2019)
+#
+# This file is part of the GW DetChar python package.
+#
+# GW DetChar is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GW DetChar is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with gwdetchar.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests for `gwdetchar.io.html`
+"""
+
+import pytest
+
+try:  # python 3.x
+    from io import StringIO
+except ImportError:  # python 2.7
+    from cStringIO import StringIO
+
+from gwpy.segments import DataQualityFlag
+
+from .. import html
+from ...utils import parse_html
+
+__author__ = 'Alex Urban <alexander.urban@ligo.org>'
+
+
+# global test objects
+
+NEW_BOOTSTRAP_PAGE = """<!DOCTYPE HTML PUBLIC \'-//W3C//DTD HTML 4.01 Transitional//EN\'>
+<html lang="en">
+<head>
+<link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css" rel="stylesheet" type="text/css" media="all" />
+<script src="https://code.jquery.com/jquery-1.11.2.min.js" type="text/javascript"></script>
+<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js" type="text/javascript"></script>
+</head>
+<body>
+</body>
+</html>"""  # nopep8
+
+FLAG_HTML = """<div class="panel panel-warning">
+<div class="panel-heading">
+<a class="panel-title" href="#flag0" data-toggle="collapse" data-parent="#accordion">
+</div>
+<div id="flag0" class="panel-collapse collapse">
+<div class="panel-body">
+<pre># seg\tstart\tstop\tduration
+0\t0\t66\t66
+</pre>
+</div>
+</div>
+</div>"""  # nopep8
+
+FLAG = DataQualityFlag(known=[(0, 66)], active=[(0, 66)])
+
+
+# -- HTML unit tests ----------------------------------------------------------
+
+def test_new_bootstrap_page():
+    page = html.new_bootstrap_page()
+    assert parse_html(str(page)) == parse_html(NEW_BOOTSTRAP_PAGE)
+
+
+def test_write_flag_html():
+    page = html.write_flag_html(FLAG)
+    assert parse_html(str(page)) == parse_html(FLAG_HTML)

--- a/gwdetchar/io/tests/test_ligolw.py
+++ b/gwdetchar/io/tests/test_ligolw.py
@@ -28,24 +28,24 @@ from glue.ligolw.ligolw import Document
 from gwpy.segments import (Segment, SegmentList)
 from gwpy.testing.utils import assert_segmentlist_equal
 
-from ..io import ligolw as io_ligolw
+from .. import ligolw
 
 
 def test_new_table():
-    tab = io_ligolw.new_table('sngl_burst')
+    tab = ligolw.new_table('sngl_burst')
     assert isinstance(tab, lsctables.SnglBurstTable)
     assert sorted(tab.columnnames) == sorted(
         lsctables.SnglBurstTable.validcolumns.keys())
 
     cols = ['peak_time', 'peak_time_ns', 'snr']
-    tab = io_ligolw.new_table(lsctables.SnglBurstTable, columns=cols)
+    tab = ligolw.new_table(lsctables.SnglBurstTable, columns=cols)
     assert tab.columnnames == cols
 
 
 def test_sngl_burst_from_times():
     numpy.random.seed(0)
     times = numpy.random.random(4) * 100.
-    tab = io_ligolw.sngl_burst_from_times(times)
+    tab = ligolw.sngl_burst_from_times(times)
     assert isinstance(tab, lsctables.SnglBurstTable)
     assert len(tab) == 4
     nanosec, sec = numpy.modf(times)
@@ -55,15 +55,15 @@ def test_sngl_burst_from_times():
 
 
 def test_segments_from_sngl_burst():
-    tab = io_ligolw.sngl_burst_from_times([1, 4, 7, 10], channel='test')
-    segs = io_ligolw.segments_from_sngl_burst(tab, 1)
+    tab = ligolw.sngl_burst_from_times([1, 4, 7, 10], channel='test')
+    segs = ligolw.segments_from_sngl_burst(tab, 1)
     assert_segmentlist_equal(segs['test'].active, SegmentList([
         Segment(0, 2), Segment(3, 5), Segment(6, 8), Segment(9, 11),
     ]))
 
 
 def test_table_to_document():
-    tab = io_ligolw.new_table('sngl_burst')
-    xmldoc = io_ligolw.table_to_document(tab)
+    tab = ligolw.new_table('sngl_burst')
+    xmldoc = ligolw.table_to_document(tab)
     assert isinstance(xmldoc, Document)
     assert xmldoc.childNodes[-1].childNodes[0] is tab

--- a/gwdetchar/omega/html.py
+++ b/gwdetchar/omega/html.py
@@ -675,7 +675,7 @@ def write_footer(about=None, date=None):
         date = datetime.datetime.now().replace(second=0, microsecond=0)
     version = get_versions()['version']
     commit = get_versions()['full-revisionid']
-    url = 'https://github.com/gwdetchar/gwdetchar/tree/%s' % commit 
+    url = 'https://github.com/gwdetchar/gwdetchar/tree/%s' % commit
     hlink = markup.oneliner.a('GW-DetChar version %s' % version, href=url,
                               target='_blank', style='color:#eee;')
     page.div(class_='row')
@@ -690,40 +690,6 @@ def write_footer(about=None, date=None):
     page.div.close()  # container
     markup.element('footer', case=page.case, parent=page).close()
     return page
-
-
-def write_config_html(filepath, format='ini'):
-    """Return an HTML-formatted copy of the file with syntax highlighting
-    This method attemps to use the `highlight` package to provide a block
-    of HTML that can be embedded inside a ``<pre></pre>`` tag.
-
-    Parameters
-    ----------
-    filepath : `str`
-        path of file to format
-    format : `str`, optional
-        syntax format for this file
-
-    Returns
-    -------
-    html : `str`
-        a formatted block of HTML containing HTML with inline CSS
-    """
-    highlight = ['highlight', '--out-format', 'html', '--syntax', format,
-                 '--inline-css', '--fragment', '--input', filepath]
-    try:
-        process = subprocess.Popen(highlight, stdout=subprocess.PIPE,
-                                   stderr=subprocess.PIPE)
-    except OSError:
-        with open(filepath, 'r') as fobj:
-            return fobj.read()
-    else:
-        out, err = process.communicate()
-        if process.returncode != 0:
-            with open(filepath, 'r') as fobj:
-                return fobj.read()
-        else:
-            return out
 
 
 # -- Qscan HTML ---------------------------------------------------------------
@@ -1137,5 +1103,7 @@ def write_about_page(configfiles):
     page.p('Omega scans are configured with INI-format files. The '
            'configuration files for this analysis are shown below in full.')
     for configfile in configfiles:
-        page.pre(write_config_html(configfile))
+        with open(configfile, 'r') as fobj:
+            contents = fobj.read()
+        page.pre(contents)
     return page

--- a/gwdetchar/omega/tests/test_config.py
+++ b/gwdetchar/omega/tests/test_config.py
@@ -70,7 +70,10 @@ channels = X1:TEST-STRAIN
 CONFIG_FILE = StringIO(CONFIGURATION)
 
 CP = config.OmegaConfigParser(ifo='X1')
-CP.readfp(CONFIG_FILE)
+try:  # python 3.x
+    CP.read_file(CONFIG_FILE)
+except AttributeError:  # python 2.7
+    CP.readfp(CONFIG_FILE)
 BLOCKS = CP.get_channel_blocks()
 PRIMARY = BLOCKS['primary']
 GW = BLOCKS['GW']

--- a/gwdetchar/omega/tests/test_html.py
+++ b/gwdetchar/omega/tests/test_html.py
@@ -20,24 +20,20 @@
 """
 
 import os
-import sys
 import shutil
 import datetime
 from getpass import getuser
 
 try:  # python 3.x
     from io import StringIO
-    from html.parser import HTMLParser
-    from html.entities import name2codepoint
-except:  # python 2.7
+except ImportError:  # python 2.7
     from cStringIO import StringIO
-    from HTMLParser import HTMLParser
-    from htmlentitydefs import name2codepoint
 
 import pytest
 
-from .. import html
+from .. import (config, html)
 from ..._version import get_versions
+from ...utils import parse_html
 
 __author__ = 'Alex Urban <alexander.urban@ligo.org>'
 __credits__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
@@ -47,6 +43,74 @@ __credits__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
 VERSION = get_versions()['version']
 COMMIT = get_versions()['full-revisionid']
+
+HTML_HEADER = """<!DOCTYPE HTML>
+<html lang="en">
+<head>
+<meta http-equiv="refresh" content="60">
+<meta content="width=device-width, initial-scale=1.0" name="viewport">
+<base href="{base}" />
+<link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css" rel="stylesheet" type="text/css" media="all" />
+<link href="https://cdnjs.cloudflare.com/ajax/libs/fancybox/2.1.5/jquery.fancybox.min.css" rel="stylesheet" type="text/css" media="all" />
+<link href="static/bootstrap-ligo.min.css" rel="stylesheet" type="text/css" media="all" />
+<link href="static/gwdetchar-omega.min.css" rel="stylesheet" type="text/css" media="all" />
+<script src="https://code.jquery.com/jquery-1.12.3.min.js" type="text/javascript"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.13.0/moment.min.js" type="text/javascript"></script>
+<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js" type="text/javascript"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/fancybox/2.1.5/jquery.fancybox.min.js" type="text/javascript"></script>
+<script src="static/bootstrap-ligo.min.js" type="text/javascript"></script>
+<script src="static/gwdetchar-omega.min.js" type="text/javascript"></script>
+</head>
+<body>
+<header class="navbar navbar-fixed-top navbar-l1">
+<div class="container">
+<div class="navbar-header">
+<button class="navbar-toggle" data-toggle="collapse" type="button" data-target=".navbar-collapse">
+<span class="icon-bar"></span>
+<span class="icon-bar"></span>
+<span class="icon-bar"></span>
+</button>
+<div class="navbar-brand">{ifo}</div>
+<div class="navbar-brand">{gps}</div>
+</div>
+<nav class="collapse navbar-collapse">
+<ul class="nav navbar-nav">
+<li><a href="#">Summary</a></li>
+<li class="dropdown">
+<a class="dropdown-toggle" data-toggle="dropdown">
+GW <b class="caret"></b>
+</a>
+<ul class="dropdown-menu" style="max-height: 700px; overflow-y: scroll;">
+<li class="dropdown-header">Gravitational-Wave Strain</li>
+<li>
+<a href="#x1-test-aux">X1:TEST-AUX</a>
+</li>
+</ul>
+</li>
+<li class="dropdown">
+<a class="dropdown-toggle" data-toggle="dropdown">
+Links <b class="caret"></b>
+</a>
+<ul class="dropdown-menu">
+<li class="dropdown-header">Internal</li>
+<li><a href="about">About this scan</a></li>
+<li class="divider"></li>
+<li class="dropdown-header">External</li>
+<li>
+<a href="https://ldas-jobs.ligo-la.caltech.edu/~detchar/summary/day//19800106" target="_blank">LLO Summary Pages</a>
+</li>
+<li>
+<a href="https://alog.ligo-la.caltech.edu/aLOG/" target="_blank">LLO Logbook</a>
+</li>
+</ul>
+</li>
+</ul>
+</nav>
+</div>
+</header>
+<div class="container">
+</body>
+</html>"""  # nopep8
 
 HTML_FOOTER = """<footer class="footer">
 <div class="container">
@@ -63,52 +127,189 @@ HTML_CLOSE = """</div>
 </body>
 </html>""" % HTML_FOOTER
 
+CONFIGURATION = u"""
+[primary]
+; the primary channel, which will be used as a matched-filter
+f-low = 4.0
+resample = 4096
+frametype = X1_HOFT
+duration = 64
+fftlength = 8
+matched-filter-length = 6
+channel = X1:TEST-STRAIN
 
-# -- class for HTML diffs -----------------------------------------------------
+[GW]
+; name of this block, which contains h(t)
+name = Gravitational Wave Strain
+q-range = 3.3166,150.0
+frequency-range = 4.0,1024
+resample = 4096
+frametype = X1_HOFT
+state-flag = X1:OBSERVING:1
+duration = 64
+fftlength = 8
+max-mismatch = 0.2
+snr-threshold = 5
+always-plot = True
+plot-time-durations = 4
+channels = X1:TEST-AUX
+"""
 
-class TestHTMLParser(HTMLParser):
-    """See https://docs.python.org/3/library/html.parser.html.
-    """
-    def handle_starttag(self, tag, attrs):
-        print("Start tag:", tag)
-        attrs.sort()
-        for attr in attrs:
-            print("attr:", attr)
+CONFIG_FILE = StringIO(CONFIGURATION)
+CP = config.OmegaConfigParser(ifo='X1')
+try:  # python 3.x
+    CP.read_file(CONFIG_FILE)
+except AttributeError:  # python 2.7
+    CP.readfp(CONFIG_FILE)
+BLOCKS = CP.get_channel_blocks()
+PRIMARY = BLOCKS['primary']
+GW = BLOCKS['GW']
 
-    def handle_endtag(self, tag):
-        print("End tag:", tag)
+# set analyzed channel list
+ANALYZED = {'GW': {
+    'name': 'Gravitational-Wave Strain',
+    'channels': GW.channels,
+}}
+for channel in ANALYZED['GW']['channels']:
+    channel.Q = 5
+    channel.t = 0
+    channel.f = 100
+    channel.energy = 1000
+    channel.snr = 44.7
+    channel.corr = 100
+    channel.stdev = 1
+    channel.delay = 0
 
-    def handle_data(self, data):
-        print("Data:", data)
-
-    def handle_comment(self, data):
-        print("Comment:", data)
-
-    def handle_entityref(self, name):
-        c = chr(name2codepoint[name])
-        print("Named entity:", c)
-
-    def handle_charref(self, name):
-        if name.startswith('x'):
-            c = chr(int(name[1:], 16))
-        else:
-            c = chr(int(name))
-        print("Numeric entity:", c)
-
-    def handle_decl(self, data):
-        print("Decl:", data)
+BLOCK_HTML = """<div class="panel panel-info">
+<div class="panel-heading clearfix">
+<div class="pull-right">
+<a href="#" class="text-info"><small>[top]</small></a>
+</div>
+<h3 class="panel-title">GW: Gravitational-Wave Strain</h3>
+</div>
+<ul class="list-group">
+<li class="list-group-item">
+<div class="container">
+<div class="row">
+<h4 id="x1-test-aux"><a href="https://cis.ligo.org/channel/byname/X1:TEST-AUX" title="CIS entry for X1:TEST-AUX" style="font-family: Monaco, &quot;Courier New&quot;, monospace; color: black;" target="_blank">X1:TEST-AUX</a></h4>
+<div class="row">
+<div class="col-md-7">
+<table class="table table-condensed table-hover table-bordered table-responsive desktop-only">
+<thead>
+<tr>
+<th scope="col">GPS Time</th>
+<th scope="col">Frequency</th>
+<th scope="col">Q</th>
+<th scope="col">Energy</th>
+<th scope="col">SNR</th>
+<th scope="col">Correlation</th>
+<th scope="col">Delay</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>0</td>
+<td>100 Hz</td>
+<td>5</td>
+<td>1000</td>
+<td>44.7</td>
+<td>100</td>
+<td>0 ms</td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="col-xs-12 col-md-5">
+<div class="btn-group" role="group">
+<div class="btn-group" role="group">
+<button id="btnGroupTimeseries0" type="button" class="btn btn-info dropdown-toggle" data-toggle="dropdown">
+Timeseries view <span class="caret"></span>
+</button>
+<ul class="dropdown-menu" role="menu" aria-labelledby="btnGroupTimeseries0">
+<li><a class="dropdown-item" onclick="showImage(&quot;X1-TEST_AUX&quot;, [&quot;4&quot;], &quot;timeseries_raw&quot;, [&quot;X1-TEST_AUX-timeseries_raw-4.png&quot;]);">raw</a></li>
+<li><a class="dropdown-item" onclick="showImage(&quot;X1-TEST_AUX&quot;, [&quot;4&quot;], &quot;timeseries_highpassed&quot;, [&quot;X1-TEST_AUX-timeseries_highpassed-4.png&quot;]);">highpassed</a></li>
+<li><a class="dropdown-item" onclick="showImage(&quot;X1-TEST_AUX&quot;, [&quot;4&quot;], &quot;timeseries_whitened&quot;, [&quot;X1-TEST_AUX-timeseries_whitened-4.png&quot;]);">whitened</a></li>
+</ul>
+</div>
+<div class="btn-group" role="group">
+<button id="btnGroupQscan0" type="button" class="btn btn-info dropdown-toggle" data-toggle="dropdown">
+Spectrogram view <span class="caret"></span>
+</button>
+<ul class="dropdown-menu" role="menu" aria-labelledby="btnGroupQscan0">
+<li><a class="dropdown-item" onclick="showImage(&quot;X1-TEST_AUX&quot;, [&quot;4&quot;], &quot;qscan_highpassed&quot;, [&quot;X1-TEST_AUX-qscan_highpassed-4.png&quot;]);">highpassed</a></li>
+<li><a class="dropdown-item" onclick="showImage(&quot;X1-TEST_AUX&quot;, [&quot;4&quot;], &quot;qscan_whitened&quot;, [&quot;X1-TEST_AUX-qscan_whitened-4.png&quot;]);">whitened</a></li>
+<li><a class="dropdown-item" onclick="showImage(&quot;X1-TEST_AUX&quot;, [&quot;4&quot;], &quot;qscan_autoscaled&quot;, [&quot;X1-TEST_AUX-qscan_autoscaled-4.png&quot;]);">autoscaled</a></li>
+</ul>
+</div>
+<div class="btn-group" role="group">
+<button id="btnGroupEventgram0" type="button" class="btn btn-info dropdown-toggle" data-toggle="dropdown">
+Eventgram view <span class="caret"></span>
+</button>
+<ul class="dropdown-menu" role="menu" aria-labelledby="btnGroupEventgram0">
+<li><a class="dropdown-item" onclick="showImage(&quot;X1-TEST_AUX&quot;, [&quot;4&quot;], &quot;eventgram_highpassed&quot;, [&quot;X1-TEST_AUX-eventgram_highpassed-4.png&quot;]);">highpassed</a></li>
+<li><a class="dropdown-item" onclick="showImage(&quot;X1-TEST_AUX&quot;, [&quot;4&quot;], &quot;eventgram_whitened&quot;, [&quot;X1-TEST_AUX-eventgram_whitened-4.png&quot;]);">whitened</a></li>
+<li><a class="dropdown-item" onclick="showImage(&quot;X1-TEST_AUX&quot;, [&quot;4&quot;], &quot;eventgram_autoscaled&quot;, [&quot;X1-TEST_AUX-eventgram_autoscaled-4.png&quot;]);">autoscaled</a></li>
+</ul>
+</div>
+</div>
+</div>
+</div>
+<div class="row">
+<div class="col-sm-12">
+<a href="plots/X1-TEST_AUX-qscan_whitened-4.png" id="a_X1-TEST_AUX_4" title="X1-TEST_AUX-qscan_whitened-4.png" class="fancybox" target="_blank" data-fancybox-group="qscan-image">
+<img id="img_X1-TEST_AUX_4" alt="X1-TEST_AUX-qscan_whitened-4.png" class="img-responsive" src="plots/X1-TEST_AUX-qscan_whitened-4.png" />
+</a>
+</div>
+</div>
+</div>
+</li>
+</ul>
+</div>"""  # nopep8
 
 
 # -- unit tests ---------------------------------------------------------------
 
-def parse_html(html):
-    parser = TestHTMLParser()
-    stdout = sys.stdout
-    sys.stdout = StringIO()
-    parser.feed(html)
-    output = sys.stdout.getvalue()
-    sys.stdout = stdout
-    return output
+def test_fancy_plot():
+    # create a dummy FancyPlot instance
+    test = html.FancyPlot('test.png')
+    assert test.img is 'test.png'
+    assert test.caption is 'test.png'
+
+    # check that its properties are unchanged when the argument
+    # to FancyPlot() is also a FancyPlot instance
+    test = html.FancyPlot(test)
+    assert test.img is 'test.png'
+    assert test.caption is 'test.png'
+
+
+def test_finalize_static_urls(tmpdir):
+    static = os.path.join(str(tmpdir), 'static')
+    css, js = html.finalize_static_urls(static, html.CSS_FILES, html.JS_FILES)
+    assert css == [
+        'https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/'
+            'bootstrap.min.css',
+        'https://cdnjs.cloudflare.com/ajax/libs/fancybox/2.1.5/'
+            'jquery.fancybox.min.css',
+        'static/bootstrap-ligo.min.css',
+        'static/gwdetchar-omega.min.css']
+    assert js == [
+        'https://code.jquery.com/jquery-1.12.3.min.js',
+        'https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.13.0/'
+            'moment.min.js',
+        'https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js',
+        'https://cdnjs.cloudflare.com/ajax/libs/fancybox/2.1.5/'
+            'jquery.fancybox.min.js',
+        'static/bootstrap-ligo.min.js',
+        'static/gwdetchar-omega.min.js']
+    shutil.rmtree(str(tmpdir), ignore_errors=True)
+
+
+def test_init_page(tmpdir):
+    base = str(tmpdir)
+    page = html.init_page('L1', 0, toc=ANALYZED, refresh=True, base=base)
+    assert parse_html(str(page)) == parse_html(
+        HTML_HEADER.format(base=base, ifo='L1', gps=0))
+    shutil.rmtree(base, ignore_errors=True)
 
 
 def test_close_page(tmpdir):
@@ -124,19 +325,6 @@ def test_close_page(tmpdir):
     shutil.rmtree(target, ignore_errors=True)
 
 
-def test_fancy_plot():
-    # create a dummy FancyPlot instance
-    test = html.FancyPlot('test.png')
-    assert test.img is 'test.png'
-    assert test.caption is 'test.png'
-
-    # check that its properties are unchanged when the argument
-    # to FancyPlot() is also a FancyPlot instance
-    test = html.FancyPlot(test)
-    assert test.img is 'test.png'
-    assert test.caption is 'test.png'
-
-
 @pytest.mark.parametrize('args, kwargs, result', [
     (('test.html', 'Test link'), {},
      '<a href="test.html" target="_blank">Test link</a>'),
@@ -146,6 +334,17 @@ def test_fancy_plot():
 def test_html_link(args, kwargs, result):
     h1 = parse_html(html.html_link(*args, **kwargs))
     h2 = parse_html(result)
+    assert h1 == h2
+
+
+def test_toggle_link():
+    h1 = parse_html(html.toggle_link('timeseries_raw', GW.channels[0], [4]))
+    h2 = parse_html(
+        '<a class="dropdown-item" '
+        'onclick="showImage(&quot;X1-TEST_AUX&quot;, [&quot;4&quot;], '
+        '&quot;timeseries_raw&quot;, '
+        '[&quot;X1-TEST_AUX-timeseries_raw-4.png&quot;]);">raw</a>'
+    )
     assert h1 == h2
 
 
@@ -161,38 +360,38 @@ def test_cis_link():
 
 
 def test_fancybox_img():
-    img = html.FancyPlot('X1-TEST_STRAIN-test-4.png')
+    img = html.FancyPlot('X1-TEST_AUX-test-4.png')
     out = html.fancybox_img(img)
     assert parse_html(out) == parse_html(
-        '<a class="fancybox" href="X1-TEST_STRAIN-test-4.png" target="_blank" '
-            'data-fancybox-group="qscan-image" id="a_X1-TEST_STRAIN_4" '
-            'title="X1-TEST_STRAIN-test-4.png">\n'
-        '<img class="img-responsive" alt="X1-TEST_STRAIN-test-4.png" '
-            'src="X1-TEST_STRAIN-test-4.png" id="img_X1-TEST_STRAIN_4"/>\n'
+        '<a class="fancybox" href="X1-TEST_AUX-test-4.png" target="_blank" '
+            'data-fancybox-group="qscan-image" id="a_X1-TEST_AUX_4" '
+            'title="X1-TEST_AUX-test-4.png">\n'
+        '<img class="img-responsive" alt="X1-TEST_AUX-test-4.png" '
+            'src="X1-TEST_AUX-test-4.png" id="img_X1-TEST_AUX_4"/>\n'
         '</a>'
     )
 
 
 def test_scaffold_plots():
     h1 = parse_html(html.scaffold_plots([
-        html.FancyPlot('X1-TEST_STRAIN-test-4.png'),
-        html.FancyPlot('X1-TEST_STRAIN-test-16.png')], nperrow=2))
+        html.FancyPlot('X1-TEST_AUX-test-4.png'),
+        html.FancyPlot('X1-TEST_AUX-test-16.png')], nperrow=2))
     h2 = parse_html(
         '<div class="row">\n'
         '<div class="col-sm-6">\n'
-        '<a class="fancybox" href="X1-TEST_STRAIN-test-4.png" target="_blank" '
-            'id="a_X1-TEST_STRAIN_4" data-fancybox-group="qscan-image" '
-            'title="X1-TEST_STRAIN-test-4.png">\n'
-        '<img class="img-responsive" alt="X1-TEST_STRAIN-test-4.png" '
-            'id="img_X1-TEST_STRAIN_4" src="X1-TEST_STRAIN-test-4.png" />\n'
+        '<a class="fancybox" href="X1-TEST_AUX-test-4.png" target="_blank" '
+            'id="a_X1-TEST_AUX_4" data-fancybox-group="qscan-image" '
+            'title="X1-TEST_AUX-test-4.png">\n'
+        '<img class="img-responsive" alt="X1-TEST_AUX-test-4.png" '
+            'id="img_X1-TEST_AUX_4" src="X1-TEST_AUX-test-4.png" />\n'
         '</a>\n'
         '</div>\n'
         '<div class="col-sm-6">\n'
-        '<a class="fancybox" href="X1-TEST_STRAIN-test-16.png" target="_blank"'
-            ' id="a_X1-TEST_STRAIN_16" data-fancybox-group="qscan-image" '
-            'title="X1-TEST_STRAIN-test-16.png">\n'
-        '<img class="img-responsive" alt="X1-TEST_STRAIN-test-16.png" '
-            'id="img_X1-TEST_STRAIN_16" src="X1-TEST_STRAIN-test-16.png" />\n'
+        '<a class="fancybox" href="X1-TEST_AUX-test-16.png" target="_blank"'
+            ' id="a_X1-TEST_AUX_16" data-fancybox-group="qscan-image" '
+            'title="X1-TEST_AUX-test-16.png">\n'
+        '<img class="img-responsive" alt="X1-TEST_AUX-test-16.png" '
+            'id="img_X1-TEST_AUX_16" src="X1-TEST_AUX-test-16.png" />\n'
         '</a>\n'
         '</div>\n'
         '</div>'
@@ -200,8 +399,100 @@ def test_scaffold_plots():
     assert h1 == h2
 
 
+def test_write_summary_table(tmpdir):
+    tmpdir.mkdir('data')
+    wdir = str(tmpdir)
+    os.chdir(wdir)
+    html.write_summary_table(ANALYZED, correlated=True)
+    shutil.rmtree(wdir)
+
+
 def test_write_footer():
     date = datetime.datetime.now()
     out = html.write_footer(date=date)
     assert parse_html(str(out)) == parse_html(
         HTML_FOOTER.format(user=getuser(), date=date))
+
+
+def test_write_summary():
+    page = html.write_summary('L1', 0, incomplete=True)
+    h1 = parse_html(str(page))
+    h2 = parse_html(
+        '<div class="banner">\n<h2>Summary</h2>\n</div>\n<div class="row">\n'
+        '<div class="col-md-5">\n<table class="table table-condensed '
+            'table-hover table-responsive">\n<tbody>\n<tr>\n'
+        '<td scope="row"><b>Interferometer</b></td>\n<td>LIGO Livingston '
+            '(L1)</td>\n</tr>\n<tr>\n<td scope="row"><b>UTC Time</b></td>\n'
+        '<td>1980-01-06 00:00:00</td>\n</tr>\n</tbody>\n</table>\n</div>\n'
+        '<div class="col-xs-12 col-md-7">\n<div class="btn-group" '
+            'role="group">\n<button id="summary_table_download" type="button" '
+            'class="btn btn-default dropdown-toggle" data-toggle="dropdown">\n'
+            'Download summary <span class="caret"></span>\n</button>\n'
+        '<ul class="dropdown-menu" role="menu" '
+            'aria-labelledby="summary_table_download">\n'
+        '<li><a href="data/summary.txt" download="L1_0_summary.txt">'
+            'txt</a></li>\n'
+        '<li><a href="data/summary.csv" download="L1_0_summary.csv">'
+            'csv</a></li>\n'
+        '<li><a href="data/summary.tex" download="L1_0_summary.tex">'
+            'tex</a></li>\n'
+        '</ul>\n</div>\n</div>\n</div>\n<div class="row">\n'
+        '<div class="alert alert-default">\n<p><strong>Note</strong>: '
+            'This scan is in progress, and will auto-refresh every 60 seconds '
+            'until completion.</p>\n</div>\n</div>'
+    )
+    assert h1 == h2
+
+
+def test_write_ranking():
+    page = html.write_ranking(ANALYZED, PRIMARY.channel.name)
+    h1 = parse_html(str(page))
+    h2 = parse_html(
+        '<div class="row">\n<div class="col-md-12">\n<p>Below are the top 5 '
+            'channels ranked by matched-filter correlation within 100 ms of '
+            '<a href="plots/primary.png" title="Whitened timeseries of the '
+            'primary channel, X1:TEST-STRAIN." class="fancybox" '
+            'target="_blank" style="font-family: Monaco, &quot;Courier '
+            'New&quot;, monospace; color: black;" data-fancybox-group='
+            '"qscan-image">X1:TEST-STRAIN</a>.</p>\n'
+        '<table class="table table-condensed table-hover table-bordered '
+            'table-responsive">\n'
+        '<thead>\n<tr>\n<th scope="col">Channel</th>\n'
+        '<th scope="col">GPS Time</th>\n<th scope="col">Frequency</th>\n'
+        '<th scope="col">Q</th>\n<th scope="col">Energy</th>\n'
+        '<th scope="col">SNR</th>\n<th scope="col">Correlation</th>\n'
+        '<th scope="col">Delay</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n'
+        '<td><a title="X1:TEST-AUX" href="#x1-test-aux" '
+            'style="font-family: Monaco, &quot;Courier New&quot;, monospace; '
+            'color: black;">X1:TEST-AUX</a></td>\n'
+        '<td>0</td>\n<td>100.0 Hz</td>\n<td>5</td>\n<td>1000</td>\n'
+        '<td>44.7</td>\n<td>100</td>\n<td>0 ms</td>\n'
+        '</tr>\n</tbody>\n</table>\n</div>\n</div>'
+    )
+    assert h1 == h2
+
+
+def test_write_block():
+    page = html.write_block('GW', ANALYZED['GW'], 'info')
+    assert parse_html(str(page)) == parse_html(BLOCK_HTML)
+
+
+# -- end-to-end tests ---------------------------------------------------------
+
+def test_write_qscan_page(tmpdir):
+    os.chdir(str(tmpdir))
+    html.write_qscan_page('L1', 0, ANALYZED, 'info')
+    shutil.rmtree(str(tmpdir), ignore_errors=True)
+
+
+def test_write_null_page(tmpdir):
+    os.chdir(str(tmpdir))
+    html.write_null_page('L1', 0, 'test', 'info')
+    shutil.rmtree(str(tmpdir), ignore_errors=True)
+
+
+def test_write_about_page(tmpdir):
+    tmpdir.mkdir('about')
+    os.chdir(str(tmpdir))
+    html.write_about_page('L1', 0, CONFIG_FILE, outdir='about')
+    shutil.rmtree(str(tmpdir), ignore_errors=True)

--- a/gwdetchar/omega/tests/test_plot.py
+++ b/gwdetchar/omega/tests/test_plot.py
@@ -85,12 +85,8 @@ def test_qgram_plot():
 
 
 def test_write_qscan_plots(tmpdir):
-    plotdir = str(tmpdir.mkdir('plots'))
-    try:  # python 3.x
-        from pathlib import Path  # nopep8
-        wdir = str(Path(plotdir).parent)
-    except ImportError:  # python 2.7
-        wdir = os.path.abspath(os.path.join(plotdir, '..'))
+    tmpdir.mkdir('plots')
+    wdir = str(tmpdir)
     os.chdir(wdir)
     plot.write_qscan_plots(gps=0, channel=CHANNEL, series=SERIES)
     shutil.rmtree(wdir, ignore_errors=True)

--- a/gwdetchar/utils.py
+++ b/gwdetchar/utils.py
@@ -20,8 +20,69 @@
 """
 
 import re
+import sys
+
+try:  # python 3.x
+    from io import StringIO
+    from html.parser import HTMLParser
+    from html.entities import name2codepoint
+except:  # python 2.7
+    from cStringIO import StringIO
+    from HTMLParser import HTMLParser
+    from htmlentitydefs import name2codepoint
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
+__credits__ = 'Alex Urban <alexander.urban@ligo.org>'
+
+
+# -- class for HTML parsing ---------------------------------------------------
+
+class GWHTMLParser(HTMLParser):
+    """See https://docs.python.org/3/library/html.parser.html.
+    """
+    def handle_starttag(self, tag, attrs):
+        print("Start tag:", tag)
+        attrs.sort()
+        for attr in attrs:
+            print("attr:", attr)
+
+    def handle_endtag(self, tag):
+        print("End tag:", tag)
+
+    def handle_data(self, data):
+        print("Data:", data)
+
+    def handle_comment(self, data):
+        print("Comment:", data)
+
+    def handle_entityref(self, name):
+        c = chr(name2codepoint[name])
+        print("Named entity:", c)
+
+    def handle_charref(self, name):
+        if name.startswith('x'):
+            c = chr(int(name[1:], 16))
+        else:
+            c = chr(int(name))
+        print("Numeric entity:", c)
+
+    def handle_decl(self, data):
+        print("Decl:", data)
+
+parser = GWHTMLParser()
+
+
+# -- utilities ----------------------------------------------------------------
+
+def parse_html(html):
+    """Parse a string containing raw HTML code
+    """
+    stdout = sys.stdout
+    sys.stdout = StringIO()
+    parser.feed(html)
+    output = sys.stdout.getvalue()
+    sys.stdout = stdout
+    return output
 
 
 def natural_sort(l, key=str):


### PR DESCRIPTION
This PR includes the following changes:

* Support python 3.7 build tests
* Add unit tests for `gwdetchar.io` submodules
* Move `gwdetchar.io.ligolw` unit test to `gwdetchar.io.tests`
* More extensive unit tests for `gwdetchar.omega.html`
* Since the `span` kwarg to `gwdetchar.io.html.write_flag_html` is not used unless plots are requested, make it optional and add a (very minimal) docstring

Note, this is related to but independent from #235.

This PR also fixes an issue rendering omega scan configuration files with HTML under python 3.7, example output is available [**here**](https://ldas-jobs.ligo-la.caltech.edu/~aurban/pyomega-test/Network_170817/) (requires `LIGO.ORG` credentials).

cc @duncanmmacleod 