### PR TITLE
Crop off unrequested data from minute trends

### DIFF
--- a/bin/gwdetchar-lasso-correlation
+++ b/bin/gwdetchar-lasso-correlation
@@ -181,7 +181,7 @@ else:
     logger.info("-- Loading primary channel data")
     primaryts = get_data(primary, start, end, frametype=args.primary_frametype,
                          obs=args.ifo[0], verbose='Reading:'.rjust(30),
-                         nproc=args.nproc)
+                         nproc=args.nproc).crop(start, end)
 
 if args.remove_outliers:
     logger.debug("-- Removing outliers above %f sigma" % args.remove_outliers)
@@ -217,7 +217,7 @@ else:
 
 auxdata = get_data(
     channels, start, end, verbose='Reading:'.rjust(30), obs=args.ifo[0],
-    frametype=frametype, nproc=args.nproc, pad=0)
+    frametype=frametype, nproc=args.nproc, pad=0).crop(start, end)
 
 # -- removes flat data to be re-introdused later
 


### PR DESCRIPTION
There is a bug upstream of `gwdetchar.io.datafind.get_data` where minute trends occasionally return more data than is requested by `gwdatafind`, which currently breaks `gwdetchar-lasso-correlation` when the primary is read from raw frame files, as those are not affected by this bug (but minute trends are). This PR provides a temporary workaround by cropping off the unwanted data whenever this occurs.

See [**here**](https://ldas-jobs.ligo-wa.caltech.edu/~aurban/lasso/for_josh/) for test output.

cc @duncanmmacleod, @andrew-lundgren, @jrsmith02 