### PR TITLE
Explicitly support reading minute trend frames for lasso

### DIFF
--- a/bin/gwdetchar-lasso-correlation
+++ b/bin/gwdetchar-lasso-correlation
@@ -108,13 +108,17 @@ auto_xlabel = ('Time [hours] from '
                         Time(start, format='gps', scale='utc').iso)
                + ' UTC (%d)' % start)
 
+# get primary channel frametype
 primary = args.primary_channel.format(ifo=args.ifo)                             
 range_is_primary = 'DMT-SNSH_EFFECTIVE_RANGE_MPC.mean' in args.primary_channel
 if args.primary_frametype is None:
     if args.primary_channel == '{ifo}:GDS-CALIB_STRAIN':
         args.primary_frametype = '{}_HOFT_C00'.format(args.ifo)
-    if range_is_primary:
+    elif range_is_primary:
         args.primary_frametype = 'SenseMonitor_hoft_{}_M'.format(args.ifo)
+    else:
+        raise ValueError("Could not determine primary channel's frametype, "
+                         "please specify with --primary-frametype")
         
 
 if not os.path.isdir(args.output_dir):

--- a/bin/gwdetchar-lasso-correlation
+++ b/bin/gwdetchar-lasso-correlation
@@ -48,6 +48,14 @@ from gwdetchar.io.datafind import get_data
 from gwdetchar.plot import get_gwpy_tex_settings
 
 
