### PR TITLE
Fix frequency axis limits in scattering plots

### DIFF
--- a/bin/gwdetchar-scattering
+++ b/bin/gwdetchar-scattering
@@ -384,7 +384,7 @@ for i, channel in enumerate(sorted(alldata[0].keys())):
     axes['fringef'].set_ylabel(r'Frequency [Hz]')
     axes['fringef'].yaxis.tick_right()
     axes['fringef'].yaxis.set_label_position("right")
-    axes['fringef'].set_ylim(args.fmin, multiplier * args.frequency_threshold)
+    axes['fringef'].set_ylim(0, multiplier * args.frequency_threshold)
     axes['fringef'].text(
         0.01, 0.95, 'Calculated fringe frequency',
         transform=axes['fringef'].transAxes, va='top', ha='left',
@@ -436,7 +436,7 @@ for i, channel in enumerate(sorted(alldata[0].keys())):
     # make histogram
     histogram = Plot(figsize=[12, 6])
     ax = histogram.gca()
-    hrange = (args.fmin, multiplier * args.frequency_threshold)
+    hrange = (0, multiplier * args.frequency_threshold)
     for m, color in list(zip(histdata, fringecolors))[::-1]:
         if histdata[m].size:
             ax.hist(


### PR DESCRIPTION
This PR fixes an issue @siddharth101 pointed out, where plots of fringe frequency as a function of time should display everything down to 0 Hz, while trigger plots should take their limits from `args.fmin`.

Example output may be found [**here**](https://ldas-jobs.ligo-la.caltech.edu/~aurban/scattering/day/20190104/) (requires `LIGO.ORG` credentials).

cc @siddharth101, @duncanmmacleod 