### PR TITLE
Remove custom panel formatting

### DIFF
--- a/gwdetchar/omega/html.py
+++ b/gwdetchar/omega/html.py
@@ -573,7 +573,7 @@ def write_block(blockkey, block, context,
         the formatted HTML for this block
     """
     page = markup.page()
-    page.div(class_='panel panel-%s' % context)
+    page.div(class_='panel well panel-%s' % context)
     # -- make heading
     page.div(class_='panel-heading clearfix')
     # link to top of page

--- a/gwdetchar/omega/tests/test_html.py
+++ b/gwdetchar/omega/tests/test_html.py
@@ -140,7 +140,7 @@ for channel in ANALYZED['GW']['channels']:
     channel.stdev = 1
     channel.delay = 0
 
-BLOCK_HTML = """<div class="panel panel-info">
+BLOCK_HTML = """<div class="panel well panel-info">
 <div class="panel-heading clearfix">
 <div class="pull-right">
 <a href="#" class="text-info"><small>[top]</small></a>

--- a/share/sass/gwdetchar.scss
+++ b/share/sass/gwdetchar.scss
@@ -64,11 +64,6 @@ a {
 		}
 }
 
-.panel {
-		box-shadow: 0 1px 10px rgba(0, 0, 0, 0.23), 0 1px 10px rgba(0, 0, 0, 0.16);
-		margin-bottom: 35px;
-}
-
 .with-margin {
 		margin-bottom: 15px;
 }


### PR DESCRIPTION
This PR removes custom `panel` formatting from `share/sass/gwdetchar.scss`, and has omega scans use the `panel well` class from `bootstrap-ligo` CSS. This has the upshot of removing drop shadows from panels that are collapsible, like the ones used in [**`gwdetchar-scattering`**](https://ldas-jobs.ligo-la.caltech.edu/~aurban/scattering/day/20190326/).

cc @duncanmmacleod 