### PR TITLE
Increase coverage of unit tests

### DIFF
--- a/bin/gwdetchar-lasso-correlation
+++ b/bin/gwdetchar-lasso-correlation
@@ -635,8 +635,8 @@ page.add(htmlio.write_param(
 page.add(htmlio.write_param('Cluster coefficient threshold: ',
                             '%g' % args.cluster_coefficient))
 if args.band_pass:
-    page.add(htmlio.write_param('Filter settings',
-                         'Flow=%dHz, Fhigh=%dHz ' % (flower, fupper)))
+    page.add(htmlio.write_param(
+        'Filter settings', 'Flow=%dHz, Fhigh=%dHz ' % (flower, fupper)))
 page.h2('Model Information')
 
 page.div(class_='model')

--- a/gwdetchar/io/tests/test_datafind.py
+++ b/gwdetchar/io/tests/test_datafind.py
@@ -40,7 +40,7 @@ HOFT = TimeSeries(
     numpy.random.normal(loc=1, scale=.5, size=16384 * 66),
     sample_rate=16384, epoch=0, name='X1:TEST-STRAIN')
 
-FLAG = DataQualityFlag(known=[(0, 66)], active=[(0, 66)],
+FLAG = DataQualityFlag(known=[(-33, 33)], active=[(-33, 33)],
                        name='X1:TEST-FLAG:1')
 
 
@@ -49,11 +49,9 @@ FLAG = DataQualityFlag(known=[(0, 66)], active=[(0, 66)],
 @mock.patch('gwpy.segments.DataQualityFlag.query', return_value=FLAG)
 def test_check_flag(segserver):
     # attempt to query segments database for an analysis flag
-    gpstime = 0
-    duration = 64
-    pad = 1
     flag = 'X1:TEST-FLAG:1'
-    assert datafind.check_flag(flag, gpstime, duration, pad) is True
+    assert datafind.check_flag(flag, gpstime=0, duration=64, pad=1) is True
+    assert datafind.check_flag(flag, gpstime=800, duration=64, pad=1) is False
 
 
 @mock.patch('gwpy.timeseries.TimeSeries.fetch', return_value=HOFT)
@@ -115,3 +113,9 @@ def test_get_data_dict_from_cache(tsdfetch):
     assert data[channels[0]].span == Segment(start, end)
     nptest.assert_array_equal(data[channels[0]].value,
                               HOFT.crop(start, end).value)
+
+
+def test_fail_on_no_frametype():
+    channel = 'X1:TEST-STRAIN'
+    with pytest.raises(TypeError):
+        datafind.get_data(channel, start=0, end=32)

--- a/gwdetchar/lasso/plot.py
+++ b/gwdetchar/lasso/plot.py
@@ -23,6 +23,7 @@ import os
 import shutil
 import tempfile
 import atexit
+import warnings
 
 from matplotlib import rcParams
 

--- a/gwdetchar/lasso/tests/test_plot.py
+++ b/gwdetchar/lasso/tests/test_plot.py
@@ -26,7 +26,7 @@ import pytest
 
 import numpy
 
-from matplotlib import use
+from matplotlib import (use, rcParams, rcParamsDefault)
 use('agg')
 
 from gwpy.plot import Plot
@@ -45,11 +45,22 @@ SERIES = TimeSeries(DATA, sample_rate=60, unit='Mpc', name='X1:TEST')
 
 # -- make sure plots run end-to-end -------------------------------------------
 
+def test_configure_mpl():
+    plot.configure_mpl()
+    assert os.environ['HOME'] == os.environ['MPLCONFIGDIR']
+    assert rcParams['ps.useafm'] is True
+    assert rcParams['pdf.use14corefonts'] is True
+    assert rcParams['text.usetex'] is True
+    rcParams.update(rcParamsDefault)
+
+
 def test_save_figure(tmpdir):
     base = str(tmpdir)
     fig = SERIES.plot()
     tsplot = plot.save_figure(fig, os.path.join(base, 'test.png'))
     assert tsplot == os.path.join(base, 'test.png')
+    noneplot = plot.save_figure(fig, os.path.join('tgpflk', 'test.png'))
+    assert noneplot is None
     shutil.rmtree(base, ignore_errors=True)
 
 

--- a/gwdetchar/omega/plot.py
+++ b/gwdetchar/omega/plot.py
@@ -60,24 +60,17 @@ def _format_time_axis(ax, gps, span):
     ax.grid(True, axis='x', which='major')
 
 
-def _format_frequency_axis(ax, axis='y'):
+def _format_frequency_axis(ax):
     """Format the frequency axis of an Omega scan plot
 
     Parameters
     ----------
     ax : `~matplotlib.axis.Axis`
         the `Axis` object to format
-
-    axis : `str`
-        a string identifiying the axis to format, must be either `'x'` or `'y'`
     """
-    ax.grid(True, axis=axis, which='both')
-    if axis == 'x':
-        ax.set_xscale('log')
-        ax.set_xlabel('Frequency [Hz]')
-    else:
-        ax.set_yscale('log')
-        ax.set_ylabel('Frequency [Hz]')
+    ax.grid(True, axis='y', which='both')
+    ax.set_yscale('log')
+    ax.set_ylabel('Frequency [Hz]')
 
 
 def _format_color_axis(ax, colormap='viridis', clim=None, norm='linear'):

--- a/gwdetchar/omega/tests/test_config.py
+++ b/gwdetchar/omega/tests/test_config.py
@@ -194,9 +194,12 @@ def test_save_loudest_tile_features():
         gps=0, channel=channel, xoft=in_, resample=4096, fftlength=8)
 
     # test loudest tiles
-    channel.save_loudest_tile_features(qgram)
+    channel.save_loudest_tile_features(qgram, correlate=glitch)
     assert channel.Q == numpy.around(qgram.plane.q, 1)
     assert channel.energy == numpy.around(qgram.peak['energy'], 1)
     assert channel.snr == numpy.around(qgram.peak['snr'], 1)
     assert channel.t == numpy.around(qgram.peak['time'], 3)
     assert channel.f == numpy.around(qgram.peak['frequency'], 1)
+    assert channel.corr == numpy.around(glitch.max().value, 1)
+    assert channel.delay == 0.0
+    assert channel.stdev == glitch.std().value

--- a/gwdetchar/omega/tests/test_html.py
+++ b/gwdetchar/omega/tests/test_html.py
@@ -481,9 +481,22 @@ def test_write_block():
 # -- end-to-end tests ---------------------------------------------------------
 
 def test_write_qscan_page(tmpdir):
-    os.chdir(str(tmpdir))
-    html.write_qscan_page('L1', 0, ANALYZED, 'info')
-    shutil.rmtree(str(tmpdir), ignore_errors=True)
+    tmpdir.mkdir('about')
+    tmpdir.mkdir('data')
+    tmpdir.mkdir('plots')
+    base = str(tmpdir)
+    config = os.path.join(base, 'config.ini')
+    with open(config, 'w') as fobj:
+        fobj.write(CONFIGURATION)
+    os.chdir(base)
+    htmlv = {
+        'title': 'test',
+        'refresh': True,
+        'config': [config],
+    }
+    html.write_qscan_page('L1', 0, ANALYZED, **htmlv)
+    html.write_qscan_page('L1', 0, ANALYZED, correlated=False, **htmlv)
+    shutil.rmtree(base, ignore_errors=True)
 
 
 def test_write_null_page(tmpdir):
@@ -493,7 +506,10 @@ def test_write_null_page(tmpdir):
 
 
 def test_write_about_page(tmpdir):
-    tmpdir.mkdir('about')
-    os.chdir(str(tmpdir))
-    html.write_about_page('L1', 0, CONFIG_FILE, outdir='about')
-    shutil.rmtree(str(tmpdir), ignore_errors=True)
+    base = str(tmpdir)
+    config = os.path.join(base, 'config.ini')
+    with open(config, 'w') as fobj:
+        fobj.write(CONFIGURATION)
+    os.chdir(base)
+    html.write_about_page('L1', 0, [config], outdir='about')
+    shutil.rmtree(base, ignore_errors=True)

--- a/gwdetchar/tests/test_daq.py
+++ b/gwdetchar/tests/test_daq.py
@@ -100,12 +100,17 @@ def test_ligo_accum_overflow_channel():
 
 @mock.patch('gwdetchar.daq.find_urls')
 @mock.patch('gwdetchar.daq.get_channel_names')
-def test_ligo_model_overflow_channels(get_names, find_frames):
+@mock.patch('gwdetchar.daq._ligo_model_overflow_channels_nds')
+def test_ligo_model_overflow_channels(nds, get_names, find_frames):
     get_names.return_value = CHANNELS
 
     names = daq.ligo_model_overflow_channels(1, ifo='X1', accum=True)
     assert names == CHANNELS[1:5]
 
+    names = daq.ligo_model_overflow_channels(1, ifo='X1', accum=False)
+    assert names == CHANNELS[5:7]
+
+    nds.return_value = CHANNELS
     names = daq.ligo_model_overflow_channels(1, ifo='X1', accum=False)
     assert names == CHANNELS[5:7]
 
@@ -118,3 +123,6 @@ def test_ligo_model_overflow_channels(get_names, find_frames):
 def test_find_crossings():
     times = daq.find_crossings(OVERFLOW_SERIES, 0.1)
     assert_array_equal(times, CROSSING_TIMES)
+
+    times0 = daq.find_crossings(OVERFLOW_SERIES, 0)
+    assert_array_equal(times0, [])

--- a/gwdetchar/utils.py
+++ b/gwdetchar/utils.py
@@ -25,11 +25,9 @@ import sys
 try:  # python 3.x
     from io import StringIO
     from html.parser import HTMLParser
-    from html.entities import name2codepoint
 except:  # python 2.7
     from cStringIO import StringIO
     from HTMLParser import HTMLParser
-    from htmlentitydefs import name2codepoint
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 __credits__ = 'Alex Urban <alexander.urban@ligo.org>'
@@ -51,20 +49,6 @@ class GWHTMLParser(HTMLParser):
 
     def handle_data(self, data):
         print("Data:", data)
-
-    def handle_comment(self, data):
-        print("Comment:", data)
-
-    def handle_entityref(self, name):
-        c = chr(name2codepoint[name])
-        print("Named entity:", c)
-
-    def handle_charref(self, name):
-        if name.startswith('x'):
-            c = chr(int(name[1:], 16))
-        else:
-            c = chr(int(name))
-        print("Numeric entity:", c)
 
     def handle_decl(self, data):
         print("Decl:", data)

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,3 +23,7 @@ addopts = -r s
 source = gwdetchar
 omit =
 	gwdetchar/*version*.py
+	gwdetchar/tests/*
+	gwdetchar/io/tests/*
+	gwdetchar/lasso/tests/*
+	gwdetchar/omega/tests/*


### PR DESCRIPTION
This PR excludes unit tests from the coverage estimate in `setup.cfg`, then increases coverage to 96% by fleshing out a number of existing unit tests, and dropping some unused functionality in `gwdetchar.utils` and `gwdetchar.omega.config`.

This PR also replaces a missing import in `gwdetchar.lasso.plot` (discovered through new unit tests) and resolves a flake8 issue in `gwdetchar-lasso-correlation`.

For completeness, I've double-checked that these build tests pass in conda environments with python 2.7 and 3.6.

cc @duncanmmacleod 