### PR TITLE
Rearranging HTML for overflows and software saturations

### DIFF
--- a/bin/gwdetchar-overflow
+++ b/bin/gwdetchar-overflow
@@ -285,7 +285,8 @@ if args.html:
         page.add(str(htmlio.write_flag_html(
             state, span, 'state', parent='accordion1', context='success',
             plotdir=args.plot, facecolor=(0.2, 0.8, 0.2),
-            edgecolor='darkgreen')))
+            edgecolor='darkgreen', known={
+                'facecolor': 'red', 'edgecolor': 'darkred', 'height': 0.4})))
         page.div.close()
     # print overflow segments
     if sum(abs(s.active) for s in overflows.values()):

--- a/bin/gwdetchar-overflow
+++ b/bin/gwdetchar-overflow
@@ -283,7 +283,9 @@ if args.html:
         page.p('This analysis was executed over the following segments:')
         page.div(class_='panel-group', id_='accordion1')
         page.add(str(htmlio.write_flag_html(
-            state, span, 'state', parent='accordion1', context='success')))
+            state, span, 'state', parent='accordion1', context='success',
+            plotdir=args.plot, facecolor=(0.2, 0.8, 0.2),
+            edgecolor='darkgreen')))
         page.div.close()
     # print overflow segments
     if sum(abs(s.active) for s in overflows.values()):

--- a/bin/gwdetchar-overflow
+++ b/bin/gwdetchar-overflow
@@ -252,6 +252,23 @@ if args.html:
                "card/slot-specific channels were then checked.")
     page.div.close()
 
+    # -- paramters
+    page.h2('Parameters')
+    page.p('This analysis used the following parameters:')
+    page.add(htmlio.write_param('Start time', args.gpsstart))
+    page.add(htmlio.write_param('End time', args.gpsend))
+    page.add(htmlio.write_param('State flag', args.state_flag))
+    page.add(htmlio.write_param('DCUIDs', ' '.join(map(str, args.dcuid))))
+    if fec_map:
+        page.add(htmlio.write_param(
+            'FEC map', '<a href="{0}" target="_blank" title="{1} FEC '
+                       'map">{0}</a>'.format(fec_map, args.ifo)))
+    if simulink:
+        page.add(htmlio.write_param(
+            'Simulink models', '<a href="{0}" target="_blank" '
+                               'title="{1} Simulink models">{0}</a>'.format(
+                                   simulink, args.ifo)))
+
     # -- segments
     page.h2('Segments')
     # link XML file
@@ -324,26 +341,6 @@ if args.html:
         page.tr.close()
     page.tbody.close()
     page.table.close()
-
-    # -- paramters
-    page.h2('Parameters')
-    page.p('This analysis used the following parameters:')
-    page.add(htmlio.write_param('Start time', args.gpsstart))
-    page.add(htmlio.write_param('End time', args.gpsend))
-    page.add(htmlio.write_param('State flag', args.state_flag))
-    page.add(htmlio.write_param('DCUIDs', ' '.join(map(str, args.dcuid))))
-
-    if (fec_map or simulink):
-        page.h2('Links')
-    if fec_map:
-        page.add(htmlio.write_param(
-            'FEC map', '<a href="{0}" target="_blank" title="{1} FEC '
-                       'map">{0}</a>'.format(fec_map, args.ifo)))
-    if simulink:
-        page.add(htmlio.write_param(
-            'Simulink models', '<a href="{0}" target="_blank" '
-                               'title="{1} Simulink models">{0}</a>'.format(
-                                   simulink, args.ifo)))
 
     # -- close and write
     page.div.close()

--- a/bin/gwdetchar-scattering
+++ b/bin/gwdetchar-scattering
@@ -227,8 +227,9 @@ page.p.close()
 if args.state_flag:
     page.p('This analysis was executed over the following segments:')
     page.div(class_='panel-group', id_='accordion1')
