### PR TITLE
Remove references to footer style

### DIFF
--- a/gwdetchar/io/html.py
+++ b/gwdetchar/io/html.py
@@ -484,8 +484,7 @@ def write_flag_html(flag, span=None, id=0, parent='accordion',
     return page()
 
 
-def write_footer(about=None, link=None, issues=None, content=None,
-                 linkstyle='color:#eee;'):
+def write_footer(about=None, link=None, issues=None, content=None):
     """Write a <footer> for a bootstrap page
 
     Parameters
@@ -502,9 +501,6 @@ def write_footer(about=None, link=None, issues=None, content=None,
     content : `str` or `~MarkupPy.markup.page`, optional
         additional footer content
 
-    linkstyle : `str`, optional
-        style options for rendering `link`
-
     Returns
     -------
     page : `~MarkupPy.markup.page`
@@ -520,11 +516,11 @@ def write_footer(about=None, link=None, issues=None, content=None,
         commit = get_versions()['full-revisionid']
         url = 'https://github.com/gwdetchar/gwdetchar/tree/{}'.format(commit)
         link = markup.oneliner.a('View gwdetchar-{} on GitHub'.format(version),
-                                 href=url, target='_blank', style=linkstyle)
+                                 href=url, target='_blank')
     if issues is None:
         report = 'https://github.com/gwdetchar/gwdetchar/issues'
         issues = markup.oneliner.a('Report an issue', href=report,
-                                  target='_blank', style=linkstyle)
+                                  target='_blank')
     page.div(class_='row')
     page.div(class_='col-md-12')
     now = datetime.datetime.now()
@@ -535,7 +531,7 @@ def write_footer(about=None, link=None, issues=None, content=None,
     page.p('{link} | {issues}'.format(link=link, issues=issues))
     # link to 'about'
     if about is not None:
-        page.a('How was this page generated?', href=about, style=linkstyle)
+        page.a('How was this page generated?', href=about)
     # extra content
     if isinstance(content, markup.page):
         page.add(str(content))

--- a/gwdetchar/io/tests/test_html.py
+++ b/gwdetchar/io/tests/test_html.py
@@ -77,7 +77,7 @@ HTML_FOOTER = """<footer class="footer">
 <div class="row">
 <div class="col-md-12">
 <p>This page was created by {user} at {date}.</p>
-<p><a href="https://github.com/gwdetchar/gwdetchar/tree/%s" target="_blank" style="color:#eee;">View gwdetchar-%s on GitHub</a> | <a href="https://github.com/gwdetchar/gwdetchar/issues" target="_blank" style="color:#eee;">Report an issue</a></p>
+<p><a href="https://github.com/gwdetchar/gwdetchar/tree/%s" target="_blank">View gwdetchar-%s on GitHub</a> | <a href="https://github.com/gwdetchar/gwdetchar/issues" target="_blank">Report an issue</a></p>
 </div>
 </div>
 </div>


### PR DESCRIPTION
This PR removes references to `style` from `gwdetchar.io.html.write_footer`. It is related to gwpy/gwsumm#241 and duncanmmacleod/bootstrap-ligo#2.

cc @duncanmmacleod 