### PR TITLE
Automatically exclude missing channels

### DIFF
--- a/bin/gwdetchar-omega
+++ b/bin/gwdetchar-omega
@@ -48,7 +48,7 @@ from __future__ import (division, print_function)
 
 import os
 import sys
-import traceback
+import warnings
 import numpy
 
 from gwpy.time import to_gps
@@ -99,8 +99,7 @@ else:
     ifo = 'Network'
 gps = numpy.around(float(args.gpstime), 3)
 
-print("-----------------------------------------------------------------------"
-      "Creating {} omega scan at GPS second {}".format(ifo, gps))
+print("Creating {} omega scan at GPS second {}".format(ifo, gps))
 
 # get default configuration
 if args.config_file is None:
@@ -120,7 +119,6 @@ if not args.disable_correlation:
         primary = config.OmegaChannelList(
             'primary', **dict(cp.items('primary')))
     except Exception:
-        import warnings
         warnings.warn(
             'No primary configured, continuing without cross-correlation')
         args.disable_correlation = True
@@ -223,9 +221,9 @@ for block in blocks.values():
                 gps, channel, data[channel.name].astype('float64'), fftlength,
                 resample=block.resample, fthresh=args.far_threshold,
                 search=block.search)
-        except Exception:
-            traceback.print_exc()
-            print('    Problem encountered, skipping {}'.format(channel.name))
+        except Exception as exc:
+            warnings.warn("Skipping {}: [{}] {}".format(
+                channel, type(exc), str(exc)), UserWarning)
             continue
 
         if series is None:

--- a/bin/gwdetchar-omega
+++ b/bin/gwdetchar-omega
@@ -118,7 +118,7 @@ if not args.disable_correlation:
     try:
         primary = config.OmegaChannelList(
             'primary', **dict(cp.items('primary')))
-    except Exception:
+    except config.configparser.NoSectionError:
         warnings.warn(
             'No primary configured, continuing without cross-correlation')
         args.disable_correlation = True
@@ -221,9 +221,9 @@ for block in blocks.values():
                 gps, channel, data[channel.name].astype('float64'), fftlength,
                 resample=block.resample, fthresh=args.far_threshold,
                 search=block.search)
-        except Exception as exc:
+        except (ValueError, KeyError) as exc:
             warnings.warn("Skipping {}: [{}] {}".format(
-                channel, type(exc), str(exc)), UserWarning)
+                channel.name, type(exc), str(exc)), UserWarning)
             continue
 
         if series is None:

--- a/bin/gwdetchar-overflow
+++ b/bin/gwdetchar-overflow
@@ -24,6 +24,7 @@ from __future__ import print_function
 
 import os.path
 
+import warnings
 import tqdm
 
 from matplotlib import (use, rcParams)
@@ -200,10 +201,14 @@ for dcuid in args.dcuid:
                               desc='        Going deep'):
             data = get_data(channels, s, e, **read_kw)
             for ch in channels:
-                overflows[ch] += daq.find_overflow_segments(
-                    data[ch],
-                    cumulative=True,
-                )
+                try:
+                    overflows[ch] += daq.find_overflow_segments(
+                        data[ch],
+                        cumulative=True,
+                    )
+                except Exception as exc:
+                    warnings.warn("Skipping {}: [{}] {}".format(
+                        ch, type(exc), str(exc)), UserWarning)
     gprint("    Complete")
 
 # write output

--- a/bin/gwdetchar-overflow
+++ b/bin/gwdetchar-overflow
@@ -208,6 +208,7 @@ for dcuid in args.dcuid:
                     )
                 except KeyError:
                     warnings.warn("Skipping {}".format(ch), UserWarning)
+                    continue
     gprint("    Complete")
 
 # write output

--- a/bin/gwdetchar-overflow
+++ b/bin/gwdetchar-overflow
@@ -206,9 +206,8 @@ for dcuid in args.dcuid:
                         data[ch],
                         cumulative=True,
                     )
-                except Exception as exc:
-                    warnings.warn("Skipping {}: [{}] {}".format(
-                        ch, type(exc), str(exc)), UserWarning)
+                except KeyError:
+                    warnings.warn("Skipping {}".format(ch), UserWarning)
     gprint("    Complete")
 
 # write output

--- a/bin/gwdetchar-scattering
+++ b/bin/gwdetchar-scattering
@@ -293,9 +293,8 @@ for i, channel in enumerate(sorted(allchannels)):
             gprint("Processing segment [%d .. %d)..." % seg)
         try:
             ts = alldata[j][channel]
-        except Exception:
-            warnings.warn("Skipping {}: [{}] {}".format(
-                channel, type(exc), str(exc)), UserWarning)
+        except KeyError:
+            warnings.warn("Skipping {}".format(channel), UserWarning)
         # get raw data and plot
         line = axes['position'].plot(ts, color=linecolor)[0]
         linecolor = line.get_color()