+# default frametypes
+DEFAULT_FRAMETYPE = {
+    'GDS-CALIB_STRAIN': '{ifo}_HOFT_C00',
+    'DMT-SNSH_EFFECTIVE_RANGE_MPC.mean': 'SenseMonitor_hoft_{ifo}_M',
+    'DMT-SNSW_EFFECTIVE_RANGE_MPC.mean': 'SenseMonitor_CAL_{ifo}_M',
+}
+
+
 # -- parse command line -------------------------------------------------------
 
 parser = cli.create_parser(
@@ -68,8 +76,9 @@ parser.add_argument('-T', '--trend-type', default='minute',
 parser.add_argument('-p', '--primary-channel',
                     default='{ifo}:DMT-SNSH_EFFECTIVE_RANGE_MPC.mean',
                     help='name of primary channel to use')
-parser.add_argument('-P', '--primary-frametype',
-                    help='frametype for --primary-channel')
+parser.add_argument('-P', '--primary-frametype', default=None,
+                    help='frametype for --primary-channel, default: guess '
+                         'by channel name')
 parser.add_argument('-O', '--remove-outliers', type=float, default=None,
                     help='Std. dev. limit for removing outliers')
 parser.add_argument('-t', '--threshold', type=float, default=0.0001,
@@ -110,15 +119,14 @@ auto_xlabel = ('Time [hours] from '
 
 # get primary channel frametype
 primary = args.primary_channel.format(ifo=args.ifo)                             
-range_is_primary = 'DMT-SNSH_EFFECTIVE_RANGE_MPC.mean' in args.primary_channel
+range_is_primary = 'EFFECTIVE_RANGE_MPC' in args.primary_channel
 if args.primary_frametype is None:
-    if args.primary_channel == '{ifo}:GDS-CALIB_STRAIN':
-        args.primary_frametype = '{}_HOFT_C00'.format(args.ifo)
-    elif range_is_primary:
-        args.primary_frametype = 'SenseMonitor_hoft_{}_M'.format(args.ifo)
-    else:
-        raise ValueError("Could not determine primary channel's frametype, "
-                         "please specify with --primary-frametype")
+    try:
+        args.primary_frametype = DEFAULT_FRAMETYPE[
+            args.primary_channel.split(':')[1]].format(ifo=args.ifo)
+    except KeyError as exc:
+        raise type(exc)("Could not determine primary channel's frametype, "
+                        "please specify with --primary-frametype")
         
 
 if not os.path.isdir(args.output_dir):

--- a/bin/gwdetchar-lasso-correlation
+++ b/bin/gwdetchar-lasso-correlation
@@ -108,10 +108,14 @@ auto_xlabel = ('Time [hours] from '
                         Time(start, format='gps', scale='utc').iso)
                + ' UTC (%d)' % start)
 
-if args.primary_channel == '{ifo}:GDS-CALIB_STRAIN':
-    args.primary_frametype = '%s_HOFT_C00' % args.ifo
-primary = args.primary_channel.format(ifo=args.ifo)
+primary = args.primary_channel.format(ifo=args.ifo)                             
 range_is_primary = 'DMT-SNSH_EFFECTIVE_RANGE_MPC.mean' in args.primary_channel
+if args.primary_frametype is None:
+    if args.primary_channel == '{ifo}:GDS-CALIB_STRAIN':
+        args.primary_frametype = '{}_HOFT_C00'.format(args.ifo)
+    if range_is_primary:
+        args.primary_frametype = 'SenseMonitor_hoft_{}_M'.format(args.ifo)
+        
 
 if not os.path.isdir(args.output_dir):
     os.makedirs(args.output_dir)
@@ -126,7 +130,7 @@ if args.band_pass:
 
     print("-- Loading primary channel data")
     bandts = get_data(
-        primary, start-pad, end+pad, verbose=True,
+        primary, start-pad, end+pad, verbose=True, obs=args.ifo[0],
         frametype=args.primary_frametype, nproc=args.nproc)
     if flower < 0 or fupper >= float((bandts.sample_rate/2.).value):
         raise ValueError("bandpass frequency is out of range for this "
@@ -158,7 +162,7 @@ else:
     # load primary channel data
     print("-- Loading primary channel data")
     primaryts = get_data(primary, start, end, frametype=args.primary_frametype,
-                         verbose=True, nproc=args.nproc)
+                         obs=args.ifo[0], verbose=True, nproc=args.nproc)
 
 if args.remove_outliers:
     print("-- Removing outliers above %f sigma" % args.remove_outliers)
@@ -193,7 +197,7 @@ else:
     frametype = '%s_T' % args.ifo  # for second trends
 
 auxdata = get_data(
-    channels, start, end, verbose=True, frametype=frametype,
+    channels, start, end, verbose=True, obs=args.ifo[0], frametype=frametype,
     nproc=args.nproc, pad=0)
 
 # -- removes flat data to be re-introdused later

--- a/bin/gwdetchar-lasso-correlation
+++ b/bin/gwdetchar-lasso-correlation
@@ -142,8 +142,8 @@ if args.band_pass:
 
     print("-- Loading primary channel data")
     bandts = get_data(
-        primary, start-pad, end+pad, verbose=True, obs=args.ifo[0],
-        frametype=args.primary_frametype, nproc=args.nproc)
+        primary, start-pad, end+pad, verbose='Reading primary:',
+        obs=args.ifo[0], frametype=args.primary_frametype, nproc=args.nproc)
     if flower < 0 or fupper >= float((bandts.sample_rate/2.).value):
         raise ValueError("bandpass frequency is out of range for this "
                          "channel, band (Hz): {0}, sample rate: {1}".format(
@@ -174,7 +174,7 @@ else:
     # load primary channel data
     print("-- Loading primary channel data")
     primaryts = get_data(primary, start, end, frametype=args.primary_frametype,
-                         obs=args.ifo[0], verbose=True, nproc=args.nproc)
+                         obs=args.ifo[0], verbose='Reading:', nproc=args.nproc)
 
 if args.remove_outliers:
     print("-- Removing outliers above %f sigma" % args.remove_outliers)
@@ -209,8 +209,8 @@ else:
     frametype = '%s_T' % args.ifo  # for second trends
 
 auxdata = get_data(
-    channels, start, end, verbose=True, obs=args.ifo[0], frametype=frametype,
-    nproc=args.nproc, pad=0)
+    channels, start, end, verbose='Reading:', obs=args.ifo[0],
+    frametype=frametype, nproc=args.nproc, pad=0)
 
 # -- removes flat data to be re-introdused later
 

--- a/bin/gwdetchar-omega
+++ b/bin/gwdetchar-omega
@@ -181,7 +181,7 @@ if not args.disable_correlation:
     end = gps + duration/2. + 1
     correlate = get_data(
         name, start, end, frametype=primary.frametype, source=primary.source,
-        obs=ifo[0], nproc=args.nproc, verbose='    Reading primary: ')
+        nproc=args.nproc, verbose='    Reading primary: ')
     correlate = omega.primary(
         gps, primary.length, correlate, fftlength, resample=primary.resample,
         f_low=primary.flow)
@@ -211,7 +211,7 @@ for block in blocks.values():
     end = gps + duration/2. + 1
     data = get_data(
         chans, start, end, frametype=block.frametype, source=block.source,
-        obs=ifo[0], nproc=args.nproc, verbose='    Reading block: ')
+        nproc=args.nproc, verbose='    Reading block: ')
 
     # scan individual channels
     for channel in block.channels:

