### PR TITLE
Resolve a python 2 issue with conda environments

### DIFF
--- a/gwdetchar/utils.py
+++ b/gwdetchar/utils.py
@@ -79,7 +79,10 @@ def parse_html(html):
     """
     stdout = sys.stdout
     sys.stdout = StringIO()
-    parser.feed(html)
+    if sys.version_info.major < 3:
+        parser.feed(html.decode('utf-8', 'ignore'))
+    else:
+        parser.feed(html)
     output = sys.stdout.getvalue()
     sys.stdout = stdout
     return output


### PR DESCRIPTION
This PR resolves an issue where, in conda environments, `StringIO` expects strings to be `utf-8`-encoded in python 2.7, but not in python 3.x. This prevented gwdetchar-0.2.1 conda build tests from passing, and will necessitate a gwdetchar-0.2.2 point release, see conda-forge/gwdetchar-feedstock#3.

cc @duncanmmacleod 