### PR TITLE
Use markup.py from MarkupPy, not glue

### DIFF
--- a/bin/gwdetchar-software-saturations
+++ b/bin/gwdetchar-software-saturations
@@ -35,7 +35,7 @@ use('agg')
 
 import gwdatafind
 
-from glue import markup
+from MarkupPy import markup
 
 from gwpy.io.cache import sieve as sieve_cache
 from gwpy.io.gwf import get_channel_names

--- a/gwdetchar/io/html.py
+++ b/gwdetchar/io/html.py
@@ -23,7 +23,7 @@ import os
 
 from six.moves import StringIO
 
-from glue import markup
+from MarkupPy import markup
 
 from ..plot import plot_segments
 

--- a/gwdetchar/omega/html.py
+++ b/gwdetchar/omega/html.py
@@ -35,7 +35,8 @@ from six.moves.urllib.parse import urlparse
 
 from pkg_resources import resource_filename
 
-from glue import markup
+from MarkupPy import markup
+
 from gwpy.table import Table
 from gwpy.time import tconvert
 from ..io.html import (JQUERY_JS, BOOTSTRAP_CSS, BOOTSTRAP_JS)
@@ -586,7 +587,7 @@ def scaffold_plots(plots, nperrow=3):
 
     Returns
     -------
-    page : `~glue.markup.page`
+    page : `~MarkupPy.markup.page`
         the markup object containing the scaffolded HTML
     """
     page = markup.page()
@@ -663,7 +664,7 @@ def write_footer(about=None, date=None):
 
     Returns
     -------
-    page : `~glue.markup.page`
+    page : `~MarkupPy.markup.page`
         the markup object containing the footer HTML
     """
     page = markup.page()
@@ -717,7 +718,7 @@ def write_summary(
 
     Returns
     -------
-    page : `~glue.markup.page`
+    page : `~MarkupPy.markup.page`
         the formatted markup object containing the analysis summary table
     """
     utc = tconvert(gpstime)
@@ -791,7 +792,7 @@ def write_ranking(toc, primary, thresh=6.5,
 
     Returns
     -------
-    page : `~glue.markup.page`
+    page : `~MarkupPy.markup.page`
         the formatted markup object containing the analysis summary table
     """
     # construct an ordered dict of channel entries
@@ -906,7 +907,7 @@ def write_block(blockkey, block, context,
 
     Returns
     -------
-    page : `~glue.markup.page`
+    page : `~MarkupPy.markup.page`
         the formatted HTML for this block
     """
     page = markup.page()

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ libsass
 lscsoft-glue >= 1.60.0
 lxml
 matplotlib >= 2.0.0
+MarkupPy >=1.14
 numpy >= 1.10
 pandas
 pycondor

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ install_requires = [
     'gwpy>=0.13.0',
     'gwtrigfind',
     'lscsoft-glue>=1.60.0',
+    'MarkupPy>=1.14',
     'matplotlib>=2.0.0',
     'numpy>=1.10',
     'pandas',


### PR DESCRIPTION
This PR modifies all relevant code to import `markup.py` from `MarkupPy`, not `glue`. The functionality is identical, and the code works just fine.

This is available in conda-forge as `markuppy`.