--- a/bin/gwdetchar-omega
+++ b/bin/gwdetchar-omega
@@ -181,7 +181,7 @@ if not args.disable_correlation:
     end = gps + duration/2. + 1
     correlate = get_data(
         name, start, end, frametype=primary.frametype, source=primary.source,
-        nproc=args.nproc, verbose='    Reading primary: ')
+        obs=ifo[0], nproc=args.nproc, verbose='    Reading primary: ')
     correlate = omega.primary(
         gps, primary.length, correlate, fftlength, resample=primary.resample,
         f_low=primary.flow)
@@ -211,7 +211,7 @@ for block in blocks.values():
     end = gps + duration/2. + 1
     data = get_data(
         chans, start, end, frametype=block.frametype, source=block.source,
-        nproc=args.nproc, verbose='    Reading block: ')
+        obs=ifo[0], nproc=args.nproc, verbose='    Reading block: ')
 
     # scan individual channels
     for channel in block.channels:

--- a/bin/gwdetchar-scattering
+++ b/bin/gwdetchar-scattering
@@ -257,7 +257,7 @@ for i, seg in enumerate(statea):
     ) if args.verbose else False
     alldata.append(
         get_data(allchannels, seg[0], seg[1], frametype=args.frametype,
-                 verbose=msg, nproc=args.nproc).resample(128))
+                 obs=args.ifo[0], verbose=msg, nproc=args.nproc).resample(128))
 
 scatter_segments = DataQualityDict()
 

--- a/bin/gwdetchar-slow-correlation
+++ b/bin/gwdetchar-slow-correlation
@@ -107,7 +107,7 @@ rcParams.update(tex_settings)
 # load data
 print("-- Loading range data")
 rangets = get_data(rangechannel, start, end, frametype=args.range_frametype,
-                   verbose=True, nproc=args.nproc)
+                   obs=args.ifo[0], verbose=True, nproc=args.nproc)
 
 if args.trend_type == 'minute':
     dstart, dend = rangets.span
@@ -116,7 +116,7 @@ else:
     dend = end
 
 print("-- Loading h(t) data")
-darmts = get_data(primary, dstart-pad, dend+pad, verbose=True,
+darmts = get_data(primary, dstart-pad, dend+pad, verbose=True, obs=args.ifo[0],
                   frametype=args.primary_frametype, nproc=args.nproc)
 
 # get darm BLRMS
@@ -179,8 +179,8 @@ if args.trend_type == 'minute':
     frametype = '%s_M' % args.ifo  # for minute trends
 else:
     frametype = '%s_T' % args.ifo  # for second trends
-auxdata = get_data(map(str, channels), dstart, dend, verbose=True,
-                   frametype=frametype, nproc=args.nproc, pad=0)
+auxdata = get_data(map(str, channels), dstart, dend, verbose=True, pad=0,
+                   obs=args.ifo[0], frametype=frametype, nproc=args.nproc)
 
 gpsstub = '%d-%d' % (start, end-start)
 re_delim = re.compile('[:_-]')

--- a/gwdetchar/io/datafind.py
+++ b/gwdetchar/io/datafind.py
@@ -120,8 +120,8 @@ def remove_missing_channels(channels, gwfcache):
     return list(keep)
 
 
-def get_data(channel, start, end, frametype=None, source=None, nproc=1,
-             verbose=False, **kwargs):
+def get_data(channel, start, end, obs=None, frametype=None, source=None,
+             nproc=1, verbose=False, **kwargs):
     """Retrieve data for given channels within a certain time range
 
     Parameters
@@ -134,6 +134,10 @@ def get_data(channel, start, end, frametype=None, source=None, nproc=1,
 
     end : `float`
         GPS end time of requested data
+
+    obs : `str`, optional
+        single-letter name of observatory, defaults to the first letter of
+        `frametype`
 
     frametype : `str`, optional
         name of frametype in which channel(s) are stored, required if `source`
@@ -178,7 +182,8 @@ def get_data(channel, start, end, frametype=None, source=None, nproc=1,
         series_class = TimeSeries
     # construct file cache if none is given
     if source is None:
-        source = gwdatafind.find_urls(frametype[0], frametype, start, end)
+        obs = obs if obs is not None else frametype[0]
+        source = gwdatafind.find_urls(obs, frametype, start, end)
     # read from frames or NDS
     if source:
         if isinstance(channel, (list, tuple)):


### PR DESCRIPTION
This PR explicitly supports reading minute trends from local frame files by allowing users to pass an `observatory` argument to `gwdatafind.find_urls`. It also makes sure lasso's `--primary-frametype` is set if the primary channel is BNS range.

cc @macedo22, @marissawalker, @duncanmmacleod 