### PR TITLE
Allow scattering code to trigger omega scans

### DIFF
--- a/bin/gwdetchar-omega-batch
+++ b/bin/gwdetchar-omega-batch
@@ -31,21 +31,12 @@ in parallel.
 
 import os
 import subprocess
-from getpass import getuser
 
-from pycondor import (Dagman, Job)
+from gwdetchar import cli
+from gwdetchar.omega import batch
 
-from gwdetchar import (cli, condor)
-
-# get gwdetchar-omega path
-WDQ = os.path.join(os.path.dirname(__file__), 'gwdetchar-omega')
-
-# set default accounting information
-CONDOR_ACCOUNTING_GROUP = os.getenv(
-    '_CONDOR_ACCOUNTING_GROUP', 'ligo.dev.{epoch}.detchar.user_req.omegascan')
-CONDOR_ACCOUNTING_USER = os.getenv(
-    '_CONDOR_ACCOUNTING_USER', getuser())
-
+__author__ = 'Duncan Macleod <duncan.macleod@ligo.org'
+__credits__ = 'Alex Urban <alexander.urban@ligo.org'
 
 # -- parse command line -------------------------------------------------------
 
@@ -87,13 +78,13 @@ cargs.add_argument('--monitor', action='store_true', default=False,
                    help='monitor the DAG progress after submission; '
                         'only used with --submit')
 cargs.add_argument('--condor-accounting-group',
-                   default=CONDOR_ACCOUNTING_GROUP,
+                   default=batch.ACCOUNTING_GROUP,
                    help='accounting_group for condor submission on the LIGO '
                         'Data Grid, include \'{epoch}\' (with curly brackets) '
                         'to auto-substitute the appropriate epoch based on '
                         'the GPS times')
 cargs.add_argument('--condor-accounting-group-user',
-                   default=CONDOR_ACCOUNTING_USER,
+                   default=batch.ACCOUNTING_GROUP_USER,
                    help='accounting_group_user for condor submission on the '
                         'LIGO Data Grid')
 cargs.add_argument('--condor-timeout', type=float, default=None, metavar='T',
@@ -121,96 +112,41 @@ if len(times) == 1:
 else:
     times = list(map(float, times))
 
-# finalise accounting tag based on run
-if '{epoch}' in args.condor_accounting_group:
-    gpsepoch = max(times)
-    epoch = condor.accounting_epoch(gpsepoch)
-    args.condor_accounting_group = args.condor_accounting_group.format(
-        epoch=epoch.lower())
+# get condor arguments
+condorcmds = batch.get_condor_arguments(
+    accounting_group=args.condor_accounting_group,
+    accounting_group_user=args.condor_accounting_group_user,
+    timeout=args.condor_timeout,
+    extra_commands=args.condor_command,
+    gps=max(times),
+)
 
-# valid the accounting tag up-front
-try:
-    valid = condor.validate_accounting_tag(args.condor_accounting_group)
-except EnvironmentError:
-    valid = True  # failed to load condor tags, not important
-if not valid:
-    listtags = 'cat {0} | json_pp | less'.format(condor.ACCOUNTING_GROUPS_FILE)
-    raise ValueError("condor accounting tag {0!r} recognised, to see the list "
-                     "of valid groups, run `{1}`".format(
-                         args.condor_accounting_group, listtags))
+# get command-line flags
+flags = batch.get_command_line_flags(
+    args.ifo,
+    colormap=args.colormap,
+    nproc=args.nproc,
+    far=args.far_threshold,
+    config_file=args.config_file,
+    disable_correlation=args.disable_correlation,
+    disable_checkpoint=args.disable_checkpoint,
+    ignore_state_flags=args.ignore_state_flags,
+)
 
 # -- generate workflow --------------------------------------------------------
 
-# generate directories
-logdir = os.path.join(outdir, 'logs')
-subdir = os.path.join(outdir, 'condor')
-
-# add custom condor commands, using defaults
-condorcmds = [
-    "accounting_group = {}".format(args.condor_accounting_group),
-    "accounting_group_user = {}".format(args.condor_accounting_group_user),
-]
-if args.condor_timeout:
-    condorcmds.append("periodic_remove = {}".format(
-        'CurrentTime-EnteredCurrentStatus > {}'.format(
-            3600 * args.condor_timeout),
-    ))
-condorcmds.extend(args.condor_command)
-
-# generate dagman
-tag = 'gwdetchar-omega-batch'
-dagman = Dagman(
-    name=tag,
-    submit=subdir,
-)
-
-# create condor job
-job = Job(
-    dag=dagman,
-    name=os.path.basename(WDQ),
-    executable=WDQ,
+# write and submit the DAG
+dagman = batch.generate_dag(
+    times,
+    flags=flags,
+    tag=os.path.basename(__file__),
+    submit=args.submit,
+    outdir=outdir,
     universe=args.universe,
-    submit=subdir,
-    error=logdir,
-    output=logdir,
-    getenv=True,
-    request_memory=4096 if args.universe != "local" else None,
-    extra_lines=condorcmds,
+    condor_commands=condorcmds,
 )
 
-# add common gwdetchar-omega options
-arguments = [
-    "--colormap", args.colormap,
-    "--ifo", args.ifo,
-]
-if args.config_file is not None:
-    arguments.extend(("--config-file", os.path.abspath(args.config_file)))
-arguments.extend(("--far-threshold", str(args.far_threshold)))
-arguments.extend(("--nproc", str(args.nproc)))
-if args.disable_correlation:
-    arguments.append("--disable-correlation")
-if args.disable_checkpoint:
-    arguments.append("--disable-checkpoint")
-if args.ignore_state_flags:
-    arguments.append("--ignore-state-flags")
-
-# make node in workflow for each time
-for t in times:
-    cmd = " ".join([str(t)] + [
-        "--output-directory", os.path.join(outdir, str(t))] + arguments)
-    job.add_arg(cmd, name=str(t).replace(".", "_"))
-
-# write DAG
-dagman.build(fancyname=False)
-print("Workflow generated for {} times".format(len(times)))
-if args.submit:
-    dagman.submit_dag(submit_options="-force")
-else:
-    print(
-        "Submit to condor via:\n\n"
-        "$ condor_submit_dag {0.submit_file}".format(dagman),
-    )
-
+# monitor progress
 if args.submit and args.monitor:
     print("Monitoring progress of {0.submit_file}".format(dagman))
     try:

--- a/bin/gwdetchar-scattering
+++ b/bin/gwdetchar-scattering
@@ -547,7 +547,7 @@ nscans = min(args.omega_scans, len(table))
 if nscans > 0:
     # launch scans
     ind = random.sample(range(0, len(table)), nscans)
-    omegatimes = [t for t in table['trigger_time'][ind]]
+    omegatimes = [str(t) for t in table['trigger_time'][ind]]
     logger.debug('Collected {} event times to omega scan: {}'.format(
         nscans, ', '.join(omegatimes)))
     logger.info('Creating workflow for omega scans')

--- a/bin/gwdetchar-scattering
+++ b/bin/gwdetchar-scattering
@@ -546,7 +546,7 @@ nscans = min(args.omega_scans, len(table))
 if nscans > 0:
     # launch scans
     ind = random.sample(range(0, len(table)), nscans)
-    omegatimes = [str(t) for t in table['trigger_time'][ind]]
+    omegatimes = list(table['trigger_time'][ind])
     logger.debug('Collected {} event times to omega scan: {}'.format(
         nscans, ', '.join(omegatimes)))
     logger.info('Creating workflow for omega scans')
@@ -554,8 +554,7 @@ if nscans > 0:
     condorcmds = batch.get_condor_arguments(timeout=4, gps=args.gpsstart)
     dagman = batch.generate_dag(omegatimes, flags=flags, submit=True,
                                 outdir='scans', condor_commands=condorcmds)
-    logger.info('Launched {} omega scans to condor, check their progress '
-                'with condor_q'.format(nscans))
+    logger.info('Launched {} omega scans to condor'.format(nscans))
 
     # render HTML
     page.h2('Omega Scans')

--- a/bin/gwdetchar-scattering
+++ b/bin/gwdetchar-scattering
@@ -22,6 +22,7 @@
 
 from __future__ import division
 
+import logging
 import os.path
 import re
 import random
@@ -31,8 +32,8 @@ from six.moves import StringIO
 
 import numpy
 
-from matplotlib import (use, rcParams)
-use('agg')  # noqa
+import matplotlib
+matplotlib.use('agg')  # noqa
 
 import gwtrigfind
 
@@ -54,6 +55,7 @@ __credits__ = 'Siddharth Soni <siddharth.soni@ligo.org>' \
               'Alex Urban <alexander.urban@ligo.org>'
 
 # TeX settings
+rcParams = matplotlib.rcParams
 tex_settings = get_gwpy_tex_settings()
 rcParams.update(tex_settings)
 rcParams.update({
@@ -66,6 +68,9 @@ rcParams.update({
     'image.cmap': 'viridis',
     'svg.fonttype': 'none',
 })
+
+# disable matplotlib logging
+logging.getLogger("matplotlib").setLevel(logging.CRITICAL)
 
 # -- parse command line -------------------------------------------------------
 

--- a/bin/gwdetchar-scattering
+++ b/bin/gwdetchar-scattering
@@ -547,7 +547,7 @@ nscans = min(args.omega_scans, len(table))
 if nscans > 0:
     # launch scans
     ind = random.sample(range(0, len(table)), nscans)
-    omegatimes = ['%.2f' % t for t in table['trigger_time'][ind]]
+    omegatimes = [t for t in table['trigger_time'][ind]]
     logger.debug('Collected {} event times to omega scan: {}'.format(
         nscans, ', '.join(omegatimes)))
     logger.info('Creating workflow for omega scans')

--- a/bin/gwdetchar-scattering
+++ b/bin/gwdetchar-scattering
@@ -547,9 +547,9 @@ nscans = min(args.omega_scans, len(table))
 if nscans > 0:
     # launch scans
     ind = random.sample(range(0, len(table)), nscans)
-    omegatimes = [str(t) for t in table['trigger_time'][ind]]
+    omegatimes = ['%.2f' % t for t in table['trigger_time'][ind]]
     logger.debug('Collected {} event times to omega scan: {}'.format(
-        nscans, omegatimes))
+        nscans, ', '.join(omegatimes)))
     logger.info('Creating workflow for omega scans')
     batch = [find_executable('gwdetchar-omega-batch')] + omegatimes + [
         '--ignore-state-flags',
@@ -569,24 +569,35 @@ if nscans > 0:
 
     # render HTML
     page.h2('Omega Scans')
+    page.p('The following event times correspond to significant Omicron '
+           'triggers that occurr during the scattering segments found above:')
+    page.div(class_='panel well panel-default')
+    page.div(class_='panel-heading clearfix')
+    page.h3(htmlio.cis_link(args.main_channel), class_='panel-title')
+    page.div.close()  # panel-heading
+    page.ul(class_='list-group')
     for t in omegatimes:
-        page.div(class_='panel panel-default')
-        page.div(class_='panel-heading clearfix')
-        page.div(class_='pull-right')
-        page.a("[full scan]", href='scans', class_='text-dark')
-        page.div.close()  # pull-right
-        page.h3(str(t))
-        page.div.close()  # panel-heading
+        page.li(class_='list-group-item')
         page.div(class_='container')
-        chan = args.main_channel.replace(':', '-')
+        page.div(class_='row')
+        page.div(class_='pull-right')
+        page.a("<small>[full scan]</small>",
+           href='scans/{}'.format(t),
+           class_='text-dark')
+        page.div.close()  # pull-right
+        page.h4(t)
+        page.div.close()  # row
+        chanstr = args.main_channel.replace('-', '_').replace(':', '-')
         plots = [
             'scans/{}/plots/{}-qscan_whitened-{}.png'.format(
-                t, chan, dur) for dur in [1, 4, 16]]
+                t, chanstr, dur) for dur in [1, 4, 16]]
         page.add(htmlio.scaffold_plots(
             [htmlio.FancyPlot(plot) for plot in plots],
             nperrow=3))
         page.div.close()  # container
-        page.div.close()  # panel
+        page.li.close()  # list-group-item
+    page.ul.close()  # list-group
+    page.div.close()  # panel
 
 elif args.omega_scans:
     logger.info('No events found during active scattering segments')

--- a/bin/gwdetchar-scattering
+++ b/bin/gwdetchar-scattering
@@ -545,49 +545,23 @@ table.write(summfile, overwrite=True)
 nscans = min(args.omega_scans, len(table))
 if nscans > 0:
     # launch scans
+    scandir = 'scans'
     ind = random.sample(range(0, len(table)), nscans)
-    omegatimes = list(table['trigger_time'][ind])
+    omegatimes = [str(t) for t in table['trigger_time'][ind]]
     logger.debug('Collected {} event times to omega scan: {}'.format(
         nscans, ', '.join(omegatimes)))
     logger.info('Creating workflow for omega scans')
     flags = batch.get_command_line_flags(ifo=args.ifo, ignore_state_flags=True)
     condorcmds = batch.get_condor_arguments(timeout=4, gps=args.gpsstart)
     dagman = batch.generate_dag(omegatimes, flags=flags, submit=True,
-                                outdir='scans', condor_commands=condorcmds)
+                                outdir=scandir, condor_commands=condorcmds)
     logger.info('Launched {} omega scans to condor'.format(nscans))
