### PR TITLE
Moved finalize_static_urls function upstream to io.html

### DIFF
--- a/bin/wdq-batch
+++ b/bin/wdq-batch
@@ -1,8 +1,11 @@
 #!/usr/bin/env python
 
 import warnings
-import pathlib
 import runpy
+try:
+    import pathlib
+except ImportError:  # python < 3
+    import pathlib2 as pathlib
 
 this = pathlib.Path(__file__)
 

--- a/gwdetchar/io/html.py
+++ b/gwdetchar/io/html.py
@@ -23,8 +23,13 @@ import os
 import sys
 import datetime
 from getpass import getuser
-from pathlib import Path
 from shutil import copyfile
+try:
+    from pathlib2 import Path
+except ImportError:  # python >= 3.6
+    # NOTE: we do it this was around because pathlib exists for py35,
+    #       but doesn't work very well
+    from pathlib import Path
 
 from six.moves import StringIO
 from six.moves.urllib.parse import urlparse

--- a/gwdetchar/io/tests/test_html.py
+++ b/gwdetchar/io/tests/test_html.py
@@ -53,7 +53,7 @@ NEW_BOOTSTRAP_PAGE = """<!DOCTYPE HTML PUBLIC \'-//W3C//DTD HTML 4.01 Transition
 <head>
 <meta content="width=device-width, initial-scale=1.0" name="viewport" />
 <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css" rel="stylesheet" type="text/css" media="all" />
-<script src="https://code.jquery.com/jquery-1.11.2.min.js" type="text/javascript"></script>
+<script src="https://code.jquery.com/jquery-1.12.3.min.js" type="text/javascript"></script>
 <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js" type="text/javascript"></script>
 </head>
 <body>

--- a/gwdetchar/io/tests/test_html.py
+++ b/gwdetchar/io/tests/test_html.py
@@ -99,6 +99,26 @@ FLAG = DataQualityFlag(known=[(0, 66)], active=[(0, 66)], name='X1:TEST_FLAG')
 
 # -- HTML unit tests ----------------------------------------------------------
 
+def test_finalize_static_urls(tmpdir):
+    static = os.path.join(str(tmpdir), 'static')
+    css, js = html.finalize_static_urls(static, html.CSS_FILES, html.JS_FILES)
+    assert css == [
+        'https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/'
+            'bootstrap.min.css',  # nopep8
+        'https://cdnjs.cloudflare.com/ajax/libs/fancybox/2.1.5/'
+            'jquery.fancybox.min.css',  # nopep8
+        'static/bootstrap-ligo.min.css']
+    assert js == [
+        'https://code.jquery.com/jquery-1.12.3.min.js',
+        'https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.13.0/'
+            'moment.min.js',  # nopep8
+        'https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js',
+        'https://cdnjs.cloudflare.com/ajax/libs/fancybox/2.1.5/'
+            'jquery.fancybox.min.js',  # nopep8
+        'static/bootstrap-ligo.min.js']
+    shutil.rmtree(str(tmpdir), ignore_errors=True)
+
+
 def test_new_bootstrap_page():
     page = html.new_bootstrap_page()
     assert parse_html(str(page)) == parse_html(NEW_BOOTSTRAP_PAGE)

--- a/gwdetchar/omega/tests/test_html.py
+++ b/gwdetchar/omega/tests/test_html.py
@@ -280,28 +280,6 @@ def test_fancy_plot():
     assert test.caption is 'test.png'
 
 
-def test_finalize_static_urls(tmpdir):
-    static = os.path.join(str(tmpdir), 'static')
-    css, js = html.finalize_static_urls(static, html.CSS_FILES, html.JS_FILES)
-    assert css == [
-        'https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/'
-            'bootstrap.min.css',  # nopep8
-        'https://cdnjs.cloudflare.com/ajax/libs/fancybox/2.1.5/'
-            'jquery.fancybox.min.css',  # nopep8
-        'static/bootstrap-ligo.min.css',
-        'static/gwdetchar-omega.min.css']
-    assert js == [
-        'https://code.jquery.com/jquery-1.12.3.min.js',
-        'https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.13.0/'
-            'moment.min.js',  # nopep8
-        'https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js',
-        'https://cdnjs.cloudflare.com/ajax/libs/fancybox/2.1.5/'
-            'jquery.fancybox.min.js',  # nopep8
-        'static/bootstrap-ligo.min.js',
-        'static/gwdetchar-omega.min.js']
-    shutil.rmtree(str(tmpdir), ignore_errors=True)
-
-
 def test_init_page(tmpdir):
     base = str(tmpdir)
     os.chdir(base)

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ scikit-learn
 scipy >= 1.2.0
 setuptools
 six
-pathlib ; python_version < '3'
+pathlib2 ; python_version < '3.6'
 pygments
 # testing
 pytest

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ install_requires = [
     'scipy>=1.2.0',
     'setuptools',
     'six',
-    'pathlib ; python_version < \'3\'',
+    'pathlib2 ; python_version < \'3.6\'',
     'pygments',
 ]
 


### PR DESCRIPTION
This PR moves the `gwdetchar.omega.html.finalize_static_urls` function upstream into `gwdetchar.io.html`, mainly so that it can be used by other tools without muddying the namespaces.