### PR TITLE
Fixed bug reading limit channels in software-saturation tool

### DIFF
--- a/gwdetchar/saturation.py
+++ b/gwdetchar/saturation.py
@@ -30,6 +30,7 @@ import numpy
 from astropy.units import Quantity
 from multiprocessing import (cpu_count, Pool)
 
+from gwpy.io.cache import file_segment
 from gwpy.timeseries import StateTimeSeries
 
 from .io.datafind import get_data
@@ -186,7 +187,8 @@ def is_saturated(channel, cache, start=None, end=None, indicator='LIMEN',
             channels[i] = c[:-6]
     # check limit if set
     indicators = ['{}_{}'.format(c, indicator) for c in channels]
-    data = get_data(indicators, start, start+1, source=cache, nproc=nproc)
+    gps = file_segment(cache[0])[0]
+    data = get_data(indicators, gps, gps+1, source=cache, nproc=nproc)
 
     # check limits for returned channels
     if len(data) < len(channels):  # exclude nonexistent channels

--- a/gwdetchar/tests/test_saturation.py
+++ b/gwdetchar/tests/test_saturation.py
@@ -88,18 +88,23 @@ def test_find_limit_channels():
 @mock.patch('gwdetchar.io.datafind.remove_missing_channels')
 @mock.patch('gwpy.timeseries.TimeSeriesDict.read')
 def test_is_saturated(tsdfetch, remove):
+    cache = [
+        "X-TEST-0-1.gwf",
+    ]
+
     tsdfetch.return_value = TSDICT
     remove.return_value = ['X1:TEST_LIMIT']
 
-    saturated = saturation.is_saturated('X1:TEST', 1, start=0, end=8)
+    saturated = saturation.is_saturated('X1:TEST', cache, start=0, end=8)
     assert isinstance(saturated, DataQualityFlag)
     assert_segmentlist_equal(saturated.active, SEGMENTS)
 
-    saturated2 = saturation.is_saturated(['X1:TEST_LIMIT'], 1, start=0, end=8)
+    saturated2 = saturation.is_saturated(
+        ['X1:TEST_LIMIT'], cache, start=0, end=8)
     assert isinstance(saturated2, list)
     assert_segmentlist_equal(saturated2[0].active, saturated.active)
 
     with pytest.raises(ValueError) as exc:
         saturated3 = saturation.is_saturated(
-            'X1:TEST', 1, start=0, end=8, indicator='blah')
+            'X1:TEST', cache, start=0, end=8, indicator='blah')
     assert str(exc.value).startswith("Don't know how to determine")


### PR DESCRIPTION
This PR fixes a bug determining the relevant channels in the `gwdetchar-software-saturations` tools, when the cache doesn't contain an entry at the 'start' time.