### PR TITLE
Update submodules before installing

### DIFF
--- a/_setup_utils.py
+++ b/_setup_utils.py
@@ -41,6 +41,11 @@ JS_FILES = [
 SASS_FILES = glob.glob(os.path.join('share', 'sass', '[!_]*.scss')) + (
     glob.glob(os.path.join('bootstrap-ligo', 'css', '[!_]*.scss')))
 
+# make sure submodule is not empty
+static = glob.glob(os.path.join('bootstrap-ligo', '*'))
+if not static:
+    raise ValueError('bootstrap-ligo submodule must be updated')
+
 
 # -- custom commands ----------------------------------------------------------
 

--- a/_setup_utils.py
+++ b/_setup_utils.py
@@ -44,7 +44,8 @@ SASS_FILES = glob.glob(os.path.join('share', 'sass', '[!_]*.scss')) + (
 # make sure submodule is not empty
 static = glob.glob(os.path.join('bootstrap-ligo', '*'))
 if not static:
-    raise ValueError('bootstrap-ligo submodule must be updated')
+    raise ValueError('bootstrap-ligo submodule is empty, please populate it '
+                     'with `git submodule update --init`')
 
 
 # -- custom commands ----------------------------------------------------------


### PR DESCRIPTION
This fixes a couple of issues with the conda build of gwdetchar-0.2.0:

* Use mock functions instead of tmp directory in unit tests for `gwdetchar.io.datafind`
* Make sure the `bootstrap-ligo` submodule is populated before building