### PR TITLE
changes in PeakF limits and writing a csv file

### DIFF
--- a/bin/gwdetchar-scattering
+++ b/bin/gwdetchar-scattering
@@ -518,7 +518,7 @@ actives = actives.coalesce() # merge contigous segments
 gps = [x for x in highsnrtrigs[names[0]] for y in actives if x in y]
 segs = [tuple(y) for x in highsnrtrigs[names[0]] for y in actives if x in y]
 data = Table([gps, segs], names=['trigger_time', 'segment'])
-data.write('summary.csv', overwrite=True, fast_writer=False)                         
+data.write(summfile, overwrite=True, fast_writer=False)                         
 
 # -- finalize -----------------------------------------------------------------
 

--- a/bin/gwdetchar-scattering
+++ b/bin/gwdetchar-scattering
@@ -350,7 +350,7 @@ for i, channel in enumerate(sorted(alldata[0].keys())):
     logger.info("Efficiency/Deadtime: %.2f" % effdt)
     
     if abs(scatter_segments[channel].active):    
-          actives.append(scatter_segments[channel].active)
+          actives.extend(scatter_segments[channel].active)
 
     # finalize plot
     logger.debug("Plotting")
@@ -504,9 +504,9 @@ page.div.close()
 # write a csv file.  
 logger.debug('Writing a summary CSV record')
 #b = [x for x in a if len(x) != 0]
-c = [item for x in actives for item in x]
-d1 = [x for x in highsnrtrigs[names[0]] for y in c if x in y]
-e =  [y for x in highsnrtrigs[names[0]] for y in c if x in y]
+#c = [item for x in actives for item in x]
+d1 = [x for x in highsnrtrigs[names[0]] for y in actives if x in y]
+e =  [y for x in highsnrtrigs[names[0]] for y in actives if x in y]
 rows = zip(d1, e)    
 data = Table([d1, e], names = ['Gpstime','Segment'])
 data.write('summary.csv', overwrite = True)                         

--- a/bin/gwdetchar-scattering
+++ b/bin/gwdetchar-scattering
@@ -123,7 +123,6 @@ if not os.path.isdir(args.output_dir):
 os.chdir(args.output_dir)
 
 segfile = '%s-SCATTERING_SEGMENTS_%s_HZ-%s.h5' % (args.ifo, tstr, gpsstr)
-
 summfile = '{}-SCATTERING_SUMMARY-{}.csv'.format(args.ifo, gpsstr)
 
 logger.info('{} Scattering {}-{}'.format(

--- a/bin/gwdetchar-scattering
+++ b/bin/gwdetchar-scattering
@@ -348,9 +348,9 @@ for i, channel in enumerate(sorted(alldata[0].keys())):
         effdt = efficiencypc/deadtimepc
     logger.info("Efficiency/Deadtime: %.2f" % effdt)
         
-    a.append(scatter_segments[channel].active) # made this change, next 3 lines
-    print(len(a))
-    print(len(highsnrtrigs[names[0]]))
+    a.append(scatter_segments[channel].active) #change
+    
+    
 
     # finalize plot
     logger.debug("Plotting")
@@ -502,12 +502,12 @@ for i, channel in enumerate(sorted(alldata[0].keys())):
 page.div.close()
 
 # write a csv file.                           
-print(len(a))
+
 b = [i for i in a if len(i) != 0]
-print(len(b))
-c = [item for i in b for item in i]
-d1 = [i for i in highsnrtrigs[names[0]] for j in c if i in j]
-e =  [j for i in highsnrtrigs[names[0]] for j in c if i in j]
+
+c = [item for i in b for item in i] # b is a list of list,so flattening it.
+d1 = [i for i in highsnrtrigs[names[0]] for j in c if i in j] # collecting the gpstimes that are within segments.
+e =  [j for i in highsnrtrigs[names[0]] for j in c if i in j] # collecting the segments that contains gpstimes.
 rows = zip(d1,e)    
 data = Table([d1,e], names = ['Gpstime','Segment'])
 data.write('summary.csv')                         

--- a/bin/gwdetchar-scattering
+++ b/bin/gwdetchar-scattering
@@ -476,7 +476,7 @@ for i, channel in enumerate(sorted(alldata[0].keys())):
         page.tr()
         page.th('Efficiency<br><small>(SNR&ge;8 and '
                 '%.2f Hz</sub>&ltf<sub>peak</sub>&lt;%.2f Hz)</small>'
-                % (10*1,4 * args.frequency_threshold))
+                % (10,4 * args.frequency_threshold))
         page.td('%d/%d events' % (efficiency, len(highsnrtrigs)))
         page.td('%.2f%%' % efficiencypc)
         page.tr.close()

--- a/bin/gwdetchar-scattering
+++ b/bin/gwdetchar-scattering
@@ -231,9 +231,7 @@ page.p()
 page.add('The full output segments are recorded in HDF5 format here:')
 page.a(os.path.basename(segfile), href=segfile, target='_blank')
 page.p.close()
-
 # link summary file
-page.h3('Summary')
 page.p()
 page.add('A summary of triggers that occur during active scattering '
          'segments is recorded in CSV format here:')

--- a/bin/gwdetchar-scattering
+++ b/bin/gwdetchar-scattering
@@ -1,4 +1,4 @@
-#!/home/siddharth.soni/.conda/envs/gwdetchar-siddev/bin/python
+#!/usr/bin/env python
 # coding=utf-8
 # Copyright (C) LIGO Scientific Collaboration (2015-)
 #
@@ -37,8 +37,7 @@ import gwtrigfind
 
 from gwpy.plot import Plot
 from gwpy.plot.tex import label_to_latex
-from gwpy.utils import gprint
-from gwpy.table import EventTable
+from gwpy.table import (Table, EventTable)
 from gwpy.table.filters import in_segmentlist
 from gwpy.segments import (DataQualityFlag, DataQualityDict,
                            Segment, SegmentList)
@@ -99,10 +98,16 @@ parser.add_argument('-o', '--output-dir', type=os.path.abspath,
                     default=os.curdir,
                     help='output directory for analysis, default: %(default)s')
 parser.add_argument('-v', '--verbose', action='store_true', default=False,
-                    help='print verbose output, default: %(default)s')
+                    help='log verbose output, default: %(default)s')
 cli.add_nproc_option(parser)
 
 args = parser.parse_args()