-
     # render HTML
     page.h2('Omega Scans')
     page.p('The following event times correspond to significant Omicron '
            'triggers that occurr during the scattering segments found above:')
-    page.div(class_='panel well panel-default')
-    page.div(class_='panel-heading clearfix')
-    page.h3(htmlio.cis_link(args.main_channel), class_='panel-title')
-    page.div.close()  # panel-heading
-    page.ul(class_='list-group')
-    for t in omegatimes:
-        page.li(class_='list-group-item')
-        page.div(class_='container')
-        page.div(class_='row')
-        page.div(class_='pull-right')
-        page.a("<small>[full scan]</small>",
-           href='scans/{}'.format(t),
-           class_='text-dark')
-        page.div.close()  # pull-right
-        page.h4(t)
-        page.div.close()  # row
-        chanstr = args.main_channel.replace('-', '_').replace(':', '-')
-        plots = [
-            'scans/{}/plots/{}-qscan_whitened-{}.png'.format(
-                t, chanstr, dur) for dur in [1, 4, 16]]
-        page.add(htmlio.scaffold_plots(
-            [htmlio.FancyPlot(plot) for plot in plots],
-            nperrow=3))
-        page.div.close()  # container
-        page.li.close()  # list-group-item
-    page.ul.close()  # list-group
-    page.div.close()  # panel
-
+    page.add(htmlio.scaffold_omega_scans(
+        omegatimes, args.main_channel, scandir=scandir))
 elif args.omega_scans:
     logger.info('No events found during active scattering segments')
 