-    page.add(str(htmlio.write_flag_html(state, 'state', parent='accordion1',
-                                        context='success', id='state')))
+    page.add(str(htmlio.write_flag_html(
+        state, span, 'state', parent='accordion1', context='success',
+        plotdir='./', facecolor=(0.2, 0.8, 0.2), edgecolor='darkgreen')))
     page.div.close()
 
 page.p("The following channels were searched for evidence of scattering "

--- a/bin/gwdetchar-scattering
+++ b/bin/gwdetchar-scattering
@@ -229,7 +229,8 @@ if args.state_flag:
     page.div(class_='panel-group', id_='accordion1')
     page.add(str(htmlio.write_flag_html(
         state, span, 'state', parent='accordion1', context='success',
-        plotdir='./', facecolor=(0.2, 0.8, 0.2), edgecolor='darkgreen')))
+        plotdir='', facecolor=(0.2, 0.8, 0.2), edgecolor='darkgreen',
+        known={'facecolor': 'red', 'edgecolor': 'darkred', 'height': 0.4})))
     page.div.close()
 
 page.p("The following channels were searched for evidence of scattering "
@@ -312,9 +313,9 @@ for i, channel in enumerate(sorted(allchannels)):
             scatter.active = scatter.active.protract(args.segment_padding)
             scatter.coalesce()
         axes['segments'].plot(scatter, facecolor='red', edgecolor='darkred',
-                              known={'alpha': 0.2, 'facecolor': 'lightgray',
-                                     'edgecolor': 'gray'},
-                              y=0, label=' ')
+                              known={'alpha': 0.6, 'facecolor': 'lightgray',
+                                     'edgecolor': 'gray', 'height': 0.4},
+                              height=0.8, y=0, label=' ')
         scatter_segments[channel] += scatter
         if args.verbose:
             gprint("    Found %d scattering segments" % (len(scatter.active)))

--- a/bin/gwdetchar-slow-correlation
+++ b/bin/gwdetchar-slow-correlation
@@ -374,6 +374,20 @@ page.p("This analysis searched %d channels for linear correlations with %s"
        % (nchan, pstr))
 page.div.close()
 
+# run parameters
+page.h2('Parameters')
+page.p('This analysis used the following parameters:')
+page.add(htmlio.write_param(
+    'Start time', '%s (%d)' % (from_gps(start), start)))
+page.add(htmlio.write_param('End time', '%s (%d)' % (from_gps(end), end)))
+page.add(htmlio.write_param(
+    'Primary channel',
+    '%s (%s)' % (primary, args.primary_frametype.format(ifo=args.ifo))))
+page.add(htmlio.write_param(
+    'Range channel',
+    '%s (%s)' % (rangechannel, args.range_frametype or '-')))
+page.add(htmlio.write_param('Band-pass', '%s-%s' % (flower, fupper)))
+
 # results
 page.h2('Results')
 r_blrms = "<i>r<sub>blrms</sub> </i>"
@@ -464,19 +478,6 @@ for i, (ch, corr1, corr2, plot1, plot2, plot3,
     page.div.close()  # panel-collapse
     page.div.close()  # panel
 page.div.close()  # panel-group
-
-page.h2('Parameters')
-page.p('This analysis used the following parameters:')
-page.add(htmlio.write_param(
-    'Start time', '%s (%d)' % (from_gps(start), start)))
-page.add(htmlio.write_param('End time', '%s (%d)' % (from_gps(end), end)))
-page.add(htmlio.write_param(
-    'Primary channel',
-    '%s (%s)' % (primary, args.primary_frametype.format(ifo=args.ifo))))
-page.add(htmlio.write_param(
-    'Range channel',
-    '%s (%s)' % (rangechannel, args.range_frametype or '-')))
-page.add(htmlio.write_param('Band-pass', '%s-%s' % (flower, fupper)))
 
 page.div.close()  # container
 with open('index.html', 'w') as f:

--- a/bin/gwdetchar-software-saturations
+++ b/bin/gwdetchar-software-saturations
@@ -240,7 +240,8 @@ if args.html:
         page.add(str(htmlio.write_flag_html(
             state, span, 'state', parent='accordion1', context='success',
             plotdir=args.plot, facecolor=(0.2, 0.8, 0.2),
-            edgecolor='darkgreen')))
+            edgecolor='darkgreen', known={
+                'facecolor': 'red', 'edgecolor': 'darkred', 'height': 0.4})))
         page.div.close()
     # print saturation segments
     if len(bad):