+
+# set up logger
+logger = cli.logger(
+    name = os.path.basename(__file__),
+    level='DEBUG' if args.verbose else 'INFO',
+)
 
 if args.frequency_threshold.is_integer():
     args.frequency_threshold = int(args.frequency_threshold)
@@ -119,6 +124,9 @@ os.chdir(args.output_dir)
 
 segfile = '%s-SCATTERING_SEGMENTS_%s_HZ-%s.h5' % (args.ifo, tstr, gpsstr)
 
+logger.info('{} Scattering {}-{}'.format(
+    args.ifo, int(args.gpsstart), int(args.gpsend)))
+
 # -- get state segments -------------------------------------------------------
 
 span = Segment(args.gpsstart, args.gpsend)
@@ -134,23 +142,21 @@ if args.state_flag is not None:
             state.active[i] = type(seg)(
                 seg[0]+args.segment_start_pad, seg[1]-args.segment_end_pad)
         else:
-            if args.verbose:
-                gprint("Segment length {} shorter than padding length {}, "
-                       "skipping this segment".format(abs(seg), padding))
+            logger.debug(
+                "Segment length {} shorter than padding length {}, "
+                "skipping this segment".format(abs(seg), padding))
     state.coalesce()
     statea = state.active
     livetime = float(abs(statea))
-    if args.verbose:
-        gprint("Downloaded %d segments for %s [%.2fs livetime]"
-               % (len(statea), args.state_flag, livetime))
+    logger.debug("Downloaded %d segments for %s [%.2fs livetime]"
+                 % (len(statea), args.state_flag, livetime))
 else:
     statea = SegmentList([span])
 
 # -- load h(t) ----------------------------------------------------------------
 
 args.main_channel = args.main_channel.format(IFO=args.ifo)
-if args.verbose:
-    gprint("Loading Omicron triggers for %s..." % args.main_channel, end=' ')
+logger.debug("Loading Omicron triggers for %s..." % args.main_channel)
 
 if args.gpsstart >= 1230336018:  # Jan 1 2019
     ext = "h5"
@@ -202,13 +208,11 @@ else:  # no files (no livetime?)
     trigs = EventTable(names=names)
 
 highsnrtrigs = trigs[trigs['snr'] >= 8]
-if args.verbose:
-    gprint("%d read" % len(trigs))
+logger.debug("%d read" % len(trigs))
 
 # -- prepare HTML -------------------------------------------------------------
 
 page = htmlio.new_bootstrap_page(title='%s Scattering' % args.ifo)
-page.div(class_='container')
 page.div(class_='page-header')
 page.h1('%s scattering: %d-%d'
         % (args.ifo, int(args.gpsstart), int(args.gpsend)))
@@ -218,7 +222,7 @@ page.p("This analysis searched for evidence of beam scattering based on the "
        "0264-9381/27/19/194011\" target=\"_blank\">Accadia et al. (2010)</a>.")
 page.div.close()
 page.add(htmlio.write_arguments(
-    [], start=int(args.gpsstart), end=int(args.gpsend), flag=args.state_flag)) 
+    [], start=int(args.gpsstart), end=int(args.gpsend), flag=args.state_flag))
 
 # link segments file
 page.h2('Segments')
@@ -226,7 +230,7 @@ page.p()
 page.add('The full output segments are recorded in HDF5 format here:')
 page.a(os.path.basename(segfile), href=segfile, target='_blank')
 page.p.close()
-# print state segments
+# record state segments
 if args.state_flag is not None:
     page.p('This analysis was executed over the following segments:')
     page.div(class_='panel-group', id_='accordion1')
@@ -245,12 +249,11 @@ page.div(class_='panel-group', id_='accordion1')
 allchannels = ['%s:%s' % (args.ifo, c) for optic in args.optic for
                c in scattering.OPTIC_MOTION_CHANNELS[optic]]
 
-if args.verbose:
-    print("Reading all data:")
+logger.info("Reading all data:")
 alldata = []
 n = len(statea)
 for i, seg in enumerate(statea):
-    msg = "    {0}/{1} {2}: ".format(
+    msg = "{0}/{1} {2}:".rjust(30).format(
         str(i).rjust(len(str(n))),
         n,
         str(seg),
@@ -262,8 +265,7 @@ for i, seg in enumerate(statea):
 scatter_segments = DataQualityDict()
 a = [] # made this change
 for i, channel in enumerate(sorted(alldata[0].keys())):
-    if args.verbose:
-        gprint("-- Processing %s --------------------" % channel)
+    logger.info("-- Processing %s" % channel)
     chanstr = re.sub('[:-]', '_', channel).replace('_', '-', 1)
     optic = channel.split('-')[1].split('_')[0]
     flag = '%s:DCH-%s_SCATTERING_GE_%s_HZ:1' % (args.ifo, optic, tstr)
@@ -289,8 +291,7 @@ for i, channel in enumerate(sorted(alldata[0].keys())):
     fringecolors = [None] * len(scattering.FREQUENCY_MULTIPLIERS)
     # loop over state segments and find scattering fringes
     for j, seg in enumerate(statea):
-        if args.verbose:
-            gprint("Processing segment [%d .. %d)..." % seg)
+        logger.debug("Processing segment [%d .. %d)..." % seg)
         ts = alldata[j][channel]
         # get raw data and plot
         line = axes['position'].plot(ts, color=linecolor)[0]
@@ -320,11 +321,9 @@ for i, channel in enumerate(sorted(alldata[0].keys())):
                                      'edgecolor': 'gray', 'height': 0.4},
                               height=0.8, y=0, label=' ')
         scatter_segments[channel] += scatter
