### PR TITLE
Gracefully handle large-memory SVG files

### DIFF
--- a/gwdetchar/io/html.py
+++ b/gwdetchar/io/html.py
@@ -326,7 +326,10 @@ def fancybox_img(img, linkparams=dict(), **params):
         'alt': os.path.basename(img),
         'class_': 'img-responsive',
     }
-    imgparams['src'] = img
+    if img.endswith('.svg') and os.path.isfile(img.replace('.svg', '.png')):
+        imgparams['src'] = img.replace('.svg', '.png')
+    else:
+        imgparams['src'] = img
     imgparams.update(params)
     page.img(id_='img_%s_%s' % (channel, duration), **imgparams)
     page.a.close()


### PR DESCRIPTION
This PR resolves a downstream bug in `hveto`, which now depends on `gwdetchar.io.html` for HTML construction. The issue is that large-memory SVG files cause webpages to crash, and the fix is to point to PNG thumbnails whenever possible.

cc @duncanmmacleod, @jrsmith02 