### PR TITLE
Misc. formatting enhancements for omega scans

### DIFF
--- a/bin/gwdetchar-omega
+++ b/bin/gwdetchar-omega
@@ -208,9 +208,9 @@ for block in blocks.values():
     # check that analysis flag is active for all of `duration`
     if block.flag and (not args.ignore_state_flags):
         if args.verbose:
-            print('  -- Querying state flag {}'.format(block.flag))
+            print('    Querying state flag {}'.format(block.flag))
         if not check_flag(block.flag, gps, duration, pad=1):
-            print('  -- {} not active, skipping block'.format(block.flag))
+            print('    {} not active, skipping block'.format(block.flag))
             continue
     # read in `duration` seconds of data centered on gps
     start = gps - duration/2. - 1
@@ -222,24 +222,26 @@ for block in blocks.values():
     # scan individual channels
     for channel in block.channels:
         try:
-            print('  -- Scanning channel {}'.format(channel.name))
+            print('    Scanning channel {}'.format(channel.name))
             series = omega.scan(
                 gps, channel, data[channel.name].astype('float64'), fftlength,
                 resample=block.resample, fthresh=args.far_threshold,
                 search=block.search)
         except Exception:
             traceback.print_exc()
-            print('  -- Problem encountered, skipping {}'.format(channel.name))
+            print('    Problem encountered, skipping {}'.format(channel.name))
             continue
 
         if series is None:
+            print('    Channel not significant at white noise false alarm '
+                  'rate {} Hz'.format(fthresh))
             continue  # channel is insignificant, skip it
 
-        print('  -- Plotting omega scan products for {}'.format(channel.name))
+        print('    Plotting omega scan products for {}'.format(channel.name))
         plot.write_qscan_plots(gps, channel, series, colormap=args.colormap)
 
         if correlate is not None:
-            print('  -- Cross-correlating {}'.format(channel.name))
+            print('    Cross-correlating {}'.format(channel.name))
             correlation = omega.cross_correlate(series[2], correlate)
             channel.save_loudest_tile_features(
                 series[3], correlation, gps=gps, dt=block.dt)