--- a/bin/gwdetchar-scattering
+++ b/bin/gwdetchar-scattering
@@ -261,7 +261,7 @@ for i, seg in enumerate(statea):
 
 scatter_segments = DataQualityDict()
 
-for i, channel in enumerate(sorted(allchannels)):
+for i, channel in enumerate(sorted(alldata[0].keys())):
     if args.verbose:
         gprint("-- Processing %s --------------------" % channel)
     chanstr = re.sub('[:-]', '_', channel).replace('_', '-', 1)
@@ -291,11 +291,7 @@ for i, channel in enumerate(sorted(allchannels)):
     for j, seg in enumerate(statea):
         if args.verbose:
             gprint("Processing segment [%d .. %d)..." % seg)
-        try:
-            ts = alldata[j][channel]
-        except KeyError:
-            warnings.warn("Skipping {}".format(channel), UserWarning)
-            continue
+        ts = alldata[j][channel]
         # get raw data and plot
         line = axes['position'].plot(ts, color=linecolor)[0]
         linecolor = line.get_color()

--- a/bin/gwdetchar-scattering
+++ b/bin/gwdetchar-scattering
@@ -295,6 +295,7 @@ for i, channel in enumerate(sorted(allchannels)):
             ts = alldata[j][channel]
         except KeyError:
             warnings.warn("Skipping {}".format(channel), UserWarning)
+            continue
         # get raw data and plot
         line = axes['position'].plot(ts, color=linecolor)[0]
         linecolor = line.get_color()

--- a/bin/gwdetchar-scattering
+++ b/bin/gwdetchar-scattering
@@ -291,7 +291,11 @@ for i, channel in enumerate(sorted(allchannels)):
     for j, seg in enumerate(statea):
         if args.verbose:
             gprint("Processing segment [%d .. %d)..." % seg)
-        ts = alldata[j][channel]
+        try:
+            ts = alldata[j][channel]
+        except Exception:
+            warnings.warn("Skipping {}: [{}] {}".format(
+                channel, type(exc), str(exc)), UserWarning)
         # get raw data and plot
         line = axes['position'].plot(ts, color=linecolor)[0]
         linecolor = line.get_color()

--- a/gwdetchar/io/datafind.py
+++ b/gwdetchar/io/datafind.py
@@ -108,7 +108,7 @@ def remove_missing_channels(channels, gwfcache):
     # get available channels from the first and last frame file
     available = set(io_gwf.iter_channel_names(gwfcache[0]))
     if len(gwfcache) > 1:
-        available.update(io_gwf.iter_channel_names(gwfcache[-1]))
+        available.intersection_update(io_gwf.iter_channel_names(gwfcache[-1]))
     # work out which channels to keep, and which to reject
     channels = set(channels)
     keep = channels & available

--- a/gwdetchar/io/datafind.py
+++ b/gwdetchar/io/datafind.py
@@ -21,10 +21,13 @@
 
 from __future__ import print_function
 
+import warnings
+
 import gwdatafind
 
 from ..const import DEFAULT_SEGMENT_SERVER
 
+from gwpy.io import gwf as io_gwf
 from gwpy.segments import (Segment, DataQualityFlag)
 from gwpy.timeseries import (TimeSeries, TimeSeriesDict)
 
@@ -68,6 +71,53 @@ def check_flag(flag, gpstime, duration, pad):
     if (not active.intersects_segment(seg)) or (abs(active[0]) < abs(seg)):
         return False
     return True
