### PR TITLE
Use a common utility to render HTML 'about' sections

### DIFF
--- a/bin/gwdetchar-lasso-correlation
+++ b/bin/gwdetchar-lasso-correlation
@@ -603,7 +603,7 @@ def style_table(html_table):
 
 
 # write html
-title = '%s Lasso slow correlations: %d-%d' % (args.ifo, start, end)
+title = '%s Lasso Slow Correlations: %d-%d' % (args.ifo, start, end)
 page = htmlio.new_bootstrap_page(title=title)
 page.div(class_='container')
 

--- a/bin/gwdetchar-lasso-correlation
+++ b/bin/gwdetchar-lasso-correlation
@@ -37,7 +37,7 @@ from gwpy.table import Table
 from pandas import set_option
 
 from gwpy.plot import Plot
-from gwpy.time import (Time, from_gps)
+from gwpy.time import Time
 from gwpy.detector import ChannelList
 from gwpy.io import nds2 as io_nds2
 
@@ -611,34 +611,24 @@ page.div(class_='page-header')
 page.h1(title)
 page.div.close()  # page-header
 
-page.h2('Parameters')
-page.p('This analysis used the following parameters:')
-page.add(
-    htmlio.write_param('Start time', '%s (%d)' % (from_gps(start), start)))
-page.add(htmlio.write_param('End time', '%s (%d)' % (from_gps(end), end)))
-page.add(htmlio.write_param(
-    'Primary channel',
-    '%s (%s)' % (primary, args.primary_frametype or '-')))
-page.add(htmlio.write_param(
-    'Channels searched',
-    '%d (%s)' % (nchan, "<a href= %s target='_blank'>channel list</a>"
-                 % channelsfile)))
-page.add(htmlio.write_param(
-    'Number of flat channels',
-    '%d (%s)' % (len(flattab),
-                 "<a href= %s target='_blank'>flat channel list</a>"
-                 % (flatfile))))
-page.add(htmlio.write_param(
-    'Lasso coefficient threshold', '%g' % args.threshold))
-page.add(htmlio.write_param(
-    'Sigma for outlier removal', '%g' % args.remove_outliers))
-page.add(htmlio.write_param('Cluster coefficient threshold',
-                            '%g' % args.cluster_coefficient))
+content = [
+    ('Primary channel',
+     '{} ({})'.format(primary, args.primary_frametype or '-')),
+    ('Channels searched',
+     '{} ({})'.format(nchan, "<a href= %s target='_blank'>channel list</a>"
+                             % channelsfile)),
+    ('Number of flat channels',
+     '{} ({})'.format(len(flattab),
+                      "<a href= %s target='_blank'>flat channel list</a>"
+                      % (flatfile))),
+    ('Lasso coefficient threshold', '{}'.format(args.threshold)),
+    ('Sigma for outlier removal', '{}'.format(args.remove_outliers)),
+    ('Cluster coefficient threshold', '{}'.format(args.cluster_coefficient))]
 if args.band_pass:
-    page.add(htmlio.write_param(
-        'Filter settings', 'Flow=%dHz, Fhigh=%dHz ' % (flower, fupper)))
-page.add(htmlio.write_param('Command line', ''))
-page.add(htmlio.get_command_line())
+    content.append(
+        ('Filter settings',
+         'Flow = {} Hz, Fhigh = {} Hz '.format(flower, fupper)))
+page.add(htmlio.write_arguments(content, start=start, end=end))
 
 page.h2('Model Information')
 

--- a/bin/gwdetchar-overflow
+++ b/bin/gwdetchar-overflow
@@ -253,23 +253,18 @@ if args.html:
     page.div.close()
 
     # -- paramters
-    page.h2('Parameters')
-    page.p('This analysis used the following parameters:')
-    page.add(htmlio.write_param('Start time', args.gpsstart))
-    page.add(htmlio.write_param('End time', args.gpsend))
-    page.add(htmlio.write_param('State flag', args.state_flag))
-    page.add(htmlio.write_param('DCUIDs', ' '.join(map(str, args.dcuid))))
+    content = [('DCUIDs', ' '.join(map(str, args.dcuid)))]
     if fec_map:
