### PR TITLE
Condor checkpointing for omega scans

### DIFF
--- a/bin/gwdetchar-omega
+++ b/bin/gwdetchar-omega
@@ -177,16 +177,12 @@ if os.path.exists(summary) and not args.disable_checkpoint:
         os.path.abspath(summary)))
     record = Table.read(summary)
     completed = list(record['Channel'])
-    if not args.disable_correlation:
-        try:
-            check_corr = record[0]['Standard Deviation']
-        except KeyError:
-            raise KeyError(
-                'Cross-correlation is not available from this record, '
-                'consider running without correlation or starting from '
-                'scratch with --disable-checkpoint')
-        else:
-            pass
+    if not args.disable_correlation and ('Standard Deviation'
+                                         not in record.colnames):
+        raise KeyError(
+            'Cross-correlation is not available from this record, '
+            'consider running without correlation or starting from '
+            'scratch with --disable-checkpoint')
 else:
     record = []
     completed = []

--- a/bin/gwdetchar-omega
+++ b/bin/gwdetchar-omega
@@ -51,6 +51,7 @@ import sys
 import warnings
 import numpy
 
+from gwpy.table import Table
 from gwpy.time import to_gps
 
 from matplotlib import use
@@ -80,6 +81,9 @@ parser.add_argument('-f', '--config-file', action='append', default=None,
 parser.add_argument('-d', '--disable-correlation', action='store_true',
                     default=False, help='disable cross-correlation of aux '
                                         'channels, default: False')
+parser.add_argument('-D', '--disable-checkpoint', action='store_true',
+                    default=False, help='disable checkpointing from previous '
+                                        'runs, default: False')
 parser.add_argument('-s', '--ignore-state-flags', action='store_true',
                     default=False, help='ignore state flag definitions in '
                                         'the configuration, default: False')
@@ -168,11 +172,13 @@ for d in [plotdir, aboutdir, datadir]:
 
 # attempt to checkpoint
 summary = os.path.join(datadir, 'summary.csv')
-if os.path.exists(summary):
+if os.path.exists(summary) and not args.disable_checkpoint:
     logger.debug('Checkpointing from {}'.format(
         os.path.abspath(summary)))
-    completed = Table.read(summary)
+    record = Table.read(summary)
+    completed = list(record['Channel'])
 else:
+    record = []
     completed = []
 
 # set up html output
@@ -226,9 +232,31 @@ for block in blocks.values():
         chans, start, end, frametype=block.frametype, source=block.source,
         nproc=args.nproc, verbose='Reading block:'.rjust(30))
 
-    # scan individual channels
+    # process individual channels
     for channel in block.channels:
