### PR TITLE
update 'gwdetchar-lasso-correlation' to indicate when BLRMS is used

### DIFF
--- a/bin/gwdetchar-lasso-correlation
+++ b/bin/gwdetchar-lasso-correlation
@@ -722,7 +722,8 @@ write_param('Lasso coefficient threshold', '%g' % args.threshold)
 write_param('Sigma for outlier removal', '%g' % args.remove_outliers)
 write_param('Cluster coefficient threshold: ',
             '%g' % args.cluster_coefficient)
-
+if args.band_pass:
+    write_param('Filter settings','Flow=%dHz, Fhigh=%dHz ' % (flower, fupper))
 page.h2('Model Information')
 
 page.div(class_='model')


### PR DESCRIPTION
As josh requested. This has the lasso results page include the band pass's parameters. 
example: https://ldas-jobs.ligo-la.caltech.edu/~jeffrey.bidler/detchar/pre-O3/bandpass-check/