-        if args.verbose:
-            gprint("    Found %d scattering segments" % (len(scatter.active)))
-    if args.verbose:
-        gprint("Completed channel, found %d segments in total."
-               % len(scatter_segments[channel].active))
+        logger.debug("    Found %d scattering segments" % (len(scatter.active)))
+    logger.debug("Completed channel, found %d segments in total."
+                 % len(scatter_segments[channel].active))
 
     # calculate efficiency and deadtime of veto
     deadtime = abs(scatter_segments[channel].active)
@@ -332,32 +331,28 @@ for i, channel in enumerate(sorted(alldata[0].keys())):
         deadtimepc = deadtime / livetime * 100
     except ZeroDivisionError:
         deadtimepc = 0.
-    if args.verbose:
-        gprint("Deadtime: %.2f%% (%.2f/%ds)"
-               % (deadtimepc, deadtime, livetime))
+    logger.info("Deadtime: %.2f%% (%.2f/%ds)"
+                % (deadtimepc, deadtime, livetime))
     efficiency = in_segmentlist(highsnrtrigs[names[0]],
                                 scatter_segments[channel].active).sum()
     try:
         efficiencypc = efficiency / len(highsnrtrigs) * 100
     except ZeroDivisionError:
         efficiencypc = 0.
-    if args.verbose:
-        gprint("Efficiency (SNR>=8): %.2f%% (%d/%d)"
-               % (efficiencypc, efficiency, len(highsnrtrigs)))
+    logger.info("Efficiency (SNR>=8): %.2f%% (%d/%d)"
+                % (efficiencypc, efficiency, len(highsnrtrigs)))
     if deadtimepc == 0.:
         effdt = 0
     else:
         effdt = efficiencypc/deadtimepc
-    if args.verbose:
-        gprint("Efficiency/Deadtime: %.2f" % effdt)
+    logger.info("Efficiency/Deadtime: %.2f" % effdt)
         
     a.append(scatter_segments[channel].active) # made this change, next 3 lines
     print(len(a))
     print(len(highsnrtrigs[names[0]]))
 
     # finalize plot
-    if args.verbose:
-        gprint("Plotting...", end=' ')
+    logger.debug("Plotting...")
     name = label_to_latex(channel) if rcParams["text.usetex"] else channel
     axes['position'].set_title("Scattering evidence in %s" % name)
     axes['position'].set_xlabel('')
@@ -418,8 +413,7 @@ for i, channel in enumerate(sorted(alldata[0].keys())):
         plot.refresh()
         plot.save(png)
     plot.close()
-    if args.verbose:
-        gprint("%s written." % png)
+    logger.debug("%s written." % png)
 
     # make histogram
     histogram = Plot(figsize=[12, 6])
@@ -512,30 +506,14 @@ d1 = [i for i in highsnrtrigs[names[0]] for j in c if i in j]
 e =  [j for i in highsnrtrigs[names[0]] for j in c if i in j]
 rows = zip(d1,e)    
 data = Table([d1,e], names = ['Gpstime','Segment'])
-data.write('summary.csv')
-#import csv
-#with open("summary.csv",'wt') as ff:
-#     ff.write("Gpstime")
-#     ff.write(",")
-#     ff.write("Segment")
-#     ff.write("\n")
-#     for i,j in rows:
-#         ff.write(str(i))
-#         ff.write(",")
-#         ff.write(str(j))
-#         ff.write("\n")                          
+data.write('summary.csv')                         
 
 # -- finalize -----------------------------------------------------------------
 
 # write segments
 scatter_segments.write(segfile, path="segments", overwrite=True)
-if args.verbose:
-    gprint("%s written" % segfile)
+logger.debug("%s written" % segfile)
 
 # write HTML
-page.add(htmlio.write_footer())
-page.div.close()
-with open('index.html', 'w') as fp:
-    fp.write(str(page))
-if args.verbose:
-    gprint("-- index.html written, all done --")
+htmlio.close_page(page, 'index.html')
+logger.info("-- index.html written, all done --")

--- a/bin/gwdetchar-scattering
+++ b/bin/gwdetchar-scattering
@@ -503,12 +503,11 @@ page.div.close()
 
 # write a csv file.  
 logger.debug('Writing a summary CSV record')
-#b = [x for x in a if len(x) != 0]
-#c = [item for x in actives for item in x]
-d1 = [x for x in highsnrtrigs[names[0]] for y in actives if x in y]
-e =  [y for x in highsnrtrigs[names[0]] for y in actives if x in y]
-rows = zip(d1, e)    
-data = Table([d1, e], names = ['Gpstime','Segment'])
+
+actives = actives.coalesce() # merge contigous segments 
+gps = [x for x in highsnrtrigs[names[0]] for y in actives if x in y]
+segs =  [y for x in highsnrtrigs[names[0]] for y in actives if x in y]
+data = Table([gps, segs], names = ['trigger_time','segment'])
 data.write('summary.csv', overwrite = True)                         
 
 # -- finalize -----------------------------------------------------------------

--- a/bin/gwdetchar-scattering
+++ b/bin/gwdetchar-scattering
@@ -508,7 +508,7 @@ actives = actives.coalesce() # merge contigous segments
 gps = [x for x in highsnrtrigs[names[0]] for y in actives if x in y]
 segs =  [y for x in highsnrtrigs[names[0]] for y in actives if x in y]
 data = Table([gps, segs], names=['trigger_time', 'segment'])
-data.write('summary.csv', overwrite=True)                         
+data.write('summary.csv', overwrite=True, fast_writer=False)                         
 
 # -- finalize -----------------------------------------------------------------
 

--- a/bin/gwdetchar-scattering
+++ b/bin/gwdetchar-scattering
@@ -507,8 +507,8 @@ logger.debug('Writing a summary CSV record')
 actives = actives.coalesce() # merge contigous segments 
 gps = [x for x in highsnrtrigs[names[0]] for y in actives if x in y]
 segs =  [y for x in highsnrtrigs[names[0]] for y in actives if x in y]
