### PR TITLE
Stamp every script's output with an HTML footer

### DIFF
--- a/bin/gwdetchar-lasso-correlation
+++ b/bin/gwdetchar-lasso-correlation
@@ -632,11 +632,14 @@ page.add(htmlio.write_param(
     'Lasso coefficient threshold', '%g' % args.threshold))
 page.add(htmlio.write_param(
     'Sigma for outlier removal', '%g' % args.remove_outliers))
-page.add(htmlio.write_param('Cluster coefficient threshold: ',
+page.add(htmlio.write_param('Cluster coefficient threshold',
                             '%g' % args.cluster_coefficient))
 if args.band_pass:
     page.add(htmlio.write_param(
         'Filter settings', 'Flow=%dHz, Fhigh=%dHz ' % (flower, fupper)))
+page.add(htmlio.write_param('Command line', ''))
+page.add(htmlio.get_command_line())
+
 page.h2('Model Information')
 
 page.div(class_='model')
@@ -652,6 +655,7 @@ page.add(htmlio.write_param(
     '%d (%s)' % (len(zeroed),
                  "<a href= %s target='_blank'>zeroed channel list</a>"
                  % (zerofile))))
+
 page.div(class_='results-table', align='center')
 page.p('<br /><br />%s' % style_table(df.to_html(
     index=True,
@@ -789,6 +793,7 @@ for i, (ch, lassocoef, plot4, plot5, plot6, ts) in enumerate(results):
     page.div.close()  # panel-collapse
     page.div.close()  # panel
 page.div.close()  # panel-group
+page.add(htmlio.write_footer())
 page.div.close()  # container
 with open('index.html', 'w') as f:
     print(str(page), file=f)

--- a/bin/gwdetchar-overflow
+++ b/bin/gwdetchar-overflow
@@ -268,6 +268,8 @@ if args.html:
             'Simulink models', '<a href="{0}" target="_blank" '
                                'title="{1} Simulink models">{0}</a>'.format(
                                    simulink, args.ifo)))
+    page.add(htmlio.write_param('Command line', ''))                                
+    page.add(htmlio.get_command_line())
 
     # -- segments
     page.h2('Segments')
@@ -346,6 +348,7 @@ if args.html:
     page.table.close()
 
     # -- close and write
+    page.add(htmlio.write_footer())
     page.div.close()
     with open(args.html, 'w') as fp:
         print(str(page), file=fp)

--- a/bin/gwdetchar-scattering
+++ b/bin/gwdetchar-scattering
@@ -216,6 +216,8 @@ page.p("This analysis searched for evidence of beam scattering based on the "
        "velocity of optic motion. The fringe frequency is predicted using "
        "equation (3) of <a href=\"http://iopscience.iop.org/article/10.1088/"
        "0264-9381/27/19/194011\" target=\"_blank\">Accadia et al. (2010)</a>.")
+page.p("This analysis was done with the following command line call:")
+page.add(htmlio.get_command_line()) 
 page.div.close()
 
 # link segments file
@@ -507,6 +509,7 @@ if args.verbose:
     gprint("%s written" % segfile)
 
 # write HTML
+page.add(htmlio.write_footer())
 page.div.close()
 with open('index.html', 'w') as fp:
     fp.write(str(page))

--- a/bin/gwdetchar-slow-correlation
+++ b/bin/gwdetchar-slow-correlation
@@ -387,6 +387,8 @@ page.add(htmlio.write_param(
     'Range channel',
     '%s (%s)' % (rangechannel, args.range_frametype or '-')))
 page.add(htmlio.write_param('Band-pass', '%s-%s' % (flower, fupper)))
+page.add(htmlio.write_param('Command line', ''))                                
+page.add(htmlio.get_command_line())
 
 # results
 page.h2('Results')
@@ -479,6 +481,7 @@ for i, (ch, corr1, corr2, plot1, plot2, plot3,
     page.div.close()  # panel
 page.div.close()  # panel-group
 
+page.add(htmlio.write_footer())
 page.div.close()  # container
 with open('index.html', 'w') as f:
     print(str(page), file=f)

--- a/bin/gwdetchar-software-saturations
+++ b/bin/gwdetchar-software-saturations
@@ -226,6 +226,8 @@ if args.html:
     page.add(htmlio.write_param('State flag', args.state_flag))
     page.add(htmlio.write_param('State end padding', args.pad_state_end))
     page.add(htmlio.write_param('Skip', ', '.join(map(repr, args.skip))))
+    page.add(htmlio.write_param('Command line', ''))                            
+    page.add(htmlio.get_command_line())
     # -- segments
     page.h2('Segments')
     # link output file
@@ -279,6 +281,7 @@ if args.html:
     page.tbody.close()
     page.table.close()
     # close and write
+    page.add(htmlio.write_footer())
     page.div.close()
     with open(args.html, 'w') as fp:
         print(str(page), file=fp)

--- a/gwdetchar/io/tests/test_html.py
+++ b/gwdetchar/io/tests/test_html.py
@@ -21,6 +21,8 @@
 
 import os
 import shutil
+import datetime
+from getpass import getuser
 
 import pytest
 
@@ -35,6 +37,7 @@ except ImportError:  # python 2.7
 from gwpy.segments import (Segment, DataQualityFlag)
 
 from .. import html
+from ..._version import get_versions
 from ...utils import parse_html
 
 __author__ = 'Alex Urban <alexander.urban@ligo.org>'
@@ -42,9 +45,13 @@ __author__ = 'Alex Urban <alexander.urban@ligo.org>'
 
 # global test objects
 
+VERSION = get_versions()['version']
+COMMIT = get_versions()['full-revisionid']
+
 NEW_BOOTSTRAP_PAGE = """<!DOCTYPE HTML PUBLIC \'-//W3C//DTD HTML 4.01 Transitional//EN\'>
 <html lang="en">
 <head>
+<meta content="width=device-width, initial-scale=1.0" name="viewport" />
 <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css" rel="stylesheet" type="text/css" media="all" />
 <script src="https://code.jquery.com/jquery-1.11.2.min.js" type="text/javascript"></script>
 <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js" type="text/javascript"></script>
@@ -52,6 +59,16 @@ NEW_BOOTSTRAP_PAGE = """<!DOCTYPE HTML PUBLIC \'-//W3C//DTD HTML 4.01 Transition
 <body>
 </body>
 </html>"""  # nopep8
+
+HTML_FOOTER = """<footer class="footer">
+<div class="container">
+<div class="row">
+<div class="col-md-12">
+<p>These results were obtained using <a style="color:#000;" href="https://github.com/gwdetchar/gwdetchar/tree/%s" target="_blank">gwdetchar version %s</a> by {user} at {date}.</p>
+</div>
+</div>
+</div>
+</footer>""" % (COMMIT, VERSION)  # nopep8
 
 FLAG_CONTENT = """<div class="panel panel-warning">
 <div class="panel-heading">
@@ -92,6 +109,13 @@ def test_write_param():
     assert parse_html(str(page)) == parse_html(
         '<p>\n<strong>test: </strong>\ntest\n</p>'
     )
+
+
+def test_write_footer():
+    date = datetime.datetime.now()
+    out = html.write_footer(date=date, class_=True)
+    assert parse_html(str(out)) == parse_html(
+        HTML_FOOTER.format(user=getuser(), date=date))
 
 
 def test_write_flag_html():

--- a/gwdetchar/omega/tests/test_html.py
+++ b/gwdetchar/omega/tests/test_html.py
@@ -112,7 +112,8 @@ Links <b class="caret"></b>
 </body>
 </html>"""  # nopep8
 
-HTML_FOOTER = """<footer class="footer">
+HTML_CLOSE = """</div>
+<footer class="footer">
 <div class="container">
 <div class="row">
 <div class="col-md-12">
@@ -120,12 +121,9 @@ HTML_FOOTER = """<footer class="footer">
 </div>
 </div>
 </div>
-</footer>""" % (COMMIT, VERSION)  # nopep8
-
-HTML_CLOSE = """</div>
-%s
+</footer>
 </body>
-</html>""" % HTML_FOOTER
+</html>""" % (COMMIT, VERSION)  # nopep8
 
 CONFIGURATION = u"""
 [primary]
@@ -406,13 +404,6 @@ def test_write_summary_table(tmpdir):
     os.chdir(wdir)
     html.write_summary_table(ANALYZED, correlated=True)
     shutil.rmtree(wdir)
-
-
-def test_write_footer():
-    date = datetime.datetime.now()
-    out = html.write_footer(date=date)
-    assert parse_html(str(out)) == parse_html(
-        HTML_FOOTER.format(user=getuser(), date=date))
 
 
 def test_write_summary():


### PR DESCRIPTION
This PR stamps every script's output with an HTML footer indicating the package version, user, and date of runtime. It also includes a few related changes:

* Show the command line used to generate all HTML output
* Refactor `write_footer` into the common `io.html` module
* Move the unit test for `write_footer` into `io.html.tests`
* Refactor syntax highlighting into utilities in `gwdetchar.io.html` and provide unit tests
* Ensure nice formatting on mobile screens for all HTML
* Remove a few unused imports

Below is a matrix of test output with these changes, all done in an environment with python-2.7.

Tool | Link
-- | --
`gwdetchar-overflow` | [**Link**](https://ldas-jobs.ligo-la.caltech.edu/~aurban/overflows/day/20190310/)
`gwdetchar-software-saturations` | [**Link**](https://ldas-jobs.ligo-la.caltech.edu/~aurban/software-saturations/day/20190310/)
`gwdetchar-scattering` | [**Link**](https://ldas-jobs.ligo-la.caltech.edu/~aurban/scattering/day/20190310/)
`gwdetchar-lasso-correlation` | [**Link**](https://ldas-jobs.ligo-la.caltech.edu/~aurban/lasso/day/20190302/)
`gwdetchar-omega` | [**Link**](https://ldas-jobs.ligo-la.caltech.edu/~aurban/pyomega-test/Network_170817/)

This fixes #56.

cc @duncanmmacleod, @tjma12, @macedo22, @uberpye, @olipatane, @jrsmith02