--- a/bin/gwdetchar-software-saturations
+++ b/bin/gwdetchar-software-saturations
@@ -238,7 +238,9 @@ if args.html:
         page.p('This analysis was executed over the following segments:')
         page.div(class_='panel-group', id_='accordion1')
         page.add(str(htmlio.write_flag_html(
-            state, id='state', parent='accordion1', context='success')))
+            state, span, 'state', parent='accordion1', context='success',
+            plotdir=args.plot, facecolor=(0.2, 0.8, 0.2),
+            edgecolor='darkgreen')))
         page.div.close()
     # print saturation segments
     if len(bad):

--- a/bin/gwdetchar-software-saturations
+++ b/bin/gwdetchar-software-saturations
@@ -218,6 +218,14 @@ if args.html:
            "are included in the Results summary and the output file."
            % sum(map(len, channels)))
     page.div.close()
+    # -- paramters
+    page.h2('Parameters')
+    page.p('This analysis used the following parameters:')
+    page.add(htmlio.write_param('Start time', args.gpsstart))
+    page.add(htmlio.write_param('End time', args.gpsend))
+    page.add(htmlio.write_param('State flag', args.state_flag))
+    page.add(htmlio.write_param('State end padding', args.pad_state_end))
+    page.add(htmlio.write_param('Skip', ', '.join(map(repr, args.skip))))
     # -- segments
     page.h2('Segments')
     # link output file
@@ -267,14 +275,6 @@ if args.html:
         page.tr.close()
     page.tbody.close()
     page.table.close()
-    # -- paramters
-    page.h2('Parameters')
-    page.p('This analysis used the following parameters:')
-    page.add(htmlio.write_param('Start time', args.gpsstart))
-    page.add(htmlio.write_param('End time', args.gpsend))
-    page.add(htmlio.write_param('State flag', args.state_flag))
-    page.add(htmlio.write_param('State end padding', args.pad_state_end))
-    page.add(htmlio.write_param('Skip', ', '.join(map(repr, args.skip))))
     # close and write
     page.div.close()
     with open(args.html, 'w') as fp:

--- a/gwdetchar/io/html.py
+++ b/gwdetchar/io/html.py
@@ -83,15 +83,7 @@ def write_flag_html(flag, span=None, id=0, parent='accordion',
     page.div.close()
     page.div(id_='flag%s' % id, class_='panel-collapse collapse')
     page.div(class_='panel-body')
-    segs = StringIO()
-    try:
-        flag.active.write(segs, format='segwizard',
-                          coltype=type(flag.active[0][0]))
-    except IndexError:
-        page.p("No segments were found.")
-    else:
-        page.pre(segs.getvalue())
-    page.div.close()
+    # render segment plot
     if plotdir is not None and plot_func is not None:
         flagr = flag.name.replace('-', '_').replace(':', '-', 1)
         png = os.path.join(
@@ -102,6 +94,16 @@ def write_flag_html(flag, span=None, id=0, parent='accordion',
         page.a(href=png, target='_blank')
         page.img(style="width: 100%;", src=png)
         page.a.close()
+    # write segments
+    segs = StringIO()
+    try:
+        flag.active.write(segs, format='segwizard',
+                          coltype=type(flag.active[0][0]))
+    except IndexError:
+        page.p("No segments were found.")
+    else:
+        page.pre(segs.getvalue())
+    page.div.close()
     page.div.close()
     page.div.close()
     return page

--- a/gwdetchar/io/html.py
+++ b/gwdetchar/io/html.py
@@ -70,7 +70,7 @@ def write_param(param, value):
 
 def write_flag_html(flag, span=None, id=0, parent='accordion',
                     context='warning', title=None, plotdir=None,
-                    plot_func=plot_segments):
+                    plot_func=plot_segments, **kwargs):
     """Write HTML for data quality flags
     """
     page = markup.page()
@@ -88,7 +88,7 @@ def write_flag_html(flag, span=None, id=0, parent='accordion',
         flagr = flag.name.replace('-', '_').replace(':', '-', 1)
         png = os.path.join(
             plotdir, '%s-%d-%d.png' % (flagr, span[0], abs(span)))
-        plot = plot_func(flag, span)
+        plot = plot_func(flag, span, **kwargs)
         plot.save(png)
         plot.close()
         page.a(href=png, target='_blank')

--- a/gwdetchar/io/tests/test_html.py
+++ b/gwdetchar/io/tests/test_html.py
@@ -58,9 +58,9 @@ FLAG_CONTENT = """<div class="panel panel-warning">
 <a class="panel-title" href="#flag0" data-toggle="collapse" data-parent="#accordion">X1:TEST_FLAG</a>
 </div>
 <div id="flag0" class="panel-collapse collapse">
-<div class="panel-body">
+<div class="panel-body">{plots}
 {content}
-</div>{plots}
+</div>
 </div>
 </div>"""  # nopep8
 

--- a/gwdetchar/plot.py
+++ b/gwdetchar/plot.py
@@ -58,17 +58,16 @@ def get_gwpy_tex_settings():
 
 # -- plotting utilities -------------------------------------------------------
 
-def plot_segments(flag, span, facecolor='red', edgecolor='darkred',
-                  known={'alpha': 0.2, 'facecolor': 'lightgray',
-                         'edgecolor': 'gray'}):
+def plot_segments(flag, span, facecolor='red', edgecolor='darkred', height=0.8,
+                  known={'alpha': 0.6, 'facecolor': 'lightgray',
+                         'edgecolor': 'gray', 'height': 0.4}):
     """Plot the saturation segments contained within a flag
     """
     name = flag.texname if rcParams["text.usetex"] else flag.name
     plot = flag.plot(
         figsize=[12, 2], facecolor=facecolor, edgecolor=edgecolor,
-        known=known, label=' ',
-        xlim=span, xscale='auto-gps', epoch=span[0],
-        title="{} segments".format(name),
+        height=height, known=known, label=' ', xlim=span, xscale='auto-gps',
+        epoch=span[0], title="{} segments".format(name),
     )
     plot.subplots_adjust(bottom=0.4, top=0.8)
     return plot


### PR DESCRIPTION
This PR makes the following changes:

* Re-order `gwdetchar.io.html.write_segments_html` so that for each expandable accordion, plots come first, and then segments
* Plot state flag segments, e.g. `DMT-GRD_ISC_LOCK_NOMINAL` (including in `gwdetchar-scattering`), and tweak the appearance of segment plots so that the `known` segments are smaller in height than the `active` segments
* Place run parameters above full results, so that they aren't buried all the way at the bottom
* Update unit tests for `gwdetchar.io.html`

Example output is available here, with comparisons against the version currently in production:

Tool | Production output | Test output (with changes)
-- | -- | --
`gwdetchar-overflow` | [**Link**](https://ldas-jobs.ligo-la.caltech.edu/~detchar/overflows/day/20190308/) | [**Link**](https://ldas-jobs.ligo-la.caltech.edu/~aurban/overflows/day/20190308/)
`gwdetchar-software-saturations` | [**Link**](https://ldas-jobs.ligo-la.caltech.edu/~detchar/software-saturations/day/20190309/) | [**Link**](https://ldas-jobs.ligo-la.caltech.edu/~aurban/software-saturations/day/20190309/)
`gwdetchar-scattering` | [**Link**](https://ldas-jobs.ligo-la.caltech.edu/~detchar/scattering/day/20190302/) | [**Link**](https://ldas-jobs.ligo-la.caltech.edu/~aurban/scattering/day/20190302/)

This was requested by @jrsmith02 and @tjma12, and is related to #253.

cc @duncanmmacleod 