-data = Table([gps, segs], names = ['trigger_time','segment'])
-data.write('summary.csv', overwrite = True)                         
+data = Table([gps, segs], names=['trigger_time', 'segment'])
+data.write('summary.csv', overwrite=True)                         
 
 # -- finalize -----------------------------------------------------------------
 

--- a/bin/gwdetchar-scattering
+++ b/bin/gwdetchar-scattering
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/home/siddharth.soni/.conda/envs/gwdetchar-siddev/bin/python
 # coding=utf-8
 # Copyright (C) LIGO Scientific Collaboration (2015-)
 #
@@ -37,6 +37,7 @@ import gwtrigfind
 
 from gwpy.plot import Plot
 from gwpy.plot.tex import label_to_latex
+from gwpy.utils import gprint
 from gwpy.table import EventTable
 from gwpy.table.filters import in_segmentlist
 from gwpy.segments import (DataQualityFlag, DataQualityDict,
@@ -98,16 +99,10 @@ parser.add_argument('-o', '--output-dir', type=os.path.abspath,
                     default=os.curdir,
                     help='output directory for analysis, default: %(default)s')
 parser.add_argument('-v', '--verbose', action='store_true', default=False,
-                    help='log verbose output, default: %(default)s')
+                    help='print verbose output, default: %(default)s')
 cli.add_nproc_option(parser)
 
 args = parser.parse_args()
-
-# set up logger
-logger = cli.logger(
-    name=os.path.basename(__file__),
-    level='DEBUG' if args.verbose else 'INFO',
-)
 
 if args.frequency_threshold.is_integer():
     args.frequency_threshold = int(args.frequency_threshold)
@@ -124,9 +119,6 @@ os.chdir(args.output_dir)
 
 segfile = '%s-SCATTERING_SEGMENTS_%s_HZ-%s.h5' % (args.ifo, tstr, gpsstr)
 
-logger.info('{} Scattering {}-{}'.format(
-    args.ifo, int(args.gpsstart), int(args.gpsend)))
-
 # -- get state segments -------------------------------------------------------
 
 span = Segment(args.gpsstart, args.gpsend)
@@ -142,21 +134,23 @@ if args.state_flag is not None:
             state.active[i] = type(seg)(
                 seg[0]+args.segment_start_pad, seg[1]-args.segment_end_pad)
         else:
-            logger.debug(
-                "Segment length {} shorter than padding length {}, "
-                "skipping this segment".format(abs(seg), padding))
+            if args.verbose:
+                gprint("Segment length {} shorter than padding length {}, "
+                       "skipping this segment".format(abs(seg), padding))
     state.coalesce()
     statea = state.active
     livetime = float(abs(statea))
-    logger.debug("Downloaded %d segments for %s [%.2fs livetime]"
-                 % (len(statea), args.state_flag, livetime))
+    if args.verbose:
+        gprint("Downloaded %d segments for %s [%.2fs livetime]"
+               % (len(statea), args.state_flag, livetime))
 else:
     statea = SegmentList([span])
 
 # -- load h(t) ----------------------------------------------------------------
 
 args.main_channel = args.main_channel.format(IFO=args.ifo)
-logger.debug("Loading Omicron triggers for %s" % args.main_channel)
+if args.verbose:
+    gprint("Loading Omicron triggers for %s..." % args.main_channel, end=' ')
 
 if args.gpsstart >= 1230336018:  # Jan 1 2019
     ext = "h5"
@@ -164,7 +158,7 @@ if args.gpsstart >= 1230336018:  # Jan 1 2019
     read_kw = {
         "columns": names,
         "selection": [
-            "frequency < {}".format(args.frequency_threshold * 2),
+            "{0} < frequency < {1}".format(10*1,args.frequency_threshold * 4),
             ("time", in_segmentlist, statea),
         ],
         "format": "hdf5",
@@ -183,7 +177,7 @@ else:
     read_kw = {
         "columns": names,
         "selection": [
-            "peak_frequency < {}".format(args.frequency_threshold * 2),
+            "{0} < peak_frequency < {1}".format(10*1,args.frequency_threshold * 4),
             ('peak', in_segmentlist, statea),
         ],
         "format": 'ligolw',
@@ -208,11 +202,13 @@ else:  # no files (no livetime?)
     trigs = EventTable(names=names)
 
 highsnrtrigs = trigs[trigs['snr'] >= 8]
-logger.debug("%d read" % len(trigs))
+if args.verbose:
+    gprint("%d read" % len(trigs))
 
 # -- prepare HTML -------------------------------------------------------------
 
 page = htmlio.new_bootstrap_page(title='%s Scattering' % args.ifo)
+page.div(class_='container')
 page.div(class_='page-header')
 page.h1('%s scattering: %d-%d'
         % (args.ifo, int(args.gpsstart), int(args.gpsend)))
@@ -222,7 +218,7 @@ page.p("This analysis searched for evidence of beam scattering based on the "
        "0264-9381/27/19/194011\" target=\"_blank\">Accadia et al. (2010)</a>.")
 page.div.close()
 page.add(htmlio.write_arguments(
-    [], start=int(args.gpsstart), end=int(args.gpsend), flag=args.state_flag))
+    [], start=int(args.gpsstart), end=int(args.gpsend), flag=args.state_flag)) 
 
 # link segments file
 page.h2('Segments')
@@ -230,7 +226,7 @@ page.p()
 page.add('The full output segments are recorded in HDF5 format here:')
 page.a(os.path.basename(segfile), href=segfile, target='_blank')
 page.p.close()
-# record state segments
+# print state segments
 if args.state_flag is not None:
     page.p('This analysis was executed over the following segments:')
     page.div(class_='panel-group', id_='accordion1')
@@ -249,11 +245,12 @@ page.div(class_='panel-group', id_='accordion1')
 allchannels = ['%s:%s' % (args.ifo, c) for optic in args.optic for
                c in scattering.OPTIC_MOTION_CHANNELS[optic]]
 
