### PR TITLE
Restore output directories for batch-mode omega scans

### DIFF
--- a/bin/gwdetchar-omega-batch
+++ b/bin/gwdetchar-omega-batch
@@ -195,7 +195,8 @@ if args.verbose:
 
 # make node in workflow for each time
 for t in times:
-    cmd = " ".join([str(t)] + arguments)
+    cmd = " ".join([str(t)] + [
+        "--output-directory", os.path.join(outdir, str(t))] + arguments)
     job.add_arg(cmd, name=str(t).replace(".", "_"))
 
 # write DAG


### PR DESCRIPTION
This PR fixes a bug where `gwdetchar-omega-batch` fails to pass its output directory to the `gwdetchar-omega` jobs it spawns, which has implications downstream for [**`hveto`**](https://github.com/gwdetchar/hveto/blob/master/hveto/html.py#L641-L660).

cc @duncanmmacleod, @jrsmith02