--- a/bin/gwdetchar-scattering
+++ b/bin/gwdetchar-scattering
@@ -571,6 +571,9 @@ if nscans > 0:
     for t in omegatimes:
         page.div(class_='panel panel-default')
         page.div(class_='panel-heading clearfix')
+        page.div(class_='pull-right')
+        page.a("[full scan]", href='scans', class_='text-dark')
+        page.div.close()  # pull-right
         page.h3(str(t))
         page.div.close()  # panel-heading
         page.div(class_='container')

--- a/bin/gwdetchar-scattering
+++ b/bin/gwdetchar-scattering
@@ -547,8 +547,9 @@ nscans = min(args.omega_scans, len(table))
 if nscans > 0:
     # launch scans
     ind = random.sample(range(0, len(table)), nscans)
-    omegatimes = table['trigger_time'][ind]
-    logger.debug('Collected {} events to omega scan'.format(nscans))
+    omegatimes = [str(t) for t in table['trigger_time'][ind]]
+    logger.debug('Collected {} event times to omega scan: {}'.format(
+        nscans, omegatimes))
     logger.info('Creating workflow for omega scans')
     batch = [find_executable('gwdetchar-omega-batch')] + omegatimes + [
         '--ignore-state-flags',

--- a/bin/gwdetchar-scattering
+++ b/bin/gwdetchar-scattering
@@ -25,11 +25,9 @@ from __future__ import division
 import os.path
 import re
 import random
-import subprocess
 import warnings
 
 from six.moves import StringIO
-from distutils.spawn import find_executable
 
 import numpy
 
@@ -48,6 +46,7 @@ from gwpy.segments import (DataQualityFlag, DataQualityDict,
 from gwdetchar import (cli, const, scattering)
 from gwdetchar.io import html as htmlio
 from gwdetchar.io.datafind import get_data
+from gwdetchar.omega import batch
 from gwdetchar.plot import get_gwpy_tex_settings
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
@@ -551,15 +550,10 @@ if nscans > 0:
     logger.debug('Collected {} event times to omega scan: {}'.format(
         nscans, ', '.join(omegatimes)))
     logger.info('Creating workflow for omega scans')
-    batch = [find_executable('gwdetchar-omega-batch')] + omegatimes + [
-        '--ignore-state-flags',
-        '--output-dir', 'scans',
-        '--ifo', args.ifo,
-        '--condor-timeout', str(4),
-        '--submit'
-    ]
-    logger.debug("$ {}".format(" ".join(batch)))
-    subprocess.check_call(cmd)
+    flags = batch.get_command_line_flags(ifo=args.ifo, ignore_state_flags=True)
+    condorcmds = batch.get_condor_arguments(timeout=4, gps=args.gpsstart)
+    dagman = batch.generate_dag(omegatimes, flags=flags, submit=True,
+                                outdir='scans', condor_commands=condorcmds)
     logger.info('Launched {} omega scans to condor, check their progress '
                 'with condor_q'.format(nscans))
 

--- a/bin/gwdetchar-scattering
+++ b/bin/gwdetchar-scattering
@@ -559,11 +559,7 @@ if nscans > 0:
         '--submit'
     ]
     logger.debug("$ {}".format(" ".join(batch)))
-    proc = subprocess.Popen(batch)
-    out, err = proc.communicate()
-    if proc.returncode:
-        raise subprocess.CalledProcessError(
-            proc.returncode, ' '.join(batch))
+    subprocess.check_call(cmd)
     logger.info('Launched {} omega scans to condor, check their progress '
                 'with condor_q'.format(nscans))
 

--- a/bin/gwdetchar-scattering
+++ b/bin/gwdetchar-scattering
@@ -24,9 +24,12 @@ from __future__ import division
 
 import os.path
 import re
+import random
+import subprocess
 import warnings
 
 from six.moves import StringIO
+from distutils.spawn import find_executable
 
 import numpy
 
@@ -48,6 +51,8 @@ from gwdetchar.io.datafind import get_data
 from gwdetchar.plot import get_gwpy_tex_settings
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
+__credits__ = 'Siddharth Soni <siddharth.soni@ligo.org>' \
+              'Alex Urban <alexander.urban@ligo.org>'
 
 # TeX settings
 tex_settings = get_gwpy_tex_settings()
@@ -100,6 +105,10 @@ cli.add_frametype_option(parser, default='%s_R' % const.IFO)
 parser.add_argument('-o', '--output-dir', type=os.path.abspath,
                     default=os.curdir,
                     help='output directory for analysis, default: %(default)s')
+parser.add_argument('-w', '--omega-scans', type=int, metavar='NSCAN',
+                    help='generate a workflow of omega scans for active '
+                         'scattering, this will launch automatically to '
+                         'condor, default: None')
 parser.add_argument('-v', '--verbose', action='store_true', default=False,
                     help='log verbose output, default: %(default)s')
 cli.add_nproc_option(parser)
@@ -518,7 +527,7 @@ for i, channel in enumerate(sorted(alldata[0].keys())):
 # close panel group
 page.div.close()
 
-# write a csv file
+# identify triggers during active segments
 logger.debug('Writing a summary CSV record')
 actives = actives.coalesce()  # merge contiguous segments
 gps = [x for x in highsnrtrigs[names[0]] for y in actives if x in y]
@@ -531,6 +540,52 @@ logger.info('The following {} triggers fell within active scattering '
 print(table)
 print('\n\n')
 table.write(summfile, overwrite=True)
+
+# -- launch omega scans -------------------------------------------------------
+
+nscans = min(args.omega_scans, len(table))
+if nscans > 0:
+    # launch scans
+    ind = random.sample(range(0, len(table)), nscans)
+    omegatimes = table['trigger_time'][ind]
+    logger.debug('Collected {} events to omega scan'.format(nscans))
+    logger.info('Creating workflow for omega scans')
+    batch = [find_executable('gwdetchar-omega-batch')] + omegatimes + [
+        '--ignore-state-flags',
+        '--output-dir', 'scans',
+        '--ifo', args.ifo,
+        '--condor-timeout', str(4),
+        '--submit'
+    ]
+    logger.debug("$ {}".format(" ".join(batch)))
+    proc = subprocess.Popen(batch)
+    out, err = proc.communicate()
+    if proc.returncode:
+        raise subprocess.CalledProcessError(
+            proc.returncode, ' '.join(batch))
+    logger.info('Launched {} omega scans to condor, check their progress '
+                'with condor_q'.format(nscans))
+
+    # render HTML
+    page.h2('Omega Scans')
+    for t in omegatimes:
+        page.div(class_='panel panel-default')
+        page.div(class_='panel-heading clearfix')
+        page.h3(str(t))
+        page.div.close()  # panel-heading
+        page.div(class_='container')
+        chan = args.main_channel.replace(':', '-')
+        plots = [
+            'scans/{}/plots/{}-qscan_whitened-{}.png'.format(
+                t, chan, dur) for dur in [1, 4, 16]]
+        page.add(htmlio.scaffold_plots(
+            [htmlio.FancyPlot(plot) for plot in plots],
+            nperrow=3))
+        page.div.close()  # container
+        page.div.close()  # panel
+
+elif args.omega_scans:
+    logger.info('No events found during active scattering segments')
 
 # -- finalize -----------------------------------------------------------------
 

--- a/gwdetchar/condor.py
+++ b/gwdetchar/condor.py
@@ -45,6 +45,22 @@ def accounting_epoch(gpstime):
     return epoch
 
 
+def is_valid(tag, path=ACCOUNTING_GROUPS_FILE):
+    """Determine whether an accounting tag is valid, and raise an exception
+    if not
+    """
+    try:
+        valid = validate_accounting_tag(tag, path=path)
+    except EnvironmentError:
+        valid = True  # failed to load condor tags, not important
+    if not valid:
+        listtags = 'cat {0} | json_pp | less'.format(path)
+        raise ValueError("condor accounting tag {0!r} recognised, to see the "
+                         "list of valid groups, run `{1}`".format(
+                             condor_accounting_group, listtags))
+    return valid
+
+
 def validate_accounting_tag(tag, path=ACCOUNTING_GROUPS_FILE):
     """Validate a given accounting tag
 

--- a/gwdetchar/condor.py
+++ b/gwdetchar/condor.py
@@ -55,9 +55,9 @@ def is_valid(tag, path=ACCOUNTING_GROUPS_FILE):
         valid = True  # failed to load condor tags, not important
     if not valid:
         listtags = 'cat {0} | json_pp | less'.format(path)
-        raise ValueError("condor accounting tag {0!r} recognised, to see the "
-                         "list of valid groups, run `{1}`".format(
-                             condor_accounting_group, listtags))
+        raise ValueError("condor accounting tag {0!r} not recognised, to see "
+                         "the list of valid groups, please run `{1}`".format(
+                             tag, listtags))
     return valid
 
 

--- a/gwdetchar/io/html.py
+++ b/gwdetchar/io/html.py
@@ -484,6 +484,41 @@ def write_flag_html(flag, span=None, id=0, parent='accordion',
     return page()
 
 
+def scaffold_omega_scans(times, channel, plot_durations=[1, 4, 16],
+                         scandir=os.path.curdir):
+    """Preview a batch of omega scans in HTML
+    """
+    page = markup.page()
+    page.div(class_='panel well panel-default')
+    page.div(class_='panel-heading clearfix')
+    page.h3(cis_link(channel), class_='panel-title')
+    page.div.close()  # panel-heading
+    page.ul(class_='list-group')
+    for t in times:
+        page.li(class_='list-group-item')
+        page.div(class_='container')
+        page.div(class_='row')
+        page.div(class_='pull-right')
+        page.a("[full scan]",
+           href='{}/{}'.format(scandir, t),
+           class_='text-dark')
+        page.div.close()  # pull-right
+        page.h4(t)
+        page.div.close()  # row
+        chanstr = channel.replace('-', '_').replace(':', '-')
+        plots = [
+            '{}/{}/plots/{}-qscan_whitened-{}.png'.format(
+                scandir, t, chanstr, dur) for dur in plot_durations]
+        page.add(scaffold_plots(
+            [FancyPlot(plot) for plot in plots],
+            nperrow=3))
+        page.div.close()  # container
+        page.li.close()  # list-group-item
+    page.ul.close()  # list-group
+    page.div.close()  # panel
+    return page()
+
+
 def write_footer(about=None, link=None, issues=None, content=None):
     """Write a <footer> for a bootstrap page
 

--- a/gwdetchar/io/tests/test_html.py
+++ b/gwdetchar/io/tests/test_html.py
@@ -117,6 +117,41 @@ FLAG_HTML_NO_SEGMENTS = FLAG_CONTENT.format(
 
 FLAG = DataQualityFlag(known=[(0, 66)], active=[(0, 66)], name='X1:TEST_FLAG')
 
+OMEGA_SCAFFOLD = """<div class="panel well panel-default">
+<div class="panel-heading clearfix">
+<h3 class="panel-title"><a href="https://cis.ligo.org/channel/byname/X1:STRAIN" title="CIS entry for X1:STRAIN" style="font-family: Monaco, &quot;Courier New&quot;, monospace; color: black;" target="_blank">X1:STRAIN</a></h3>
+</div>
+<ul class="list-group">
+<li class="list-group-item">
+<div class="container">
+<div class="row">
+<div class="pull-right">
+<a href="./1126259462" class="text-dark">[full scan]</a>
+</div>
+<h4>1126259462</h4>
+</div>
+<div class="row">
+<div class="col-sm-4">
+<a href="./1126259462/plots/X1-STRAIN-qscan_whitened-1.png" id="a_X1-STRAIN_1" title="X1-STRAIN-qscan_whitened-1.png" class="fancybox" target="_blank" data-fancybox-group="images">
+<img id="img_X1-STRAIN_1" alt="X1-STRAIN-qscan_whitened-1.png" class="img-responsive" src="./1126259462/plots/X1-STRAIN-qscan_whitened-1.png" />
+</a>
+</div>
+<div class="col-sm-4">
+<a href="./1126259462/plots/X1-STRAIN-qscan_whitened-4.png" id="a_X1-STRAIN_4" title="X1-STRAIN-qscan_whitened-4.png" class="fancybox" target="_blank" data-fancybox-group="images">
+<img id="img_X1-STRAIN_4" alt="X1-STRAIN-qscan_whitened-4.png" class="img-responsive" src="./1126259462/plots/X1-STRAIN-qscan_whitened-4.png" />
+</a>
+</div>
+<div class="col-sm-4">
+<a href="./1126259462/plots/X1-STRAIN-qscan_whitened-16.png" id="a_X1-STRAIN_16" title="X1-STRAIN-qscan_whitened-16.png" class="fancybox" target="_blank" data-fancybox-group="images">
+<img id="img_X1-STRAIN_16" alt="X1-STRAIN-qscan_whitened-16.png" class="img-responsive" src="./1126259462/plots/X1-STRAIN-qscan_whitened-16.png" />
+</a>
+</div>
+</div>
+</div>
+</li>
+</ul>
+</div>"""  # nopep8
+
 
 # -- HTML unit tests ----------------------------------------------------------
 
@@ -254,6 +289,14 @@ def test_write_flag_html_with_plots(tmpdir):
     page = html.write_flag_html(FLAG, span=Segment(0, 66), plotdir='plots')
     assert parse_html(str(page)) == parse_html(FLAG_HTML_WITH_PLOTS)
     shutil.rmtree(str(tmpdir), ignore_errors=True)
+
+
+def test_scaffold_omega_scans():
+    times = [1126259462]
+    channel = 'X1:STRAIN'
+    page = html.scaffold_omega_scans(times, channel)
+    print(page)
+    assert parse_html(page) == parse_html(OMEGA_SCAFFOLD)
 
 
 def test_write_footer():

--- a/gwdetchar/io/tests/test_html.py
+++ b/gwdetchar/io/tests/test_html.py
@@ -295,7 +295,6 @@ def test_scaffold_omega_scans():
     times = [1126259462]
     channel = 'X1:STRAIN'
     page = html.scaffold_omega_scans(times, channel)
-    print(page)
     assert parse_html(page) == parse_html(OMEGA_SCAFFOLD)
 
 

--- a/gwdetchar/omega/batch.py
+++ b/gwdetchar/omega/batch.py
@@ -80,7 +80,7 @@ def get_condor_arguments(accounting_group=ACCOUNTING_GROUP,
     if timeout:
         condorcmds.append("periodic_remove = {}".format(
             'CurrentTime-EnteredCurrentStatus > {}'.format(
-                3600 * args.condor_timeout),
+                3600 * timeout),
         ))
     condorcmds.extend(extra_commands)
     return condorcmds

--- a/gwdetchar/omega/batch.py
+++ b/gwdetchar/omega/batch.py
@@ -1,0 +1,158 @@
+# coding=utf-8
+# Copyright (C) Alex Urban (2019)
+#
+# This file is part of the GW DetChar python package.
+#
+# GW DetChar is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GW DetChar is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GW DetChar.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Batch-mode utilities for omega scans
+"""
+
+import os
+
+from getpass import getuser
+from distutils.spawn import find_executable
+from pycondor import (Dagman, Job)
+
+from .. import condor
+
+__author__ = 'Alex Urban <alexander.urban@ligo.org>'
+__credits__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
+
+# set default accounting information
+ACCOUNTING_GROUP = os.getenv(
+    '_CONDOR_ACCOUNTING_GROUP', 'ligo.dev.{epoch}.detchar.user_req.omegascan')
+ACCOUNTING_GROUP_USER = os.getenv(
+    '_CONDOR_ACCOUNTING_USER', getuser())
+
+
+# -- utilities ----------------------------------------------------------------
+
+def get_command_line_flags(ifo, colormap='viridis', nproc=8, far=3.171e-8,
+                           config_file=None, disable_correlation=False,
+                           disable_checkpoint=False, ignore_state_flags=False):
+    """Get a list of optional command-line arguments to `gwdetchar-omega`
+    """
+    flags = [
+        "--ifo", ifo,
+        "--colormap", colormap,
+        "--nproc", str(nproc),
+        "--far-threshold", str(far),
+    ]
+    if config_file is not None:
+        flags.extend(("--config-file", os.path.abspath(config_file)))
+    if disable_correlation:
+        flags.append("--disable-correlation")
+    if disable_checkpoint:
+        flags.append("--disable-checkpoint")
+    if ignore_state_flags:
+        flags.append("--ignore-state-flags")
+    return flags
+
+
+def get_condor_arguments(accounting_group=ACCOUNTING_GROUP,
+                         accounting_group_user=ACCOUNTING_GROUP_USER,
+                         timeout=0, extra_commands=[], gps=0):
+    """Get a list of arguments for Condor processing
+    """
+    # get reference epoch
+    if '{epoch}' in accounting_group:
+        epoch = condor.accounting_epoch(gps)
+        accounting_group = accounting_group.format(epoch=epoch.lower())
+    # validate accounting tag
+    condor.is_valid(accounting_group)
+    # determine condor arguments
+    condorcmds = [
+        "accounting_group = {}".format(accounting_group),
+        "accounting_group_user = {}".format(accounting_group_user),
+    ]
+    if timeout:
+        condorcmds.append("periodic_remove = {}".format(
+            'CurrentTime-EnteredCurrentStatus > {}'.format(
+                3600 * args.condor_timeout),
+        ))
+    condorcmds.extend(extra_commands)
+    return condorcmds
+
+
+def generate_dag(times, flags=[], tag='gwdetchar-omega-batch',
+                 submit=False, outdir=os.getcwd(), universe='vanilla',
+                 condor_commands=get_condor_arguments()):
+    """Construct a Directed Acyclic Graph (DAG)
+
+    Parameters
+    ----------
+    times : `list` of `float`
+        list of GPS times to scan
+
+    flags : `list` of `str`, optional
+        a list of command line flags to run for each job, defaults to an
+        empty list
+
+    tag : `str`, optional
+        a helpful string to use to name the DAG,
+        default: `'gwdetchar-omega-batch'`
+
+    submit : `bool`, optional
+        whether to submit the DAG to condor, default: `False`
+
+    outdir : `str`, optional
+        the output directory in which to store files, will result in
+        sub-directories called `'condor'` and `'log'`, default: `os.getcwd`
+
+    universe : `str`, optional
+        condor universe to run in, default: `'vanilla'`
+
+    condor_arguments : `list` of `str`, optional
+        list of Condor settings to process with, defaults to the output of
+        `get_condor_arguments`
+
+    Returns
+    -------
+    dagman : `~pycondor.Dagman`
+        the fully built DAG object
+    """
+    logdir = os.path.join(outdir, 'logs')
+    subdir = os.path.join(outdir, 'condor')
+    executable = find_executable('gwdetchar-omega')
+    # create DAG and jobs
+    dagman = Dagman(name=tag, submit=subdir)
+    job = Job(
+        dag=dagman,
+        name=os.path.basename(executable),
+        executable=executable,
+        universe=universe,
+        submit=subdir,
+        error=logdir,
+        output=logdir,
+        getenv=True,
+        request_memory=4096 if universe != "local" else None,
+        extra_lines=condor_commands
+    )
+    # make a node in the workflow for each event time
+    for t in times:
+        cmd = " ".join([str(t)] + [
+            "--output-directory", os.path.join(outdir, str(t))] + flags)
+        job.add_arg(cmd, name=str(t).replace(".", "_"))
+    # write and submit the DAG
+    dagman.build(fancyname=False)
+    print("Workflow generated for {} times".format(len(times)))
+    if submit:
+        dagman.submit_dag(submit_options="-force")
+    else:
+        print(
+            "Submit to condor via:\n\n"
+            "$ condor_submit_dag {0.submit_file}".format(dagman),
+        )
+    return dagman

--- a/gwdetchar/omega/batch.py
+++ b/gwdetchar/omega/batch.py
@@ -89,7 +89,7 @@ def get_condor_arguments(accounting_group=ACCOUNTING_GROUP,
 def generate_dag(times, flags=[], tag='gwdetchar-omega-batch',
                  submit=False, outdir=os.getcwd(), universe='vanilla',
                  condor_commands=get_condor_arguments()):
-    """Construct a Directed Acyclic Graph (DAG)
+    """Construct a Directed Acyclic Graph (DAG) for a batch of omega scans
 
     Parameters
     ----------
@@ -105,7 +105,7 @@ def generate_dag(times, flags=[], tag='gwdetchar-omega-batch',
         default: `'gwdetchar-omega-batch'`
 
     submit : `bool`, optional
-        whether to submit the DAG to condor, default: `False`
+        submit the DAG to condor, default: `False`
 
     outdir : `str`, optional
         the output directory in which to store files, will result in
@@ -114,8 +114,8 @@ def generate_dag(times, flags=[], tag='gwdetchar-omega-batch',
     universe : `str`, optional
         condor universe to run in, default: `'vanilla'`
 
-    condor_arguments : `list` of `str`, optional
-        list of Condor settings to process with, defaults to the output of
+    condor_commands : `list` of `str`, optional
+        list of condor settings to process with, defaults to the output of
         `get_condor_arguments`
 
     Returns
@@ -150,6 +150,10 @@ def generate_dag(times, flags=[], tag='gwdetchar-omega-batch',
     print("Workflow generated for {} times".format(len(times)))
     if submit:
         dagman.submit_dag(submit_options="-force")
+        print(
+            "Submitted to condor, check status via:\n\n"
+            "$ condor_q {}".format(getuser())
+        )
     else:
         print(
             "Submit to condor via:\n\n"

--- a/gwdetchar/omega/tests/test_batch.py
+++ b/gwdetchar/omega/tests/test_batch.py
@@ -1,0 +1,93 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Alex Urban (2019)
+#
+# This file is part of the GW DetChar python package.
+#
+# GW DetChar is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GW DetChar is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with gwdetchar.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests for `gwdetchar.omega.batch`
+"""
+
+import os
+import shutil
+import numpy.testing as nptest
+
+from getpass import getuser
+from pycondor import Dagman
+
+from gwpy.testing.compat import mock
+
+from .. import batch
+
+__author__ = 'Alex Urban <alexander.urban@ligo.org>'
+
+# global test objects
+
+FLAGS = [
+    '--ifo', 'X1',
+    '--colormap', 'viridis',
+    '--nproc', '8',
+    '--far-threshold', '3.171e-08',
+    '--disable-correlation',
+    '--disable-checkpoint',
+    '--ignore-state-flags',
+]
+
+CONDORCMDS = [
+    'accounting_group = ligo.dev.o1.detchar.user_req.omegascan',
+    'accounting_group_user = {}'.format(getuser()),
+    'periodic_remove = CurrentTime-EnteredCurrentStatus > 14400',
+    'test',
+]
+
+
+# -- unit tests ---------------------------------------------------------------
+
+def test_get_command_line_flags():
+    ifo = 'X1'
+    flags = batch.get_command_line_flags(
+        ifo, disable_correlation=True, disable_checkpoint=True,
+        ignore_state_flags=True)
+    nptest.assert_array_equal(flags, FLAGS)
+
+
+def test_get_condor_arguments():
+    gps = 1126259462
+    condorcmds = batch.get_condor_arguments(
+        timeout=4, extra_commands=['test'], gps=gps)
+    nptest.assert_array_equal(condorcmds, CONDORCMDS)
+
+
+@mock.patch('pycondor.Dagman.submit_dag')
+def test_generate_dag(dag, tmpdir, capsys):
+    outdir = str(tmpdir)
+    times = [1187008882]
+    dag.return_value = 1
+    # test without submit
+    dagman = batch.generate_dag(
+        times, flags=FLAGS, outdir=outdir, condor_commands=CONDORCMDS)
+    assert isinstance(dagman, Dagman)
+    assert os.path.exists(os.path.join(outdir, 'condor'))
+    assert os.path.exists(os.path.join(outdir, 'logs'))
+    captured = capsys.readouterr()
+    assert captured.out.startswith('The directory')
+    assert 'Submit to condor via' in captured.out
+    # test with submit
+    dagman = batch.generate_dag(
+        times, flags=FLAGS, submit=True, outdir=outdir,
+        condor_commands=CONDORCMDS)
+    captured = capsys.readouterr()
+    assert 'condor_q' in captured.out
+    # clean up
+    shutil.rmtree(outdir, ignore_errors=True)

--- a/gwdetchar/tests/test_condor.py
+++ b/gwdetchar/tests/test_condor.py
@@ -59,3 +59,8 @@ def tagfile():
 ])
 def test_validate_accounting_tag(tagfile, tag, result):
     assert condor.validate_accounting_tag(tag, path=tagfile) == result
+    if result:
+        assert condor.is_valid(tag, path=tagfile) == result
+    else:
+        with pytest.raises(ValueError):
+            condor.is_valid(tag, path=tagfile)


### PR DESCRIPTION
This PR adds an option `--omega-scans`, whose argument is an integer, to `gwdetchar-scattering`. When `--omega-scans N` is nonzero, a random sample of `N` triggers that fall within active scattering segments is chosen to omega scan, with jobs launched in batch mode and displayed on the scattering page.

This PR also refactors the heavy lifting in `gwdetchar-omega-batch` into a new submodule, `gwdetchar.omega.batch`, including unit tests.

Test output is available [**here**](https://ldas-jobs.ligo-la.caltech.edu/~aurban/scattering/day/20190331/) (requires `LIGO.ORG` credentials).

This fixes #287.

cc @duncanmmacleod, @siddharth101 