### PR TITLE
Added package_list and package_table functions

### DIFF
--- a/gwdetchar/io/html.py
+++ b/gwdetchar/io/html.py
@@ -499,6 +499,8 @@ def package_list():
              "list", "installed",
              "--format", "json"],
         )
+    if isinstance(raw, bytes):
+        raw = raw.decode('utf-8')
     return json.loads(raw)
 
 

--- a/gwdetchar/io/html.py
+++ b/gwdetchar/io/html.py
@@ -519,8 +519,8 @@ def package_table(
 
     Returns
     -------
-    page : `MarkupPy.markup.page`
-        the page object including a `<table>`
+    html : `str`
+        an HTML table
     """
     # get package list and inspect columns
     pkgs = package_list()
@@ -530,7 +530,7 @@ def package_table(
         cols = ("name", "version")
 
     # create page and write <table>
-    page = markup.page()
+    page = markup.page(separator="")
     if h2 is not None:
         page.h2(h2)
     page.table(class_=class_)
@@ -551,4 +551,4 @@ def package_table(
     page.tbody.close()
     page.table.close()
 
-    return page
+    return page()

--- a/gwdetchar/io/tests/test_html.py
+++ b/gwdetchar/io/tests/test_html.py
@@ -246,7 +246,7 @@ def test_write_footer():
         HTML_FOOTER.format(user=getuser(), date=date))
 
 
-@mock.patch("pathlib.Path.is_dir")
+@mock.patch("{}.Path.is_dir".format(html.Path.__module__))
 @mock.patch("subprocess.check_output", return_value="{\"key\": 0}")
 @pytest.mark.parametrize("isdir, cmd", [
     pytest.param(

--- a/gwdetchar/io/tests/test_html.py
+++ b/gwdetchar/io/tests/test_html.py
@@ -22,7 +22,12 @@
 import os
 import shutil
 import datetime
+import sys
 from getpass import getuser
+try:
+    from unittest import mock
+except ImportError:  # python < 3
+    import mock
 
 import pytest
 
@@ -239,3 +244,57 @@ def test_write_footer():
     out = html.write_footer(date=date, class_=True)
     assert parse_html(str(out)) == parse_html(
         HTML_FOOTER.format(user=getuser(), date=date))
+
+
+@mock.patch("pathlib.Path.is_dir")
+@mock.patch("subprocess.check_output", return_value="{\"key\": 0}")
+@pytest.mark.parametrize("isdir, cmd", [
+    pytest.param(
+        False,
+        "{} -m pip list installed --format json".format(sys.executable),
+        id="pip",
+    ),
+    pytest.param(
+        True,
+        "conda list --prefix {} --json".format(sys.prefix),
+        id="conda",
+    ),
+])
+def test_package_list(check_output, is_dir, isdir, cmd):
+    is_dir.return_value = isdir
+    assert html.package_list() == {"key": 0}
+    check_output.assert_called_with(cmd.split())
+
+
+@mock.patch(
+    "gwdetchar.io.html.package_list",
+    return_value=[
+        {"name": "gwpy", "version": "1.0.0"},
+        {"name": "gwdetchar", "version": "1.2.3"},
+    ],
+)
+def test_package_table(package_list):
+    assert parse_html(
+        str(html.package_table(class_="test", caption="Test")),
+    ) == parse_html(
+        """<h2>Environment</h2>
+<table class="test">
+<caption>Test</caption>
+<thead>
+<tr>
+<th scope="col">Name</th>
+<th scope="col">Version</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>gwdetchar</td>
+<td>1.2.3</td>
+</tr>
+<tr>
+<td>gwpy</td>
+<td>1.0.0</td>
+</tr>
+</tbody>
+</table>""",
+    )

--- a/gwdetchar/io/tests/test_html.py
+++ b/gwdetchar/io/tests/test_html.py
@@ -275,26 +275,13 @@ def test_package_list(check_output, is_dir, isdir, cmd):
 )
 def test_package_table(package_list):
     assert parse_html(
-        str(html.package_table(class_="test", caption="Test")),
+        html.package_table(class_="test", caption="Test"),
     ) == parse_html(
-        """<h2>Environment</h2>
-<table class="test">
-<caption>Test</caption>
-<thead>
-<tr>
-<th scope="col">Name</th>
-<th scope="col">Version</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>gwdetchar</td>
-<td>1.2.3</td>
-</tr>
-<tr>
-<td>gwpy</td>
-<td>1.0.0</td>
-</tr>
-</tbody>
-</table>""",
+        "<h2>Environment</h2><table class=\"test\"><caption>Test</caption>"
+        "<thead>"
+        "<tr><th scope=\"col\">Name</th><th scope=\"col\">Version</th></tr>"
+        "</thead><tbody>"
+        "<tr><td>gwdetchar</td><td>1.2.3</td></tr>"
+        "<tr><td>gwpy</td><td>1.0.0</td></tr>"
+        "</tbody></table>",
     )

--- a/gwdetchar/omega/html.py
+++ b/gwdetchar/omega/html.py
@@ -842,4 +842,6 @@ def write_about_page(configfiles):
         with open(configfile, 'r') as fobj:
             inifile = fobj.read()
         page.add(htmlio.render_code(inifile, 'ini'))
+    # add environment listing
+    page.add(str(htmlio.package_table()))
     return page


### PR DESCRIPTION
This PR adds some utility functions to `gwdetchar.io.html` to scape the environment from `pip`/`conda` and render as an html table, and added this to the about page for `gwdetchar-omega`.

Example output is [here](https://ldas-jobs.ligo-la.caltech.edu/~duncan.macleod/gwdetchar/testing/package-table/GW170817/about/) (LIGO.ORG).