-logger.info("Reading all data")
+if args.verbose:
+    print("Reading all data:")
 alldata = []
 n = len(statea)
 for i, seg in enumerate(statea):
-    msg = "{0}/{1} {2}:".rjust(30).format(
+    msg = "    {0}/{1} {2}: ".format(
         str(i).rjust(len(str(n))),
         n,
         str(seg),
@@ -263,9 +260,10 @@ for i, seg in enumerate(statea):
                  obs=args.ifo[0], verbose=msg, nproc=args.nproc).resample(128))
 
 scatter_segments = DataQualityDict()
-
+a = [] # made this change
 for i, channel in enumerate(sorted(alldata[0].keys())):
-    logger.info("-- Processing %s" % channel)
+    if args.verbose:
+        gprint("-- Processing %s --------------------" % channel)
     chanstr = re.sub('[:-]', '_', channel).replace('_', '-', 1)
     optic = channel.split('-')[1].split('_')[0]
     flag = '%s:DCH-%s_SCATTERING_GE_%s_HZ:1' % (args.ifo, optic, tstr)
@@ -291,7 +289,8 @@ for i, channel in enumerate(sorted(alldata[0].keys())):
     fringecolors = [None] * len(scattering.FREQUENCY_MULTIPLIERS)
     # loop over state segments and find scattering fringes
     for j, seg in enumerate(statea):
-        logger.debug("Processing segment [%d .. %d)" % seg)
+        if args.verbose:
+            gprint("Processing segment [%d .. %d)..." % seg)
         ts = alldata[j][channel]
         # get raw data and plot
         line = axes['position'].plot(ts, color=linecolor)[0]
@@ -321,10 +320,11 @@ for i, channel in enumerate(sorted(alldata[0].keys())):
                                      'edgecolor': 'gray', 'height': 0.4},
                               height=0.8, y=0, label=' ')
         scatter_segments[channel] += scatter
-        logger.debug(
-            "    Found %d scattering segments" % (len(scatter.active)))
-    logger.debug("Completed channel, found %d segments in total."
-                 % len(scatter_segments[channel].active))
+        if args.verbose:
+            gprint("    Found %d scattering segments" % (len(scatter.active)))
+    if args.verbose:
+        gprint("Completed channel, found %d segments in total."
+               % len(scatter_segments[channel].active))
 
     # calculate efficiency and deadtime of veto
     deadtime = abs(scatter_segments[channel].active)
@@ -332,24 +332,32 @@ for i, channel in enumerate(sorted(alldata[0].keys())):
         deadtimepc = deadtime / livetime * 100
     except ZeroDivisionError:
         deadtimepc = 0.
-    logger.info("Deadtime: %.2f%% (%.2f/%ds)"
-                % (deadtimepc, deadtime, livetime))
+    if args.verbose:
+        gprint("Deadtime: %.2f%% (%.2f/%ds)"
+               % (deadtimepc, deadtime, livetime))
     efficiency = in_segmentlist(highsnrtrigs[names[0]],
                                 scatter_segments[channel].active).sum()
     try:
         efficiencypc = efficiency / len(highsnrtrigs) * 100
     except ZeroDivisionError:
         efficiencypc = 0.
-    logger.info("Efficiency (SNR>=8): %.2f%% (%d/%d)"
-                % (efficiencypc, efficiency, len(highsnrtrigs)))
+    if args.verbose:
+        gprint("Efficiency (SNR>=8): %.2f%% (%d/%d)"
+               % (efficiencypc, efficiency, len(highsnrtrigs)))
     if deadtimepc == 0.:
         effdt = 0
     else:
         effdt = efficiencypc/deadtimepc
-    logger.info("Efficiency/Deadtime: %.2f" % effdt)
+    if args.verbose:
+        gprint("Efficiency/Deadtime: %.2f" % effdt)
+        
+    a.append(scatter_segments[channel].active) # made this change, next 3 lines
+    print(len(a))
+    print(len(highsnrtrigs[names[0]]))
 
     # finalize plot
-    logger.debug("Plotting")
+    if args.verbose:
+        gprint("Plotting...", end=' ')
     name = label_to_latex(channel) if rcParams["text.usetex"] else channel
     axes['position'].set_title("Scattering evidence in %s" % name)
     axes['position'].set_xlabel('')
@@ -410,7 +418,8 @@ for i, channel in enumerate(sorted(alldata[0].keys())):
         plot.refresh()
         plot.save(png)
     plot.close()
-    logger.debug("%s written." % png)
+    if args.verbose:
+        gprint("%s written." % png)
 
     # make histogram
     histogram = Plot(figsize=[12, 6])
@@ -435,7 +444,8 @@ for i, channel in enumerate(sorted(alldata[0].keys())):
     hpng = '%s_SCATTERING_HISTOGRAM-%s.png' % (chanstr, gpsstr)
     histogram.save(hpng)
     histogram.close()
-    logger.debug("%s written." % hpng)
+    if args.verbose:
+        gprint("%s written." % hpng)
 
     # write HTML
     if deadtime != 0 and effdt > 2:
@@ -472,8 +482,8 @@ for i, channel in enumerate(sorted(alldata[0].keys())):
         page.tr.close()
         page.tr()
         page.th('Efficiency<br><small>(SNR&ge;8 and '
-                'f<sub>peak</sub>&lt;%.2f Hz)</small>'
-                % (2 * args.frequency_threshold))
+                '%.2f Hz</sub>&ltf<sub>peak</sub>&lt;%.2f Hz)</small>'
+                % (10*1,4 * args.frequency_threshold))
         page.td('%d/%d events' % (efficiency, len(highsnrtrigs)))
         page.td('%.2f%%' % efficiencypc)
         page.tr.close()
@@ -493,16 +503,39 @@ for i, channel in enumerate(sorted(alldata[0].keys())):
     page.div.close()
     page.div.close()
     page.div.close()
