### PR TITLE
Set LaTeX params at runtime, rather than at the module level

### DIFF
--- a/bin/gwdetchar-mct
+++ b/bin/gwdetchar-mct
@@ -25,9 +25,6 @@ import numpy
 import os
 import sys
 
-from matplotlib import (use, rcParams)
-use('agg')
-
 import gwdatafind
 
 from glue.ligolw.utils import write_fileobj
@@ -42,7 +39,6 @@ from gwdetchar import (const, cli, cds, __version__)
 from gwdetchar.io import (ligolw, html as htmlio)
 from gwdetchar.io.datafind import get_data
 from gwdetchar.daq import find_crossings
-from gwdetchar.plot import get_gwpy_tex_settings
 
 __author__ = 'TJ Massinger <thomas.massinger@ligo.org>'
 __credits__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
@@ -82,10 +78,6 @@ else:
     statea = SegmentList([span])
 
 duration = abs(span)
-
-# set TeX settings
-tex_settings = get_gwpy_tex_settings()
-rcParams.update(tex_settings)
 
 # initialize output files for each threshold and store them in a dict
 outfiles = {}

--- a/bin/gwdetchar-overflow
+++ b/bin/gwdetchar-overflow
@@ -28,7 +28,7 @@ import sys
 
 import tqdm
 
-from matplotlib import use
+from matplotlib import (use, rcParams)
 use('agg')
 
 import gwdatafind
@@ -41,6 +41,7 @@ from gwpy.io.cache import cache_segments
 from gwpy.utils import gprint
 
 from gwdetchar import (cds, cli, const, daq, __version__)
+from gwdetchar.plot import get_gwpy_tex_settings
 from gwdetchar.io import (ligolw, html as htmlio)
 from gwdetchar.io.datafind import get_data
 
@@ -105,6 +106,10 @@ if args.ifo == 'L1':
         simulink = 'https://llocds.ligo-la.caltech.edu/daq/simulink/'
 
 span = Segment(args.gpsstart, args.gpsend)
+
+# set TeX settings
+tex_settings = get_gwpy_tex_settings()
+rcParams.update(tex_settings)
 
 # get segments
 if args.state_flag:

--- a/bin/gwdetchar-scattering
+++ b/bin/gwdetchar-scattering
@@ -53,7 +53,7 @@ from gwdetchar.plot import get_gwpy_tex_settings
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
-# update rcParams
+# TeX settings
 tex_settings = get_gwpy_tex_settings()
 rcParams.update(tex_settings)
 rcParams.update({

--- a/bin/gwdetchar-software-saturations
+++ b/bin/gwdetchar-software-saturations
@@ -30,7 +30,7 @@ except ImportError:
     from StringIO import StringIO
 
 
-from matplotlib import use
+from matplotlib import (use, rcParams)
 use('agg')
 
 import gwdatafind
@@ -43,6 +43,7 @@ from gwpy.segments import (Segment, SegmentList,
                            DataQualityFlag, DataQualityDict)
 
 from gwdetchar import (__version__, cli, const, saturation)
+from gwdetchar.plot import get_gwpy_tex_settings
 from gwdetchar.io import html as htmlio
 
 __author__ = 'Dan Hoak <daniel.hoak@ligo.org>'
@@ -80,6 +81,10 @@ args = parser.parse_args()
 ifo = args.ifo.upper()
 site = ifo[0]
 frametype = args.frametype or '%s_R' % ifo
+
+# set TeX settings
+tex_settings = get_gwpy_tex_settings()
+rcParams.update(tex_settings)
 
 # get segments
 span = Segment(args.gpsstart, args.gpsend)

--- a/gwdetchar/plot.py
+++ b/gwdetchar/plot.py
@@ -56,11 +56,6 @@ def get_gwpy_tex_settings():
     return params
 
 
-# TeX settings
-tex_settings = get_gwpy_tex_settings()
-rcParams.update(tex_settings)
-
-
 # -- plotting utilities -------------------------------------------------------
 
 def plot_segments(flag, span, facecolor='red', edgecolor='darkred',


### PR DESCRIPTION
There was a bug in omega scan plots where rendering was done with LaTeX because TeX params were set in `gwdetchar.plot` and then imported by `gwdetchar.omega.html`. This PR corrects that by (reverting to) handling all TeX settings in scripts at runtime, rather than at the module level.

cc @duncanmmacleod 