-        try:
+        if channel.name in completed:
+            logger.info(' -- Checkpointing {} from a previous '
+                        'run'.format(channel.name))
+            try:  # attempt to checkpoint
+                cindex = completed.index(channel.name)
+                channel.load_loudest_tile_features(
+                    record[cindex], correlated=correlate is not None)
+            except KeyError:  # cross-correlation not enabled
+                raise KeyError('Cross-correlation is not available from this '
+                               'record, consider starting from scratch with '
+                               '--disable-checkpoint')
+            else:
+                try:  # update analyzed dict
+                    analyzed[channel.section]['channels'].append(channel)
+                except KeyError:
+                    analyzed[channel.section] = {
+                        'name': blocks[channel.section].name,
+                        'channels': [channel]}
+                htmlv['toc'] = analyzed
+                html.write_qscan_page(ifo, gps, analyzed, **htmlv)
+                continue
+
+        try:  # scan the channel
             logger.info(' -- Scanning channel {}'.format(channel.name))
             series = omega.scan(
                 gps, channel, data[channel.name].astype('float64'), fftlength,

--- a/bin/gwdetchar-omega
+++ b/bin/gwdetchar-omega
@@ -246,12 +246,8 @@ for block in blocks.values():
             cindex = completed.index(channel.name)
             channel.load_loudest_tile_features(
                 record[cindex], correlated=correlate is not None)
-            try:  # update analyzed dict
-                analyzed[channel.section]['channels'].append(channel)
-            except KeyError:
-                analyzed[channel.section] = {
-                    'name': blocks[channel.section].name,
-                    'channels': [channel]}
+            analyzed = html.update_toc(analyzed, channel,
+                                       name=blocks[channel.section].name)
             htmlv['toc'] = analyzed
             html.write_qscan_page(ifo, gps, analyzed, **htmlv)
             continue
@@ -285,11 +281,8 @@ for block in blocks.values():
         else:
             channel.save_loudest_tile_features(series[3])
 
-        try:  # update analyzed dict
-            analyzed[channel.section]['channels'].append(channel)
-        except KeyError:
-            analyzed[channel.section] = {'name': blocks[channel.section].name,
-                                         'channels': [channel]}
+        analyzed = html.update_toc(analyzed, channel,
+                                   name=blocks[channel.section].name)
         htmlv['toc'] = analyzed
         html.write_qscan_page(ifo, gps, analyzed, **htmlv)
 

--- a/bin/gwdetchar-omega
+++ b/bin/gwdetchar-omega
@@ -170,13 +170,23 @@ for d in [plotdir, aboutdir, datadir]:
     if not os.path.isdir(d):
         os.makedirs(d)
 
-# attempt to checkpoint
+# determine checkpoints
 summary = os.path.join(datadir, 'summary.csv')
 if os.path.exists(summary) and not args.disable_checkpoint:
     logger.debug('Checkpointing from {}'.format(
         os.path.abspath(summary)))
     record = Table.read(summary)
     completed = list(record['Channel'])
+    if not args.disable_correlation:
+        try:
+            check_corr = record[0]['Standard Deviation']
+        except KeyError:
+            raise KeyError(
+                'Cross-correlation is not available from this record, '
+                'consider running without correlation or starting from '
+                'scratch with --disable-checkpoint')
+        else:
+            pass
 else:
     record = []
     completed = []
@@ -234,27 +244,21 @@ for block in blocks.values():
 
     # process individual channels
     for channel in block.channels:
-        if channel.name in completed:
+        if channel.name in completed:  # load checkpoint
             logger.info(' -- Checkpointing {} from a previous '
                         'run'.format(channel.name))
-            try:  # attempt to checkpoint
-                cindex = completed.index(channel.name)
-                channel.load_loudest_tile_features(
-                    record[cindex], correlated=correlate is not None)
-            except KeyError:  # cross-correlation not enabled
-                raise KeyError('Cross-correlation is not available from this '
-                               'record, consider starting from scratch with '
-                               '--disable-checkpoint')
-            else:
-                try:  # update analyzed dict
-                    analyzed[channel.section]['channels'].append(channel)
-                except KeyError:
-                    analyzed[channel.section] = {
-                        'name': blocks[channel.section].name,
-                        'channels': [channel]}
-                htmlv['toc'] = analyzed
-                html.write_qscan_page(ifo, gps, analyzed, **htmlv)
-                continue
+            cindex = completed.index(channel.name)
+            channel.load_loudest_tile_features(
+                record[cindex], correlated=correlate is not None)
+            try:  # update analyzed dict
+                analyzed[channel.section]['channels'].append(channel)
+            except KeyError:
+                analyzed[channel.section] = {
+                    'name': blocks[channel.section].name,
+                    'channels': [channel]}
+            htmlv['toc'] = analyzed
+            html.write_qscan_page(ifo, gps, analyzed, **htmlv)
+            continue
 
         try:  # scan the channel
             logger.info(' -- Scanning channel {}'.format(channel.name))

--- a/bin/gwdetchar-omega
+++ b/bin/gwdetchar-omega
@@ -153,7 +153,7 @@ outdir = os.path.abspath(outdir)
 if not os.path.isdir(outdir):
     os.makedirs(outdir)
 os.chdir(outdir)
-logger.debug("Output directory created as {}".format(outdir))
+logger.debug('Output directory created as {}'.format(outdir))
 
 
 # -- Compute Qscan ------------------------------------------------------------
@@ -165,6 +165,15 @@ datadir = 'data'
 for d in [plotdir, aboutdir, datadir]:
     if not os.path.isdir(d):
         os.makedirs(d)
+
+# attempt to checkpoint
+summary = os.path.join(datadir, 'summary.csv')
+if os.path.exists(summary):
+    logger.debug('Checkpointing from {}'.format(
+        os.path.abspath(summary)))
+    completed = Table.read(summary)
+else:
+    completed = []
 
 # set up html output
 logger.debug('Setting up HTML at {}/index.html'.format(outdir))

--- a/bin/gwdetchar-omega-batch
+++ b/bin/gwdetchar-omega-batch
@@ -106,9 +106,6 @@ cargs.add_argument('--condor-command', action='append', default=[],
 
 args = parser.parse_args()
 
-# set up logger
-logger = cli.logger(name=os.path.basename(__file__))
-
 # set up output directory
 outdir = os.path.abspath(os.path.expanduser(args.output_dir))
 
@@ -205,17 +202,17 @@ for t in times:
 
 # write DAG
 dagman.build(fancyname=False)
-logger.info("Workflow generated for {} times".format(len(times)))
+print("Workflow generated for {} times".format(len(times)))
 if args.submit:
     dagman.submit_dag(submit_options="-force")
 else:
-    logger.info(
+    print(
         "Submit to condor via:\n\n"
         "$ condor_submit_dag {0.submit_file}".format(dagman),
     )
 
 if args.submit and args.monitor:
-    logger.info("Monitoring progress of {0.submit_file}".format(dagman))
+    print("Monitoring progress of {0.submit_file}".format(dagman))
     try:
         subprocess.check_call(
             ["pycondor", "monitor", dagman.submit_file],

--- a/bin/gwdetchar-omega-batch
+++ b/bin/gwdetchar-omega-batch
@@ -67,6 +67,9 @@ parser.add_argument('--colormap', default='viridis',
 parser.add_argument('-d', '--disable-correlation', action='store_true',
                     default=False, help='disable cross-correlation of aux '
                                         'channels, default: False')
+parser.add_argument('-D', '--disable-checkpoint', action='store_true',
+                    default=False, help='disable checkpointing from previous '
+                                        'runs, default: False')
 parser.add_argument('-t', '--far-threshold', type=float, default=3.171e-8,
                     help='white noise false alarm rate threshold (Hz) for '
                          'processing channels, default: %(default)s')
@@ -189,6 +192,8 @@ arguments.extend(("--far-threshold", str(args.far_threshold)))
 arguments.extend(("--nproc", str(args.nproc)))
 if args.disable_correlation:
     arguments.append("--disable-correlation")
+if args.disable_checkpoint:
+    arguments.append("--disable-checkpoint")
 if args.ignore_state_flags:
     arguments.append("--ignore-state-flags")
 

--- a/gwdetchar/omega/config.py
+++ b/gwdetchar/omega/config.py
@@ -322,7 +322,7 @@ class OmegaChannel(Channel):
             delay = (corr.t0 + corr.argmax() * corr.dt).value - gps
             self.delay = int(delay * 1000)  # convert to ms
 
-    def load_loudest_tile_features(table, correlated=False):
+    def load_loudest_tile_features(self, table, correlated=False):
         """Load properties of the loudest time-frequency tile from a table
 
         Parameters

--- a/gwdetchar/omega/config.py
+++ b/gwdetchar/omega/config.py
@@ -345,7 +345,7 @@ class OmegaChannel(Channel):
         """
         # save parameters
         self.Q = table['Q']
-        self.energy = numpy.around(table['Energy'], 1)
+        self.energy = table['Energy']
         self.snr = table['SNR']
         self.t = table['Central Time']
         self.f = table['Central Frequency (Hz)']

--- a/gwdetchar/omega/config.py
+++ b/gwdetchar/omega/config.py
@@ -322,6 +322,38 @@ class OmegaChannel(Channel):
             delay = (corr.t0 + corr.argmax() * corr.dt).value - gps
             self.delay = int(delay * 1000)  # convert to ms
 
+    def load_loudest_tile_features(table, correlated=False):
+        """Load properties of the loudest time-frequency tile from a table
+
+        Parameters
+        ----------
+        table : `~gwpy.table.Table`
+            table of properties of the loudest time-frequency tile
+
+        correlated : `bool`, optional
+            boolean switch to determine if cross-correlation properties are
+            included, default: `False`
+
+        Notes
+        -----
+        Attributes stored in-place include `Q`, `energy`, `snr`, `t`, and `f`,
+        all corresponding to the columns contained in `table`.
+
+        If `correlated` is not `None` then the maximum correlation amplitude,
+        relative time delay, and standard deviation are stored as attributes
+        `corr`, `delay`, and `stdev`, respectively.
+        """
+        # save parameters
+        self.Q = table['Q']
+        self.energy = table['Energy']
+        self.snr = table['SNR']
+        self.t = table['Central Time']
+        self.f = table['Central Frequency (Hz)']
+        if correlated:
+            self.corr = table['Correlation']
+            self.stdev = table['Standard Deviation']
+            self.delay = table['Delay (ms)']
+
 
 class OmegaChannelList(object):
     """A conceptual list of `OmegaChannel` objects with common signal

--- a/gwdetchar/omega/config.py
+++ b/gwdetchar/omega/config.py
@@ -345,7 +345,7 @@ class OmegaChannel(Channel):
         """
         # save parameters
         self.Q = table['Q']
-        self.energy = table['Energy']
+        self.energy = numpy.around(table['Energy'], 1)
         self.snr = table['SNR']
         self.t = table['Central Time']
         self.f = table['Central Frequency (Hz)']

--- a/gwdetchar/omega/html.py
+++ b/gwdetchar/omega/html.py
@@ -110,6 +110,35 @@ OBSERVATORY_MAP = {
 
 # -- HTML construction --------------------------------------------------------
 
+def update_toc(toc, channel, name='GW'):
+    """Add a channel to the page table of contents
+
+    Parameters
+    ----------
+    toc : `dict`
+        dictionary used as table of contents for a bootstrap page
+
+    channel : `OmegaChannel`
+        channel to be added to `toc`
+
+    name : `str`, optional
+        name of a channel's block, default: `'GW'`
+
+    Returns
+    -------
+    out : `dict`
+        the updated dictionary
+    """
+    out = toc
+    try:  # update analyzed dict
+        out[channel.section]['channels'].append(channel)
+    except KeyError:
+        out[channel.section] = {
+            'name': name,
+            'channels': [channel]}
+    return out
+
+
 def navbar(ifo, gpstime, toc={}):
     """Initialise a new `markup.page`
     This method constructs an HTML page with the following structure

--- a/gwdetchar/omega/html.py
+++ b/gwdetchar/omega/html.py
@@ -314,7 +314,7 @@ def write_summary_table(blocks, correlated, base=os.path.curdir):
     # record summary data for each channel
     channel, time, freq, Q, energy, snr = ([], [], [], [], [], [])
     if correlated:
-        corr, delay = ([], [])
+        corr, stdev, delay = ([], [], [])
     for block in blocks.values():
         for chan in block['channels']:
             channel.append(chan.name)
@@ -325,13 +325,14 @@ def write_summary_table(blocks, correlated, base=os.path.curdir):
             snr.append(chan.snr)
             if correlated:
                 corr.append(chan.corr)
+                stdev.append(chan.stdev)
                 delay.append(chan.delay)
     # store in a table
     if correlated:
-        data = Table([channel, time, freq, Q, energy, snr, corr, delay],
+        data = Table([channel, time, freq, Q, energy, snr, corr, stdev, delay],
                      names=('Channel', 'Central Time',
                             'Central Frequency (Hz)', 'Q', 'Energy', 'SNR',
-                            'Correlation', 'Delay (ms)'))
+                            'Correlation', 'Standard Deviation', 'Delay (ms)'))
     else:
         data = Table([channel, time, freq, Q, energy, snr], names=(
             'Channel', 'Central Time', 'Central Frequency (Hz)', 'Q', 'Energy',

--- a/gwdetchar/omega/tests/test_config.py
+++ b/gwdetchar/omega/tests/test_config.py
@@ -29,6 +29,7 @@ except ImportError:  # python 2.7
 import numpy
 from scipy import signal
 
+from gwpy.table import Table
 from gwpy.timeseries import TimeSeries
 
 from .. import (config, core)
@@ -76,6 +77,11 @@ except AttributeError:  # python 2.7
 BLOCKS = CP.get_channel_blocks()
 PRIMARY = BLOCKS['primary']
 GW = BLOCKS['GW']
+
+ROWS = [[0]] * 8
+COLS = ('Q', 'Energy', 'SNR', 'Central Time', 'Central Frequency (Hz)',
+        'Correlation', 'Standard Deviation', 'Delay (ms)')
+TABLE = Table(ROWS, names=COLS)
 
 
 # -- test utilities -----------------------------------------------------------
@@ -202,3 +208,16 @@ def test_save_loudest_tile_features():
     assert channel.corr == numpy.around(glitch.max().value, 1)
     assert channel.delay == 0.0
     assert channel.stdev == glitch.std().value
+
+
+def test_load_loudest_tile_features():
+    channel = GW.channels[0]
+    channel.load_loudest_tile_features(TABLE, correlated=True)
+    assert channel.Q == 0
+    assert channel.energy == 0
+    assert channel.snr == 0
+    assert channel.t == 0
+    assert channel.f == 0
+    assert channel.corr == 0
+    assert channel.delay == 0
+    assert channel.stdev == 0

--- a/gwdetchar/omega/tests/test_html.py
+++ b/gwdetchar/omega/tests/test_html.py
@@ -59,7 +59,7 @@ HTML_HEADER = """<header class="navbar navbar-fixed-top navbar-l1">
 GW <b class="caret"></b>
 </a>
 <ul class="dropdown-menu" style="max-height: 700px; overflow-y: scroll;">
-<li class="dropdown-header">Gravitational-Wave Strain</li>
+<li class="dropdown-header">Gravitational Wave Strain</li>
 <li>
 <a href="#x1-test-aux">X1:TEST-AUX</a>
 </li>
@@ -127,7 +127,7 @@ GW = BLOCKS['GW']
 
 # set analyzed channel list
 ANALYZED = {'GW': {
-    'name': 'Gravitational-Wave Strain',
+    'name': 'Gravitational Wave Strain',
     'channels': GW.channels,
 }}
 for channel in ANALYZED['GW']['channels']:
@@ -145,7 +145,7 @@ BLOCK_HTML = """<div class="panel well panel-info">
 <div class="pull-right">
 <a href="#" class="text-info"><small>[top]</small></a>
 </div>
-<h3 class="panel-title">GW: Gravitational-Wave Strain</h3>
+<h3 class="panel-title">GW: Gravitational Wave Strain</h3>
 </div>
 <ul class="list-group">
 <li class="list-group-item">
@@ -228,6 +228,15 @@ Eventgram view <span class="caret"></span>
 
 
 # -- unit tests ---------------------------------------------------------------
+
+def test_update_toc():
+    toc = html.update_toc(dict(), GW.channels[0], GW.name)
+    assert toc.keys() == ANALYZED.keys()
+    assert toc['GW'].keys() == ANALYZED['GW'].keys()
+    assert len(toc['GW']['channels']) == len(ANALYZED['GW']['channels'])
+    assert toc['GW']['channels'][0].name == ANALYZED['GW']['channels'][0].name
+    assert toc['GW']['name'] == ANALYZED['GW']['name']
+
 
 def test_navbar():
     page = html.navbar('L1', 0, toc=ANALYZED)

--- a/gwdetchar/omega/tests/test_html.py
+++ b/gwdetchar/omega/tests/test_html.py
@@ -59,7 +59,7 @@ HTML_HEADER = """<header class="navbar navbar-fixed-top navbar-l1">
 GW <b class="caret"></b>
 </a>
 <ul class="dropdown-menu" style="max-height: 700px; overflow-y: scroll;">
-<li class="dropdown-header">Gravitational Wave Strain</li>
+<li class="dropdown-header">Gravitational-Wave Strain</li>
 <li>
 <a href="#x1-test-aux">X1:TEST-AUX</a>
 </li>
@@ -100,7 +100,7 @@ channel = X1:TEST-STRAIN
 
 [GW]
 ; name of this block, which contains h(t)
-name = Gravitational Wave Strain
+name = Gravitational-Wave Strain
 q-range = 3.3166,150.0
 frequency-range = 4.0,1024
 resample = 4096
@@ -127,7 +127,7 @@ GW = BLOCKS['GW']
 
 # set analyzed channel list
 ANALYZED = {'GW': {
-    'name': 'Gravitational Wave Strain',
+    'name': 'Gravitational-Wave Strain',
     'channels': GW.channels,
 }}
 for channel in ANALYZED['GW']['channels']:
@@ -145,7 +145,7 @@ BLOCK_HTML = """<div class="panel well panel-info">
 <div class="pull-right">
 <a href="#" class="text-info"><small>[top]</small></a>
 </div>
-<h3 class="panel-title">GW: Gravitational Wave Strain</h3>
+<h3 class="panel-title">GW: Gravitational-Wave Strain</h3>
 </div>
 <ul class="list-group">
 <li class="list-group-item">


### PR DESCRIPTION
This PR implements condor checkpointing for `gwdetchar-omega`:

* Take advantage of the fact that, if a given time has already been analyzed, there will exist a `summary.csv` file containing information about channels that were processed above that run's false alarm rate threshold
* Use that file to load summary information about previously analyzed channels
* Get as far as you can with this information, throwing useful errors if anything breaks

This has the added benefit that channels which _weren't_ above the previous run's FAR threshold will still be analyzed, meaning this functionality supports re-running analyses to allow higher FARs.

This fixes #200.

cc @duncanmmacleod, @areeda 