-
-# close panel group
-page.div.close()
+# Made this change, added the following block to write a csv file.                           
+print(len(a))
+b = [i for i in a if len(i) != 0]
+print(len(b))
+c = [item for i in b for item in i]
+d1 = [i for i in highsnrtrigs[names[0]] for j in c if i in j]
+e =  [j for i in highsnrtrigs[names[0]] for j in c if i in j]
+rows = zip(d1,e)    
+data = Table([d1,e], names = ['Gpstime','Segment'])
+data.write('summary.csv')
+#import csv
+#with open("summary.csv",'wt') as ff:
+#     ff.write("Gpstime")
+#     ff.write(",")
+#     ff.write("Segment")
+#     ff.write("\n")
+#     for i,j in rows:
+#         ff.write(str(i))
+#         ff.write(",")
+#         ff.write(str(j))
+#         ff.write("\n")                          
 
 # -- finalize -----------------------------------------------------------------
 
 # write segments
 scatter_segments.write(segfile, path="segments", overwrite=True)
-logger.debug("%s written" % segfile)
+if args.verbose:
+    gprint("%s written" % segfile)
 
 # write HTML
-htmlio.close_page(page, 'index.html')
-logger.info("-- index.html written, all done --")
+page.add(htmlio.write_footer())
+page.div.close()
+with open('index.html', 'w') as fp:
+    fp.write(str(page))
+if args.verbose:
+    gprint("-- index.html written, all done --")

--- a/bin/gwdetchar-scattering
+++ b/bin/gwdetchar-scattering
@@ -348,9 +348,7 @@ for i, channel in enumerate(sorted(alldata[0].keys())):
         effdt = efficiencypc/deadtimepc
     logger.info("Efficiency/Deadtime: %.2f" % effdt)
         
-    a.append(scatter_segments[channel].active) #change
-    
-    
+    a.append(scatter_segments[channel].active)
 
     # finalize plot
     logger.debug("Plotting")
@@ -502,9 +500,7 @@ for i, channel in enumerate(sorted(alldata[0].keys())):
 page.div.close()
 
 # write a csv file.                           
-
 b = [i for i in a if len(i) != 0]
-
 c = [item for i in b for item in i] # b is a list of list,so flattening it.
 d1 = [i for i in highsnrtrigs[names[0]] for j in c if i in j] # collecting the gpstimes that are within segments.
 e =  [j for i in highsnrtrigs[names[0]] for j in c if i in j] # collecting the segments that contains gpstimes.