-        page.add(htmlio.write_param(
+        content.append((
             'FEC map', '<a href="{0}" target="_blank" title="{1} FEC '
                        'map">{0}</a>'.format(fec_map, args.ifo)))
     if simulink:
-        page.add(htmlio.write_param(
-            'Simulink models', '<a href="{0}" target="_blank" '
-                               'title="{1} Simulink models">{0}</a>'.format(
+        content.append((
+            'Simulink models', '<a href="{0}" target="_blank" title="{1} '
+                               'Simulink models">{0}</a>'.format(
                                    simulink, args.ifo)))
-    page.add(htmlio.write_param('Command line', ''))                                
-    page.add(htmlio.get_command_line())
+    page.add(htmlio.write_arguments(
+        content, start=args.gpsstart, end=args.gpsend, flag=args.state_flag))
 
     # -- segments
     page.h2('Segments')
@@ -284,11 +279,11 @@ if args.html:
     if args.state_flag:
         page.p('This analysis was executed over the following segments:')
         page.div(class_='panel-group', id_='accordion1')
-        page.add(str(htmlio.write_flag_html(
+        page.add(htmlio.write_flag_html(
             state, span, 'state', parent='accordion1', context='success',
             plotdir=args.plot, facecolor=(0.2, 0.8, 0.2),
             edgecolor='darkgreen', known={
-                'facecolor': 'red', 'edgecolor': 'darkred', 'height': 0.4})))
+                'facecolor': 'red', 'edgecolor': 'darkred', 'height': 0.4}))
         page.div.close()
     # print overflow segments
     if sum(abs(s.active) for s in overflows.values()):
@@ -308,9 +303,9 @@ if args.html:
                 title = '%s [%d]' % (flag.name, len(flag.active))
             else:
                 title = '%s (%s) [%d]' % (flag.name, channel, len(flag.active))
-            page.add(str(htmlio.write_flag_html(
+            page.add(htmlio.write_flag_html(
                 flag, span, i, parent='accordion2', title=title,
-                context=context, plotdir=args.plot)))
+                context=context, plotdir=args.plot))
         page.div.close()
     else:
         page.div(class_='alert alert-info')

--- a/bin/gwdetchar-scattering
+++ b/bin/gwdetchar-scattering
@@ -69,7 +69,7 @@ rcParams.update({
 parser = cli.create_parser(description=__doc__)
 cli.add_gps_start_stop_arguments(parser)
 cli.add_ifo_option(parser)
-parser.add_argument('-a', '--state-flag', metavar='FLAG',
+parser.add_argument('-a', '--state-flag', metavar='FLAG', default=None,
                     help='restrict search to times when FLAG was active')
 parser.add_argument('-t', '--frequency-threshold', type=float, default=40.,
                     help='critical fringe frequency threshold (in Hertz), '
@@ -124,7 +124,7 @@ segfile = '%s-SCATTERING_SEGMENTS_%s_HZ-%s.h5' % (args.ifo, tstr, gpsstr)
 span = Segment(args.gpsstart, args.gpsend)
 
 # get segments
-if args.state_flag:
+if args.state_flag is not None:
     state = DataQualityFlag.query(args.state_flag, int(args.gpsstart),
                                   int(args.gpsend),
                                   url=const.DEFAULT_SEGMENT_SERVER)
@@ -216,8 +216,8 @@ page.p("This analysis searched for evidence of beam scattering based on the "
        "velocity of optic motion. The fringe frequency is predicted using "
        "equation (3) of <a href=\"http://iopscience.iop.org/article/10.1088/"
        "0264-9381/27/19/194011\" target=\"_blank\">Accadia et al. (2010)</a>.")
-page.p("This analysis was done with the following command line call:")
-page.add(htmlio.get_command_line()) 
+page.add(htmlio.write_arguments(
+    [], start=int(args.gpsstart), end=int(args.gpsend), flag=args.state_flag)) 
 page.div.close()
 
 # link segments file
@@ -226,7 +226,7 @@ page.add('The full output segments are recorded in HDF5 format here:')
 page.a(os.path.basename(segfile), href=segfile, target='_blank')
 page.p.close()
 # print state segments
-if args.state_flag:
+if args.state_flag is not None:
     page.p('This analysis was executed over the following segments:')
     page.div(class_='panel-group', id_='accordion1')
     page.add(htmlio.write_flag_html(

--- a/bin/gwdetchar-scattering
+++ b/bin/gwdetchar-scattering
@@ -207,7 +207,7 @@ if args.verbose:
 
 # -- prepare HTML -------------------------------------------------------------
 
-page = htmlio.new_bootstrap_page(title='%s scattering' % args.ifo)
+page = htmlio.new_bootstrap_page(title='%s Scattering' % args.ifo)
 page.div(class_='container')
 page.div(class_='page-header')
 page.h1('%s scattering: %d-%d'
@@ -216,11 +216,12 @@ page.p("This analysis searched for evidence of beam scattering based on the "
        "velocity of optic motion. The fringe frequency is predicted using "
        "equation (3) of <a href=\"http://iopscience.iop.org/article/10.1088/"
        "0264-9381/27/19/194011\" target=\"_blank\">Accadia et al. (2010)</a>.")
+page.div.close()
 page.add(htmlio.write_arguments(
     [], start=int(args.gpsstart), end=int(args.gpsend), flag=args.state_flag)) 
-page.div.close()
 
 # link segments file
+page.h2('Segments')
 page.p()
 page.add('The full output segments are recorded in HDF5 format here:')
 page.a(os.path.basename(segfile), href=segfile, target='_blank')

--- a/bin/gwdetchar-scattering
+++ b/bin/gwdetchar-scattering
@@ -229,10 +229,10 @@ page.p.close()
 if args.state_flag:
     page.p('This analysis was executed over the following segments:')
     page.div(class_='panel-group', id_='accordion1')
-    page.add(str(htmlio.write_flag_html(
+    page.add(htmlio.write_flag_html(
         state, span, 'state', parent='accordion1', context='success',
         plotdir='', facecolor=(0.2, 0.8, 0.2), edgecolor='darkgreen',
-        known={'facecolor': 'red', 'edgecolor': 'darkred', 'height': 0.4})))
+        known={'facecolor': 'red', 'edgecolor': 'darkred', 'height': 0.4}))
     page.div.close()
 
 page.p("The following channels were searched for evidence of scattering "

--- a/bin/gwdetchar-slow-correlation
+++ b/bin/gwdetchar-slow-correlation
@@ -355,7 +355,7 @@ with open('results.txt', 'w') as f:
         print('%s %s %s %s %s' % (ch, corr1, corr2, corr1s, corr2s), file=f)
 
 # -- write html
-title = '%s slow correlations: %d-%d' % (args.ifo, start, end)
+title = '%s Slow Correlations: %d-%d' % (args.ifo, start, end)
 page = htmlio.new_bootstrap_page(title=title)
 page.div(class_='container')
 

--- a/bin/gwdetchar-slow-correlation
+++ b/bin/gwdetchar-slow-correlation
@@ -32,7 +32,6 @@ use('agg')
 import matplotlib.pyplot as plt
 
 from gwpy.plot import Plot
-from gwpy.time import from_gps
 from gwpy.detector import ChannelList
 from gwpy.io import nds2 as io_nds2
 
@@ -375,20 +374,13 @@ page.p("This analysis searched %d channels for linear correlations with %s"
 page.div.close()
 
 # run parameters
-page.h2('Parameters')
-page.p('This analysis used the following parameters:')
-page.add(htmlio.write_param(
-    'Start time', '%s (%d)' % (from_gps(start), start)))
-page.add(htmlio.write_param('End time', '%s (%d)' % (from_gps(end), end)))
-page.add(htmlio.write_param(
-    'Primary channel',
-    '%s (%s)' % (primary, args.primary_frametype.format(ifo=args.ifo))))
-page.add(htmlio.write_param(
-    'Range channel',
-    '%s (%s)' % (rangechannel, args.range_frametype or '-')))
-page.add(htmlio.write_param('Band-pass', '%s-%s' % (flower, fupper)))
-page.add(htmlio.write_param('Command line', ''))                                
-page.add(htmlio.get_command_line())
+contents = [
+    ('Primary channel',
+     '{} ({})'.format(primary, args.primary_frametype.format(ifo=args.ifo))),
+    ('Range channel',
+     '{} ({})'.format(rangechannel, args.range_frametype or '-')),
+    ('Band-pass', '{}-{}'.format(flower, fupper))]
+page.add(htmlio.write_arguments(content, start=start, end=end))
 
 # results
 page.h2('Results')

--- a/bin/gwdetchar-software-saturations
+++ b/bin/gwdetchar-software-saturations
@@ -209,7 +209,7 @@ if args.html:
     page.div(class_='container')
     # -- header
     page.div(class_='page-header')
-    page.h1('%s software saturations: %d-%d'
+    page.h1('%s Software Saturations: %d-%d'
             % (ifo, int(args.gpsstart), int(args.gpsend)))
     page.p("This analysis searched %d channels for times during which their "
            "OUTPUT value matched the LIMIT value set in software. Only "

--- a/bin/gwdetchar-software-saturations
+++ b/bin/gwdetchar-software-saturations
@@ -219,15 +219,11 @@ if args.html:
            % sum(map(len, channels)))
     page.div.close()
     # -- paramters
-    page.h2('Parameters')
-    page.p('This analysis used the following parameters:')
-    page.add(htmlio.write_param('Start time', args.gpsstart))
-    page.add(htmlio.write_param('End time', args.gpsend))
-    page.add(htmlio.write_param('State flag', args.state_flag))
-    page.add(htmlio.write_param('State end padding', args.pad_state_end))
-    page.add(htmlio.write_param('Skip', ', '.join(map(repr, args.skip))))
-    page.add(htmlio.write_param('Command line', ''))                            
-    page.add(htmlio.get_command_line())
+    content = [
+        ('State end padding', args.pad_state_end)
+        ('Skip', ', '.join(map(repr, args.skip)))]
+    page.add(htmlio.write_arguments(
+        content, start=args.gpsstart, end=args.gpsend, flag=args.state_flag))
     # -- segments
     page.h2('Segments')
     # link output file
@@ -239,11 +235,11 @@ if args.html:
     if args.state_flag:
         page.p('This analysis was executed over the following segments:')
         page.div(class_='panel-group', id_='accordion1')
-        page.add(str(htmlio.write_flag_html(
+        page.add(htmlio.write_flag_html(
             state, span, 'state', parent='accordion1', context='success',
             plotdir=args.plot, facecolor=(0.2, 0.8, 0.2),
             edgecolor='darkgreen', known={
-                'facecolor': 'red', 'edgecolor': 'darkred', 'height': 0.4})))
+                'facecolor': 'red', 'edgecolor': 'darkred', 'height': 0.4}))
         page.div.close()
     # print saturation segments
     if len(bad):
@@ -252,9 +248,9 @@ if args.html:
         for i, (c, flag) in enumerate(saturations.items()):
             if abs(flag.active) > 0:
                 title = '%s [%d]' % (flag.name, len(flag.active))
-                page.add(str(htmlio.write_flag_html(
+                page.add(htmlio.write_flag_html(
                     flag, span=span, id=i, parent='accordion2', title=title,
-                    plotdir=args.plot)))
+                    plotdir=args.plot))
         page.div.close()
     else:
         page.div(class_='alert alert-info')

--- a/bin/gwdetchar-software-saturations
+++ b/bin/gwdetchar-software-saturations
@@ -220,7 +220,7 @@ if args.html:
     page.div.close()
     # -- paramters
     content = [
-        ('State end padding', args.pad_state_end)
+        ('State end padding', args.pad_state_end),
         ('Skip', ', '.join(map(repr, args.skip)))]
     page.add(htmlio.write_arguments(
         content, start=args.gpsstart, end=args.gpsend, flag=args.state_flag))

--- a/gwdetchar/io/html.py
+++ b/gwdetchar/io/html.py
@@ -359,6 +359,7 @@ def scaffold_plots(plots, nperrow=3):
             page.div.close()  # row
     if i % nperrow < nperrow-1:
         page.div.close()  # row
+    return page()
 
 
 def write_arguments(content, start, end, flag=None, section='Parameters',

--- a/gwdetchar/io/tests/test_html.py
+++ b/gwdetchar/io/tests/test_html.py
@@ -217,13 +217,6 @@ def test_write_arguments():
     assert '<strong>Command line: </strong>' in page
 
 
-def test_write_footer():
-    date = datetime.datetime.now()
-    out = html.write_footer(date=date, class_=True)
-    assert parse_html(str(out)) == parse_html(
-        HTML_FOOTER.format(user=getuser(), date=date))
-
-
 def test_write_flag_html():
     page = html.write_flag_html(FLAG)
     assert parse_html(str(page)) == parse_html(FLAG_HTML)
@@ -239,3 +232,10 @@ def test_write_flag_html_with_plots(tmpdir):
     page = html.write_flag_html(FLAG, span=Segment(0, 66), plotdir='plots')
     assert parse_html(str(page)) == parse_html(FLAG_HTML_WITH_PLOTS)
     shutil.rmtree(str(tmpdir), ignore_errors=True)
+
+
+def test_write_footer():
+    date = datetime.datetime.now()
+    out = html.write_footer(date=date, class_=True)
+    assert parse_html(str(out)) == parse_html(
+        HTML_FOOTER.format(user=getuser(), date=date))

--- a/gwdetchar/io/tests/test_html.py
+++ b/gwdetchar/io/tests/test_html.py
@@ -207,6 +207,16 @@ def test_scaffold_plots():
     assert h1 == h2
 
 
+def test_write_arguments():
+    page = html.write_arguments([('test', 'test')], 0, 1, flag='X1:TEST')
+    assert '<h2>Parameters</h2>' in page
+    assert '<strong>Start time: </strong>\n0 (1980-01-06 00:00:00)' in page
+    assert '<strong>End time: </strong>\n1 (1980-01-06 00:00:01)' in page
+    assert '<strong>State flag: </strong>\nX1:TEST' in page
+    assert '<strong>test: </strong>\ntest' in page
+    assert '<strong>Command line: </strong>' in page
+
+
 def test_write_footer():
     date = datetime.datetime.now()
     out = html.write_footer(date=date, class_=True)


### PR DESCRIPTION
This PR introduces a common utility (under `gwdetchar.io.html`) for rendering 'about' sections in HTML. The new utility is invoked by the overflow, software saturations, scattering, slow correlation, and LASSO correlation tools.

This PR also includes a unit test, and pedantically re-orders function definitions in `gwdetchar.io.html`.

Test output is available here:

Tool | Output
-- | --
`gwdetchar-lasso-correlation` | [**Link**](https://ldas-jobs.ligo-la.caltech.edu/~aurban/lasso/day/20190302/)
`gwdetchar-overflow` | [**Link**](https://ldas-jobs.ligo-la.caltech.edu/~aurban/overflows/day/20190310/)
`gwdetchar-software-saturations` | [**Link**](https://ldas-jobs.ligo-la.caltech.edu/~aurban/software-saturations/day/20190310/)
`gwdetchar-scattering` | [**Link**](https://ldas-jobs.ligo-la.caltech.edu/~aurban/scattering/day/20190310/)

cc @duncanmmacleod 