--- a/bin/gwdetchar-omega
+++ b/bin/gwdetchar-omega
@@ -89,6 +89,10 @@ parser.add_argument('-t', '--far-threshold', type=float, default=3.171e-8,
 parser.add_argument('-c', '--colormap', default='viridis',
                     help='name of colormap to use, default: %(default)s')
 cli.add_nproc_option(parser)
+parser.add_argument('-n', '--no-checkpoint', action='store_true',
+                    default=False,
+                    help='ignore condor checkpointing and start this analysis '
+                         'from scratch, default: False')
 
 args = parser.parse_args()
 

--- a/bin/gwdetchar-omega
+++ b/bin/gwdetchar-omega
@@ -89,10 +89,6 @@ parser.add_argument('-t', '--far-threshold', type=float, default=3.171e-8,
 parser.add_argument('-c', '--colormap', default='viridis',
                     help='name of colormap to use, default: %(default)s')
 cli.add_nproc_option(parser)
-parser.add_argument('-n', '--ignore-checkpoint', action='store_true',
-                    default=False,
-                    help='ignore condor checkpointing and start this analysis '
-                         'from scratch, default: False')
 
 args = parser.parse_args()
 

--- a/bin/gwdetchar-omega
+++ b/bin/gwdetchar-omega
@@ -113,7 +113,7 @@ args.config_file = [os.path.abspath(f) for f in args.config_file]
 if args.verbose:
     print('Parsing the following configuration files:')
     for fname in args.config_file:
-        print(' '.join(['  --', fname]))
+        print(''.join(['    ', fname]))
 cp = config.OmegaConfigParser(ifo=ifo)
 cp.read(args.config_file)
 

--- a/bin/gwdetchar-omega
+++ b/bin/gwdetchar-omega
@@ -101,7 +101,7 @@ else:
     ifo = 'Network'
 gps = numpy.around(float(args.gpstime), 3)
 
-print("----------------------------------------------\n"
+print("---------------------------------------------------------------------\n"
       "Creating {} omega scan at GPS second {}".format(ifo, gps))
 
 # get default configuration
@@ -141,7 +141,7 @@ else:
 
 # prepare html variables
 htmlv = {
-    'title': '%s Qscan | %s' % (ifo, gps),
+    'title': '{} Qscan | {}'.format(ifo, gps),
     'config': args.config_file,
     'refresh': True,
 }
@@ -177,7 +177,7 @@ print('Launching omega scans')
 
 # construct a matched-filter from primary channel
 if not args.disable_correlation:
-    print('Processing primary channel')
+    print('\nProcessing primary channel')
     duration = primary.duration
     fftlength = primary.fftlength
     # process `duration` seconds of data centered on gps
@@ -186,7 +186,7 @@ if not args.disable_correlation:
     end = gps + duration/2. + 1
     correlate = get_data(
         name, start, end, frametype=primary.frametype, source=primary.source,
-        nproc=args.nproc, verbose=args.verbose)
+        nproc=args.nproc, verbose='Reading primary: ')
     correlate = omega.primary(
         gps, primary.length, correlate, fftlength, resample=primary.resample,
         f_low=primary.flow)
@@ -200,7 +200,7 @@ else:
 
 # range over channel blocks
 for block in blocks.values():
-    print('Processing block %s' % block.key)
+    print('\nProcessing block {}'.format(block.key))
     chans = [c.name for c in block.channels]
     # get configuration
     duration = block.duration
@@ -217,7 +217,7 @@ for block in blocks.values():
     end = gps + duration/2. + 1
     data = get_data(
         chans, start, end, frametype=block.frametype, source=block.source,
-        nproc=args.nproc, verbose=args.verbose)
+        nproc=args.nproc, verbose='Reading block: ')
 
     # scan individual channels
     for channel in block.channels:

--- a/bin/gwdetchar-omega
+++ b/bin/gwdetchar-omega
@@ -89,7 +89,7 @@ parser.add_argument('-t', '--far-threshold', type=float, default=3.171e-8,
 parser.add_argument('-c', '--colormap', default='viridis',
                     help='name of colormap to use, default: %(default)s')
 cli.add_nproc_option(parser)
-parser.add_argument('-n', '--no-checkpoint', action='store_true',
+parser.add_argument('-n', '--ignore-checkpoint', action='store_true',
                     default=False,
                     help='ignore condor checkpointing and start this analysis '
                          'from scratch, default: False')

--- a/bin/gwdetchar-omega
+++ b/bin/gwdetchar-omega
@@ -102,7 +102,7 @@ else:
 gps = numpy.around(float(args.gpstime), 3)
 
 print("----------------------------------------------\n"
-      "Creating %s omega scan at GPS second %s" % (ifo, gps))
+      "Creating {} omega scan at GPS second {}".format(ifo, gps))
 
 # get default configuration
 if args.config_file is None:
@@ -113,7 +113,7 @@ args.config_file = [os.path.abspath(f) for f in args.config_file]
 if args.verbose:
     print('Parsing the following configuration files:')
     for fname in args.config_file:
-        print(''.join(['\t', fname]))
+        print(' '.join(['  --', fname]))
 cp = config.OmegaConfigParser(ifo=ifo)
 cp.read(args.config_file)
 
@@ -155,7 +155,7 @@ outdir = os.path.abspath(outdir)
 if not os.path.isdir(outdir):
     os.makedirs(outdir)
 os.chdir(outdir)
-print("Output directory created as %s" % outdir)
+print("Output directory created as {}".format(outdir))
 
 
 # -- Compute Qscan ------------------------------------------------------------
@@ -169,7 +169,7 @@ for d in [plotdir, aboutdir, datadir]:
         os.makedirs(d)
 
 # set up html output
-print('Setting up HTML at %s/index.html' % outdir)
+print('Setting up HTML at {}/index.html'.format(outdir))
 html.write_qscan_page(ifo, gps, analyzed, **htmlv)
 
 # launch omega scans
@@ -208,9 +208,9 @@ for block in blocks.values():
     # check that analysis flag is active for all of `duration`
     if block.flag and (not args.ignore_state_flags):
         if args.verbose:
-            print('Querying state flag %s' % block.flag)
+            print('  -- Querying state flag {}'.format(block.flag))
         if not check_flag(block.flag, gps, duration, pad=1):
-            print('%s not active, skipping block' % block.flag)
+            print('  -- {} not active, skipping block'.format(block.flag))
             continue
     # read in `duration` seconds of data centered on gps
     start = gps - duration/2. - 1
@@ -222,24 +222,24 @@ for block in blocks.values():
     # scan individual channels
     for channel in block.channels:
         try:
-            print('Scanning channel %s' % channel.name)
+            print('  -- Scanning channel {}'.format(channel.name))
             series = omega.scan(
                 gps, channel, data[channel.name].astype('float64'), fftlength,
                 resample=block.resample, fthresh=args.far_threshold,
                 search=block.search)
         except Exception:
             traceback.print_exc()
-            print('Problem encountered, skipping channel %s' % channel.name)
+            print('  -- Problem encountered, skipping {}'.format(channel.name))
             continue
 
         if series is None:
             continue  # channel is insignificant, skip it
 
-        print('Plotting omega scan products for channel %s' % channel.name)
+        print('  -- Plotting omega scan products for {}'.format(channel.name))
         plot.write_qscan_plots(gps, channel, series, colormap=args.colormap)
 
         if correlate is not None:
-            print('Cross-correlating channel %s' % channel.name)
+            print('  -- Cross-correlating {}'.format(channel.name))
             correlation = omega.cross_correlate(series[2], correlate)
             channel.save_loudest_tile_features(
                 series[3], correlation, gps=gps, dt=block.dt)
@@ -258,7 +258,7 @@ for block in blocks.values():
 # -- Prepare HTML -------------------------------------------------------------
 
 # write HTML page and finish
-print('Finalizing HTML at %s/index.html' % outdir)
+print('Finalizing HTML at {}/index.html'.format(outdir))
 htmlv['refresh'] = False  # turn off auto-refresh
 if analyzed:
     html.write_qscan_page(ifo, gps, analyzed, **htmlv)

--- a/bin/gwdetchar-omega
+++ b/bin/gwdetchar-omega
@@ -89,8 +89,6 @@ parser.add_argument('-t', '--far-threshold', type=float, default=3.171e-8,
 parser.add_argument('-c', '--colormap', default='viridis',
                     help='name of colormap to use, default: %(default)s')
 cli.add_nproc_option(parser)
-parser.add_argument('-v', '--verbose', action='store_true', default=False,
-                    help='print verbose output, default: False')
 
 args = parser.parse_args()
 
@@ -101,7 +99,7 @@ else:
     ifo = 'Network'
 gps = numpy.around(float(args.gpstime), 3)
 
-print("---------------------------------------------------------------------\n"
+print("-----------------------------------------------------------------------"
       "Creating {} omega scan at GPS second {}".format(ifo, gps))
 
 # get default configuration
@@ -110,10 +108,9 @@ if args.config_file is None:
 
 # parse configuration files
 args.config_file = [os.path.abspath(f) for f in args.config_file]
-if args.verbose:
-    print('Parsing the following configuration files:')
-    for fname in args.config_file:
-        print(''.join(['    ', fname]))
+print('Parsing the following configuration files:')
+for fname in args.config_file:
+    print(''.join(['    ', fname]))
 cp = config.OmegaConfigParser(ifo=ifo)
 cp.read(args.config_file)
 
@@ -177,7 +174,7 @@ print('Launching omega scans')
 
 # construct a matched-filter from primary channel
 if not args.disable_correlation:
-    print('\nProcessing primary channel')
+    print('Processing primary channel')
     duration = primary.duration
     fftlength = primary.fftlength
     # process `duration` seconds of data centered on gps
@@ -200,15 +197,14 @@ else:
 
 # range over channel blocks
 for block in blocks.values():
-    print('\nProcessing block {}'.format(block.key))
+    print('Processing block {}'.format(block.key))
     chans = [c.name for c in block.channels]
     # get configuration
     duration = block.duration
     fftlength = block.fftlength
     # check that analysis flag is active for all of `duration`
     if block.flag and (not args.ignore_state_flags):
-        if args.verbose:
-            print('    Querying state flag {}'.format(block.flag))
+        print('    Querying state flag {}'.format(block.flag))
         if not check_flag(block.flag, gps, duration, pad=1):
             print('    {} not active, skipping block'.format(block.flag))
             continue

--- a/bin/gwdetchar-omega-batch
+++ b/bin/gwdetchar-omega-batch
@@ -152,7 +152,8 @@ condorcmds = [
 ]
 if args.condor_timeout:
     condorcmds.append("periodic_remove = {}".format(
-        'CurrentTime-EnteredCurrentStatus > %d' % (3600 * args.condor_timeout),
+        'CurrentTime-EnteredCurrentStatus > {}'.format(
+            3600 * args.condor_timeout),
     ))
 condorcmds.extend(args.condor_command)
 

--- a/bin/gwdetchar-omega-batch
+++ b/bin/gwdetchar-omega-batch
@@ -76,8 +76,6 @@ parser.add_argument('-s', '--ignore-state-flags', action='store_true',
                     default=False, help='ignore state flag definitions in '
                                         'the configuration, default: False')
 cli.add_nproc_option(parser)
-parser.add_argument('-v', '--verbose', action='store_true', default=False,
-                    help='print verbose output, default: False')
 
 cargs = parser.add_argument_group('Condor options')
 cargs.add_argument('-u', '--universe', default='vanilla', type=str,
@@ -191,8 +189,6 @@ if args.disable_correlation:
     arguments.append("--disable-correlation")
 if args.ignore_state_flags:
     arguments.append("--ignore-state-flags")
-if args.verbose:
-    arguments.append("--verbose")
 
 # make node in workflow for each time
 for t in times:

--- a/gwdetchar/omega/config.py
+++ b/gwdetchar/omega/config.py
@@ -153,6 +153,9 @@ try:  # python 3.x
 except ImportError:  # python 2.x
     import ConfigParser as configparser
 
+if sys.version_info < (3, 7):
+    from collections import OrderedDict
+
 __author__ = 'Alex Urban <alexander.urban@ligo.org>'
 __credits__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
@@ -178,7 +181,6 @@ class OmegaConfigParser(configparser.ConfigParser):
         if sys.version_info >= (3, 7):  # python 3.7+
             return {s: OmegaChannelList(s, **self[s]) for s in self.sections()}
         else:
-            from collections import OrderedDict
             return OrderedDict([(s, OmegaChannelList(s, **dict(self.items(s))))
                                 for s in self.sections()])
 

--- a/gwdetchar/omega/config.py
+++ b/gwdetchar/omega/config.py
@@ -194,6 +194,7 @@ def get_default_configuration(ifo, gpstime):
     ----------
     ifo : `str`
         interferometer ID string, e.g. `'L1'`
+
     gpstime : `float`
         time of analysis in GPS second format
     """
@@ -217,10 +218,13 @@ def get_fancyplots(channel, plottype, duration, caption=None):
     ----------
     channel : `str`
         the name of the channel
+
     plottype : `str`
         the type of plot, e.g. 'raw_timeseries'
+
     duration : `str`
         duration of the plot, in seconds
+
     caption : `str`, optional
         a caption to render in the fancybox
     """
@@ -232,6 +236,22 @@ def get_fancyplots(channel, plottype, duration, caption=None):
     return html.FancyPlot(filename, caption)
 
 
+def get_already_processed(cache, blocks):
+    """Work out which blocks have already been processed given a local cache
+    of intermediate data products
+
+    Parameters
+    ----------
+    cache : `str`
+        path to a local file with intermediate data products
+
+    blocks : `list` of `OmegaChannelList`
+        blocks configured to run
+    """
+    out = []
+    processed = numpy.recfromcsv(cache)
+
+
 # -- channel list objects -----------------------------------------------------
 
 class OmegaChannel(Channel):
@@ -241,8 +261,10 @@ class OmegaChannel(Channel):
     ----------
     channelname : `str`
         name of this channel, e.g. `L1:GDS-CALIB_STRAIN`
+
     section : `str`
         configuration section to which this channel belongs
+
     params : `dict`
         parameters set in a configuration file
     """
@@ -329,6 +351,7 @@ class OmegaChannelList(object):
     key : `str`
         the unique identifier for this list, e.g. `'CAL'` for calibration
         channels
+
     params : `dict`
         parameters set in a configuration file
     """

--- a/gwdetchar/omega/config.py
+++ b/gwdetchar/omega/config.py
@@ -236,22 +236,6 @@ def get_fancyplots(channel, plottype, duration, caption=None):
     return html.FancyPlot(filename, caption)
 
 
-def get_already_processed(cache, blocks):
-    """Work out which blocks have already been processed given a local cache
-    of intermediate data products
-
-    Parameters
-    ----------
-    cache : `str`
-        path to a local file with intermediate data products
-
-    blocks : `list` of `OmegaChannelList`
-        blocks configured to run
-    """
-    out = []
-    processed = numpy.recfromcsv(cache)
-
-
 # -- channel list objects -----------------------------------------------------
 
 class OmegaChannel(Channel):

--- a/gwdetchar/omega/core.py
+++ b/gwdetchar/omega/core.py
@@ -295,9 +295,7 @@ def scan(gps, channel, xoft, fftlength, resample=None, fthresh=1e-10,
         wxoft, mismatch=channel.mismatch, qrange=channel.qrange,
         frange=channel.frange, search=search)
     if (far >= fthresh) and (not channel.always_plot):
-        print('Channel not significant at white noise false alarm '
-              'rate %s Hz' % fthresh)
-        return None
+        return None  # series is insignificant
     # compute raw Q-gram
     Q = qgram.plane.q
     rqgram, _ = q_scan(


### PR DESCRIPTION
This PR implements miscellaneous formatting enhancements for omega scans, including:

* Use the `format` builtin for string formatting in `gwdetchar-omega` and `gwdetchar-omega-batch`
* Move a print statement out of `gwdetchar.omega.scan` and into `gwdetchar-omega` in anticipation of using the logger utility
* Remove `--verbose` flag from `gwdetchar-omega` and `gwdetchar-omega-batch`, as it's rarely used to do anything useful

cc @duncanmmacleod 