--- a/bin/gwdetchar-scattering
+++ b/bin/gwdetchar-scattering
@@ -164,7 +164,7 @@ if args.gpsstart >= 1230336018:  # Jan 1 2019
     read_kw = {
         "columns": names,
         "selection": [
-            "{0} < frequency < {1}".format(10*1, args.frequency_threshold * 4),
+            "{0} < frequency < {1}".format(10, args.frequency_threshold * 4),
             ("time", in_segmentlist, statea),
         ],
         "format": "hdf5",
@@ -183,7 +183,7 @@ else:
     read_kw = {
         "columns": names,
         "selection": [
-            "{0} < peak_frequency < {1}".format(10*1, args.frequency_threshold * 4),
+            "{0} < peak_frequency < {1}".format(10, args.frequency_threshold * 4),
             ('peak', in_segmentlist, statea),
         ],
         "format": 'ligolw',

--- a/bin/gwdetchar-scattering
+++ b/bin/gwdetchar-scattering
@@ -264,6 +264,7 @@ for i, seg in enumerate(statea):
 
 scatter_segments = DataQualityDict()
 actives = SegmentList()
+
 for i, channel in enumerate(sorted(alldata[0].keys())):
     logger.info("-- Processing %s" % channel)
     chanstr = re.sub('[:-]', '_', channel).replace('_', '-', 1)

--- a/bin/gwdetchar-scattering
+++ b/bin/gwdetchar-scattering
@@ -164,7 +164,7 @@ if args.gpsstart >= 1230336018:  # Jan 1 2019
     read_kw = {
         "columns": names,
         "selection": [
-            "{0} < frequency < {1}".format(10*1,args.frequency_threshold * 4),
+            "{0} < frequency < {1}".format(10*1, args.frequency_threshold * 4),
             ("time", in_segmentlist, statea),
         ],
         "format": "hdf5",
@@ -183,7 +183,7 @@ else:
     read_kw = {
         "columns": names,
         "selection": [
-            "{0} < peak_frequency < {1}".format(10*1,args.frequency_threshold * 4),
+            "{0} < peak_frequency < {1}".format(10*1, args.frequency_threshold * 4),
             ('peak', in_segmentlist, statea),
         ],
         "format": 'ligolw',

--- a/bin/gwdetchar-scattering
+++ b/bin/gwdetchar-scattering
@@ -124,7 +124,7 @@ os.chdir(args.output_dir)
 
 segfile = '%s-SCATTERING_SEGMENTS_%s_HZ-%s.h5' % (args.ifo, tstr, gpsstr)
 
-summfile = 'summary.csv'
+summfile = '{}-SCATTERING_SUMMARY-{}.csv'.format(args.ifo, gpsstr)
 
 logger.info('{} Scattering {}-{}'.format(
     args.ifo, int(args.gpsstart), int(args.gpsend)))

--- a/bin/gwdetchar-scattering
+++ b/bin/gwdetchar-scattering
@@ -506,7 +506,7 @@ d1 = [x for x in highsnrtrigs[names[0]] for y in c if x in y]
 e =  [y for x in highsnrtrigs[names[0]] for y in c if x in y]
 rows = zip(d1, e)    
 data = Table([d1, e], names = ['Gpstime','Segment'])
-data.write('summary.csv')                         
+data.write('summary.csv', overwrite = True)                         
 
 # -- finalize -----------------------------------------------------------------
 

--- a/bin/gwdetchar-scattering
+++ b/bin/gwdetchar-scattering
@@ -124,6 +124,8 @@ os.chdir(args.output_dir)
 
 segfile = '%s-SCATTERING_SEGMENTS_%s_HZ-%s.h5' % (args.ifo, tstr, gpsstr)
 
+summfile = 'summary.csv'
+
 logger.info('{} Scattering {}-{}'.format(
     args.ifo, int(args.gpsstart), int(args.gpsend)))
 
@@ -230,6 +232,14 @@ page.p()
 page.add('The full output segments are recorded in HDF5 format here:')
 page.a(os.path.basename(segfile), href=segfile, target='_blank')
 page.p.close()
+
+#link summary file
+page.h3('Summary')
+page.p()
+page.add('The Scattering summary is recorded in a csv format here:')
+page.a(os.path.basename(summfile), href=summfile, target='_blank')
+page.p.close()
+
 # record state segments
 if args.state_flag is not None:
     page.p('This analysis was executed over the following segments:')
@@ -506,7 +516,7 @@ logger.debug('Writing a summary CSV record')
 
 actives = actives.coalesce() # merge contigous segments 
 gps = [x for x in highsnrtrigs[names[0]] for y in actives if x in y]
-segs =  [tuple(y) for x in highsnrtrigs[names[0]] for y in actives if x in y]
+segs = [tuple(y) for x in highsnrtrigs[names[0]] for y in actives if x in y]
 data = Table([gps, segs], names=['trigger_time', 'segment'])
 data.write('summary.csv', overwrite=True, fast_writer=False)                         
 

--- a/bin/gwdetchar-scattering
+++ b/bin/gwdetchar-scattering
@@ -105,7 +105,7 @@ args = parser.parse_args()
 
 # set up logger
 logger = cli.logger(
-    name = os.path.basename(__file__),
+    name=os.path.basename(__file__),
     level='DEBUG' if args.verbose else 'INFO',
 )
 
@@ -156,7 +156,7 @@ else:
 # -- load h(t) ----------------------------------------------------------------
 
 args.main_channel = args.main_channel.format(IFO=args.ifo)
-logger.debug("Loading Omicron triggers for %s..." % args.main_channel)
+logger.debug("Loading Omicron triggers for %s" % args.main_channel)
 
 if args.gpsstart >= 1230336018:  # Jan 1 2019
     ext = "h5"
@@ -291,7 +291,7 @@ for i, channel in enumerate(sorted(alldata[0].keys())):
     fringecolors = [None] * len(scattering.FREQUENCY_MULTIPLIERS)
     # loop over state segments and find scattering fringes
     for j, seg in enumerate(statea):
-        logger.debug("Processing segment [%d .. %d)..." % seg)
+        logger.debug("Processing segment [%d .. %d)" % seg)
         ts = alldata[j][channel]
         # get raw data and plot
         line = axes['position'].plot(ts, color=linecolor)[0]
@@ -352,7 +352,7 @@ for i, channel in enumerate(sorted(alldata[0].keys())):
     print(len(highsnrtrigs[names[0]]))
 
     # finalize plot
-    logger.debug("Plotting...")
+    logger.debug("Plotting")
     name = label_to_latex(channel) if rcParams["text.usetex"] else channel
     axes['position'].set_title("Scattering evidence in %s" % name)
     axes['position'].set_xlabel('')

--- a/bin/gwdetchar-scattering
+++ b/bin/gwdetchar-scattering
@@ -500,12 +500,12 @@ for i, channel in enumerate(sorted(alldata[0].keys())):
 page.div.close()
 
 # write a csv file.                           
-b = [i for i in a if len(i) != 0]
-c = [item for i in b for item in i]
-d1 = [i for i in highsnrtrigs[names[0]] for j in c if i in j]
-e =  [j for i in highsnrtrigs[names[0]] for j in c if i in j]
-rows = zip(d1,e)    
-data = Table([d1,e], names = ['Gpstime','Segment'])
+b = [x for x in a if len(x) != 0]
+c = [item for x in b for item in x]
+d1 = [x for x in highsnrtrigs[names[0]] for y in c if x in y]
+e =  [y for x in highsnrtrigs[names[0]] for y in c if x in y]
+rows = zip(d1, e)    
+data = Table([d1, e], names = ['Gpstime','Segment'])
 data.write('summary.csv')                         
 
 # -- finalize -----------------------------------------------------------------

--- a/bin/gwdetchar-scattering
+++ b/bin/gwdetchar-scattering
@@ -506,7 +506,7 @@ logger.debug('Writing a summary CSV record')
 
 actives = actives.coalesce() # merge contigous segments 
 gps = [x for x in highsnrtrigs[names[0]] for y in actives if x in y]
-segs =  [y for x in highsnrtrigs[names[0]] for y in actives if x in y]
+segs =  [tuple(y) for x in highsnrtrigs[names[0]] for y in actives if x in y]
 data = Table([gps, segs], names=['trigger_time', 'segment'])
 data.write('summary.csv', overwrite=True, fast_writer=False)                         
 

--- a/bin/gwdetchar-scattering
+++ b/bin/gwdetchar-scattering
@@ -249,7 +249,7 @@ page.div(class_='panel-group', id_='accordion1')
 allchannels = ['%s:%s' % (args.ifo, c) for optic in args.optic for
                c in scattering.OPTIC_MOTION_CHANNELS[optic]]
 
-logger.info("Reading all data:")
+logger.info("Reading all data")
 alldata = []
 n = len(statea)
 for i, seg in enumerate(statea):
@@ -263,7 +263,7 @@ for i, seg in enumerate(statea):
                  obs=args.ifo[0], verbose=msg, nproc=args.nproc).resample(128))
 
 scatter_segments = DataQualityDict()
-a = [] # made this change
+a = []
 for i, channel in enumerate(sorted(alldata[0].keys())):
     logger.info("-- Processing %s" % channel)
     chanstr = re.sub('[:-]', '_', channel).replace('_', '-', 1)
@@ -321,7 +321,8 @@ for i, channel in enumerate(sorted(alldata[0].keys())):
                                      'edgecolor': 'gray', 'height': 0.4},
                               height=0.8, y=0, label=' ')
         scatter_segments[channel] += scatter
