### PR TITLE
Removed unused imports

### DIFF
--- a/gwdetchar/io/tests/test_datafind.py
+++ b/gwdetchar/io/tests/test_datafind.py
@@ -24,7 +24,6 @@ import pytest
 import numpy
 from numpy import testing as nptest
 
-from gwpy.testing import utils
 from gwpy.testing.compat import mock
 from gwpy.timeseries import (TimeSeries, TimeSeriesDict)
 from gwpy.segments import (Segment, DataQualityFlag)

--- a/gwdetchar/io/tests/test_html.py
+++ b/gwdetchar/io/tests/test_html.py
@@ -34,11 +34,6 @@ import pytest
 from matplotlib import use
 use('Agg')  # nopep8
 
-try:  # python 3.x
-    from io import StringIO
-except ImportError:  # python 2.7
-    from cStringIO import StringIO
-
 from gwpy.segments import (Segment, DataQualityFlag)
 
 from .. import html

--- a/gwdetchar/lasso/tests/test_core.py
+++ b/gwdetchar/lasso/tests/test_core.py
@@ -19,8 +19,6 @@
 """Tests for `gwdetchar.lasso`
 """
 
-import pytest
-
 import numpy
 from numpy import testing as nptest
 

--- a/gwdetchar/lasso/tests/test_plot.py
+++ b/gwdetchar/lasso/tests/test_plot.py
@@ -22,8 +22,6 @@
 import os
 import shutil
 
-import pytest
-
 import numpy
 
 from matplotlib import (use, rcParams, rcParamsDefault)

--- a/gwdetchar/omega/config.py
+++ b/gwdetchar/omega/config.py
@@ -143,7 +143,7 @@ import ast
 import os.path
 import numpy
 
-from gwpy.detector import (Channel, ChannelList)
+from gwpy.detector import Channel
 
 from .. import const
 from ..io.html import FancyPlot

--- a/gwdetchar/omega/plot.py
+++ b/gwdetchar/omega/plot.py
@@ -185,7 +185,6 @@ def spectral_plot(data, gps, span, channel, output, colormap='viridis',
     figsize : `tuple`
         size (width x height) of the final figure, default: `(12, 6)`
     """
-    import numpy
     from gwpy.spectrogram import Spectrogram
     # construct plot
     if isinstance(data, Spectrogram):

--- a/gwdetchar/omega/tests/test_config.py
+++ b/gwdetchar/omega/tests/test_config.py
@@ -26,8 +26,6 @@ try:  # python 3.x
 except ImportError:  # python 2.7
     from cStringIO import StringIO
 
-import pytest
-
 import numpy
 from scipy import signal
 

--- a/gwdetchar/omega/tests/test_core.py
+++ b/gwdetchar/omega/tests/test_core.py
@@ -19,8 +19,6 @@
 """Tests for `gwdetchar.omega.core`
 """
 
-import pytest
-
 import numpy
 from numpy import testing as nptest
 from scipy import signal

--- a/gwdetchar/omega/tests/test_html.py
+++ b/gwdetchar/omega/tests/test_html.py
@@ -29,8 +29,6 @@ try:  # python 3.x
 except ImportError:  # python 2.7
     from cStringIO import StringIO
 
-import pytest
-
 from .. import (config, html)
 from ..._version import get_versions
 from ...utils import parse_html

--- a/gwdetchar/omega/tests/test_plot.py
+++ b/gwdetchar/omega/tests/test_plot.py
@@ -23,8 +23,6 @@ import os
 import shutil
 import tempfile
 
-import pytest
-
 import numpy
 from scipy import signal
 

--- a/gwdetchar/tests/test_daq.py
+++ b/gwdetchar/tests/test_daq.py
@@ -30,11 +30,10 @@ import numpy
 from numpy.testing import assert_array_equal
 
 from gwpy.timeseries import TimeSeries
-from gwpy.segments import (Segment, SegmentList, DataQualityDict)
+from gwpy.segments import (Segment, SegmentList)
 from gwpy.testing.utils import assert_segmentlist_equal
 
 from .. import daq
-from ..io import ligolw
 
 OVERFLOW_SERIES = TimeSeries([0, 0, 0, 1, 1, 0, 0, 1, 0, 1], dx=.5)
 CUMULATIVE_SERIES = TimeSeries([0, 0, 0, 1, 2, 2, 2, 3, 3, 4], dx=.5)

--- a/gwdetchar/tests/test_plot.py
+++ b/gwdetchar/tests/test_plot.py
@@ -22,8 +22,6 @@
 import os
 import shutil
 
-import pytest
-
 from gwpy.segments import DataQualityFlag
 
 from matplotlib import use

--- a/gwdetchar/tests/test_saturation.py
+++ b/gwdetchar/tests/test_saturation.py
@@ -19,9 +19,6 @@
 """Tests for :mod:`gwdetchar.saturation`
 """
 
-import os
-import shutil
-
 import pytest
 
 import numpy

--- a/gwdetchar/tests/test_scattering.py
+++ b/gwdetchar/tests/test_scattering.py
@@ -19,8 +19,6 @@
 """Tests for `gwdetchar.scattering`
 """
 
-import pytest
-
 import numpy
 from numpy import testing as nptest
 


### PR DESCRIPTION
This PR removes unused imports from all modules. We should set up flake8 to run as part of the CI to catch these automatically. GWpy does this already, so we can probably steal from there.