+
+
+def remove_missing_channels(channels, gwfcache):
+    """Find and remove channels from a given list that are not available in
+    a given cache of frame files
+
+    Parameters
+    ----------
+    channels : `list` of `str`
+        list of requested channels
+
+    gwfcache : `list` of `str`
+        list of paths to .gwf files
+
+    Returns
+    -------
+    keep : `list` of `str`
+        list of common channels found in the first and last files in the
+        cache
+
+    Notes
+    -----
+    As a shorthand, this utility checks `channels` against only the first
+    and last frame files in `gwfcache`. This saves time and memory by not
+    loading tables of contents for large numbers of very long data files.
+
+    For every channel requested that is not available in `gwfcache`, a
+    `UserWarning` will be raised.
+
+    See Also
+    --------
+    gwpy.io.gwf.iter_channel_names
+        for the utility used to identify frame contents
+    """
+    # get available channels from the first and last frame file
+    available = set(io_gwf.iter_channel_names(gwfcache[0]))
+    if len(gwfcache) > 1:
+        available.update(io_gwf.iter_channel_names(gwfcache[-1]))
+    # work out which channels to keep, and which to reject
+    channels = set(channels)
+    keep = channels & available
+    reject = channels - keep
+    for channel in reject:
+        warnings.warn(
+            '{} is being removed because it was not available in all '
+            'requested files'.format(channel), UserWarning)
+    return list(keep)
 
 
 def get_data(channel, start, end, frametype=None, source=None, nproc=1,
@@ -131,6 +181,8 @@ def get_data(channel, start, end, frametype=None, source=None, nproc=1,
         source = gwdatafind.find_urls(frametype[0], frametype, start, end)
     # read from frames or NDS
     if source:
+        if isinstance(channel, (list, tuple)):
+            channel = remove_missing_channels(channel, source)
         return series_class.read(
             source, channel, start=start, end=end, nproc=nproc,
             verbose=verbose, **kwargs)

--- a/gwdetchar/saturation.py
+++ b/gwdetchar/saturation.py
@@ -185,12 +185,14 @@ def is_saturated(channel, cache, start=None, end=None, indicator='LIMEN',
         if c.endswith('_LIMIT'):
             channels[i] = c[:-6]
     # check limit if set
-    indicators = ['%s_%s' % (c, indicator) for c in channels]
+    indicators = ['{}_{}'.format(c, indicator) for c in channels]
     data = get_data(indicators, start, start+1, source=cache, nproc=nproc)
 
     # check limits for returned channels
-    channels = [
-        c for c in channels if '{}_{}'.format(c, indicator) in data]
+    if len(data) < len(channels):  # exclude nonexistent channels
+        channels = [
+            c for c in channels if '{}_{}'.format(c, indicator) in data]
+        indicators = ['{}_{}'.format(c, indicator) for c in channels]
     if indicator.upper() == 'LIMEN':
         active = dict((c, data[indicators[i]].value[0]) for
                       i, c in enumerate(channels))

--- a/gwdetchar/saturation.py
+++ b/gwdetchar/saturation.py
@@ -187,6 +187,10 @@ def is_saturated(channel, cache, start=None, end=None, indicator='LIMEN',
     # check limit if set
     indicators = ['%s_%s' % (c, indicator) for c in channels]
     data = get_data(indicators, start, start+1, source=cache, nproc=nproc)
+
+    # check limits for returned channels
+    channels = [
+        c for c in channels if '{}_{}'.format(c, indicator) in data.keys()]
     if indicator.upper() == 'LIMEN':
         active = dict((c, data[indicators[i]].value[0]) for
                       i, c in enumerate(channels))

--- a/gwdetchar/saturation.py
+++ b/gwdetchar/saturation.py
@@ -190,7 +190,7 @@ def is_saturated(channel, cache, start=None, end=None, indicator='LIMEN',
 
     # check limits for returned channels
     channels = [
-        c for c in channels if '{}_{}'.format(c, indicator) in data.keys()]
+        c for c in channels if '{}_{}'.format(c, indicator) in data]
     if indicator.upper() == 'LIMEN':
         active = dict((c, data[indicators[i]].value[0]) for
                       i, c in enumerate(channels))

--- a/gwdetchar/tests/test_saturation.py
+++ b/gwdetchar/tests/test_saturation.py
@@ -85,8 +85,12 @@ def test_find_limit_channels():
     assert not swstats2
 
 
-@mock.patch('gwpy.timeseries.TimeSeriesDict.read', return_value=TSDICT)
-def test_is_saturated(mread):
+@mock.patch('gwdetchar.io.datafind.remove_missing_channels')
+@mock.patch('gwpy.timeseries.TimeSeriesDict.read')
+def test_is_saturated(tsdfetch, remove):
+    tsdfetch.return_value = TSDICT
+    remove.return_value = ['X1:TEST_LIMIT']
+
     saturated = saturation.is_saturated('X1:TEST', 1, start=0, end=8)
     assert isinstance(saturated, DataQualityFlag)
     assert_segmentlist_equal(saturated.active, SEGMENTS)


### PR DESCRIPTION
This PR adds a new utility under `gwdetchar.io.datafind` called `remove_missing_channels`. Whenever a list of channels is requested to `get_data`, this tool is used to exclude those channels that are missing from the first or last frame file within the given cache, throwing a loud warning showing exactly which channels are being ignored.

Two things to note:
* If NDS is used instead, `remove_missing_channels` is not invoked, meaning the call will still fail if channels cannot be found over the server.
* If only a single channel is passed (not a list), but that channel cannot be found in requested local frame files, then the call will still fail.

**Upshot:** Since all tools use `get_data` to retrieve timeseries data, this utility will cut down on the number of jobs that fail because channels are requested that cannot be found for the given time range, _except_ when using NDS or reading one channel at a time. In the latter case, users can easily work around this by wrapping the function call in a `try-except` block.

This fixes #150.

cc @duncanmmacleod, @areeda, @tjma12, @macedo22, @uberpye, @jrsmith02 