-        logger.debug("    Found %d scattering segments" % (len(scatter.active)))
+        logger.debug(
+            "    Found %d scattering segments" % (len(scatter.active)))
     logger.debug("Completed channel, found %d segments in total."
                  % len(scatter_segments[channel].active))
 
@@ -438,8 +439,7 @@ for i, channel in enumerate(sorted(alldata[0].keys())):
     hpng = '%s_SCATTERING_HISTOGRAM-%s.png' % (chanstr, gpsstr)
     histogram.save(hpng)
     histogram.close()
-    if args.verbose:
-        gprint("%s written." % hpng)
+    logger.debug("%s written." % hpng)
 
     # write HTML
     if deadtime != 0 and effdt > 2:
@@ -497,7 +497,11 @@ for i, channel in enumerate(sorted(alldata[0].keys())):
     page.div.close()
     page.div.close()
     page.div.close()
-# Made this change, added the following block to write a csv file.                           
+
+# close panel group
+page.div.close()
+
+# write a csv file.                           
 print(len(a))
 b = [i for i in a if len(i) != 0]
 print(len(b))

--- a/bin/gwdetchar-scattering
+++ b/bin/gwdetchar-scattering
@@ -232,7 +232,7 @@ page.add('The full output segments are recorded in HDF5 format here:')
 page.a(os.path.basename(segfile), href=segfile, target='_blank')
 page.p.close()
 
-#link summary file
+# link summary file
 page.h3('Summary')
 page.p()
 page.add('A summary of triggers that occur during active scattering '

--- a/bin/gwdetchar-scattering
+++ b/bin/gwdetchar-scattering
@@ -236,7 +236,8 @@ page.p.close()
 #link summary file
 page.h3('Summary')
 page.p()
-page.add('The Scattering summary is recorded in a csv format here:')
+page.add('A summary of triggers that occur during active scattering '
+         'segments is recorded in CSV format here:')
 page.a(os.path.basename(summfile), href=summfile, target='_blank')
 page.p.close()
 

--- a/bin/gwdetchar-scattering
+++ b/bin/gwdetchar-scattering
@@ -477,7 +477,7 @@ for i, channel in enumerate(sorted(alldata[0].keys())):
         page.tr()
         page.th('Efficiency<br><small>(SNR&ge;8 and '
                 '%.2f Hz</sub>&ltf<sub>peak</sub>&lt;%.2f Hz)</small>'
-                % (10,4 * args.frequency_threshold))
+                % (10, 4 * args.frequency_threshold))
         page.td('%d/%d events' % (efficiency, len(highsnrtrigs)))
         page.td('%.2f%%' % efficiencypc)
         page.tr.close()

--- a/bin/gwdetchar-scattering
+++ b/bin/gwdetchar-scattering
@@ -501,9 +501,9 @@ page.div.close()
 
 # write a csv file.                           
 b = [i for i in a if len(i) != 0]
-c = [item for i in b for item in i] # b is a list of list,so flattening it.
-d1 = [i for i in highsnrtrigs[names[0]] for j in c if i in j] # collecting the gpstimes that are within segments.
-e =  [j for i in highsnrtrigs[names[0]] for j in c if i in j] # collecting the segments that contains gpstimes.
+c = [item for i in b for item in i]
+d1 = [i for i in highsnrtrigs[names[0]] for j in c if i in j]
+e =  [j for i in highsnrtrigs[names[0]] for j in c if i in j]
 rows = zip(d1,e)    
 data = Table([d1,e], names = ['Gpstime','Segment'])
 data.write('summary.csv')                         

--- a/bin/gwdetchar-scattering
+++ b/bin/gwdetchar-scattering
@@ -263,7 +263,7 @@ for i, seg in enumerate(statea):
                  obs=args.ifo[0], verbose=msg, nproc=args.nproc).resample(128))
 
 scatter_segments = DataQualityDict()
-a = []
+actives = SegmentList()
 for i, channel in enumerate(sorted(alldata[0].keys())):
     logger.info("-- Processing %s" % channel)
     chanstr = re.sub('[:-]', '_', channel).replace('_', '-', 1)
@@ -347,8 +347,9 @@ for i, channel in enumerate(sorted(alldata[0].keys())):
     else:
         effdt = efficiencypc/deadtimepc
     logger.info("Efficiency/Deadtime: %.2f" % effdt)
-        
-    a.append(scatter_segments[channel].active)
+    
+    if abs(scatter_segments[channel].active):    
+          actives.append(scatter_segments[channel].active)
 
     # finalize plot
     logger.debug("Plotting")
@@ -499,9 +500,10 @@ for i, channel in enumerate(sorted(alldata[0].keys())):
 # close panel group
 page.div.close()
 
-# write a csv file.                           
-b = [x for x in a if len(x) != 0]
-c = [item for x in b for item in x]
+# write a csv file.  
+logger.debug('Writing a summary CSV record')
+#b = [x for x in a if len(x) != 0]
+c = [item for x in actives for item in x]
 d1 = [x for x in highsnrtrigs[names[0]] for y in c if x in y]
 e =  [y for x in highsnrtrigs[names[0]] for y in c if x in y]
 rows = zip(d1, e)    


### PR DESCRIPTION
The Peak_freq distribution of the O2 Scattering suggested that most of the triggers had Peak_freq above 30 Hz.  
1. So we changed the filter on Peak freq from : Peak_freq < 30 Hz to 10 Hz < Peak_freq < 60 Hz.
2. A summary file that contains gpstimes of the omicron triggers that fall within scattering segments and the corresponding segments is linked on the Scattering summary page.
3. Output of the updated code  https://ldas-jobs.ligo-la.caltech.edu/~siddharth.soni/scatoutput/1236297618/
