### PR TITLE
Add protections for the get_data utility

### DIFF
--- a/bin/gwdetchar-conlog
+++ b/bin/gwdetchar-conlog
@@ -45,7 +45,7 @@ parser = cli.create_parser(description=__doc__)
 cli.add_gps_start_stop_arguments(parser)
 cli.add_ifo_option(parser)
 cli.add_frametype_option(parser, required=const.IFO is None,
-                         default='%s_T'.format(const.IFO))
+                         default='{}_T'.format(const.IFO))
 cli.add_nproc_option(parser)
 parser.add_argument('-o', '--output', default='changes.csv',
                     help='Path to output data file, default: %(default)s')

--- a/bin/gwdetchar-lasso-correlation
+++ b/bin/gwdetchar-lasso-correlation
@@ -149,7 +149,7 @@ if args.band_pass:
     logger.info("-- Loading primary channel data")
     bandts = get_data(
         primary, start-pad, end+pad, verbose='Reading primary:'.rjust(30),
-        obs=args.ifo[0], frametype=args.primary_frametype, nproc=args.nproc)
+        frametype=args.primary_frametype, nproc=args.nproc)
     if flower < 0 or fupper >= float((bandts.sample_rate/2.).value):
         raise ValueError("bandpass frequency is out of range for this "
                          "channel, band (Hz): {0}, sample rate: {1}".format(
@@ -180,7 +180,7 @@ else:
     # load primary channel data
     logger.info("-- Loading primary channel data")
     primaryts = get_data(primary, start, end, frametype=args.primary_frametype,
-                         obs=args.ifo[0], verbose='Reading:'.rjust(30),
+                         verbose='Reading:'.rjust(30),
                          nproc=args.nproc).crop(start, end)
 
 if args.remove_outliers:
@@ -216,7 +216,7 @@ else:
     frametype = '%s_T' % args.ifo  # for second trends
 
 auxdata = get_data(
-    channels, start, end, verbose='Reading:'.rjust(30), obs=args.ifo[0],
+    channels, start, end, verbose='Reading:'.rjust(30),
     frametype=frametype, nproc=args.nproc, pad=0).crop(start, end)
 
 # -- removes flat data to be re-introdused later

--- a/bin/gwdetchar-scattering
+++ b/bin/gwdetchar-scattering
@@ -289,7 +289,7 @@ for i, seg in enumerate(statea):
     ) if args.verbose else False
     alldata.append(
         get_data(allchannels, seg[0], seg[1], frametype=args.frametype,
-                 obs=args.ifo[0], verbose=msg, nproc=args.nproc).resample(128))
+                 verbose=msg, nproc=args.nproc).resample(128))
 
 scatter_segments = DataQualityDict()
 actives = SegmentList()

--- a/bin/gwdetchar-slow-correlation
+++ b/bin/gwdetchar-slow-correlation
@@ -112,7 +112,7 @@ rcParams.update(tex_settings)
 # load data
 logger.info("-- Loading range data")
 rangets = get_data(rangechannel, start, end, frametype=args.range_frametype,
-                   obs=args.ifo[0], verbose=True, nproc=args.nproc)
+                   verbose=True, nproc=args.nproc)
 
 if args.trend_type == 'minute':
     dstart, dend = rangets.span
@@ -121,7 +121,7 @@ else:
     dend = end
 
 logger.info("-- Loading h(t) data")
-darmts = get_data(primary, dstart-pad, dend+pad, verbose=True, obs=args.ifo[0],
+darmts = get_data(primary, dstart-pad, dend+pad, verbose=True,
                   frametype=args.primary_frametype, nproc=args.nproc)
 
 # get darm BLRMS
@@ -185,7 +185,7 @@ if args.trend_type == 'minute':
 else:
     frametype = '%s_T' % args.ifo  # for second trends
 auxdata = get_data(map(str, channels), dstart, dend, verbose=True, pad=0,
-                   obs=args.ifo[0], frametype=frametype, nproc=args.nproc)
+                   frametype=frametype, nproc=args.nproc)
 
 gpsstub = '%d-%d' % (start, end-start)
 re_delim = re.compile('[:_-]')

--- a/gwdetchar/io/datafind.py
+++ b/gwdetchar/io/datafind.py
@@ -192,7 +192,10 @@ def get_data(channel, start, end, frametype=None, source=None,
             ifo = re.search('[A-Z]1', frametype).group(0)
             obs = ifo[0]
             source = gwdatafind.find_urls(obs, frametype, start, end)
-        except HTMLError:  # frame files not found
+        except AttributeError:
+            raise AttributeError(
+                'Could not determine observatory from frametype')
+        except HTTPError:  # frame files not found
             pass
     if isinstance(source, list) and isinstance(channel, (list, tuple)):
         channel = remove_missing_channels(channel, source)

--- a/gwdetchar/io/datafind.py
+++ b/gwdetchar/io/datafind.py
@@ -187,20 +187,19 @@ def get_data(channel, start, end, frametype=None, source=None,
     else:
         series_class = TimeSeries
 
-    try:  # locate frame files
-        if frametype is not None:
+    if frametype is not None:
+        try:  # locate frame files
             ifo = re.search('[A-Z]1', frametype).group(0)
             obs = ifo[0]
             source = gwdatafind.find_urls(obs, frametype, start, end)
-    except HTMLError:  # frame files not found
-        pass
-    else:  # read from frame files
-        if isinstance(source, list) and isinstance(channel, (list, tuple)):
-            channel = remove_missing_channels(channel, source)
-        if source is not None:
-            return series_class.read(
-                source, channel, start=start, end=end, nproc=nproc,
-                verbose=verbose, **kwargs)
+        except HTMLError:  # frame files not found
+            pass
+    if isinstance(source, list) and isinstance(channel, (list, tuple)):
+        channel = remove_missing_channels(channel, source)
+    if source is not None:  # read from frame files
+        return series_class.read(
+            source, channel, start=start, end=end, nproc=nproc,
+            verbose=verbose, **kwargs)
 
     # read single channel from NDS
     if not isinstance(channel, (list, tuple)):

--- a/gwdetchar/io/tests/test_datafind.py
+++ b/gwdetchar/io/tests/test_datafind.py
@@ -72,7 +72,7 @@ def test_get_data_from_NDS(tsget):
     start = 0
     end = 64
     channel = 'X1:TEST-STRAIN'
-    data = datafind.get_data(channel, start, end, source=0)
+    data = datafind.get_data(channel, start, end)
 
     # test data products
     assert isinstance(data, TimeSeries)
@@ -86,7 +86,7 @@ def test_get_data_dict_from_NDS(tsdget):
     start = 33
     end = 64
     channels = ['X1:TEST-STRAIN']
-    data = datafind.get_data(channels, start, end, source=0)
+    data = datafind.get_data(channels, start, end)
 
     # test data products
     assert isinstance(data, TimeSeriesDict)

--- a/gwdetchar/io/tests/test_datafind.py
+++ b/gwdetchar/io/tests/test_datafind.py
@@ -128,3 +128,10 @@ def test_get_data_dict_from_cache(tsdget, remove):
     assert data[channels[0]].span == Segment(start, end)
     nptest.assert_array_equal(data[channels[0]].value,
                               HOFT.crop(start, end).value)
+
+
+def test_get_data_bad_frametype():
+    channel = 'X1:TEST-STRAIN'
+    with pytest.raises(AttributeError) as exc:
+        datafind.get_data(channel, start=0, end=32, frametype='bad_frametype')
+    assert 'Could not determine observatory' in str(exc.value)

--- a/gwdetchar/io/tests/test_datafind.py
+++ b/gwdetchar/io/tests/test_datafind.py
@@ -128,9 +128,3 @@ def test_get_data_dict_from_cache(tsdget, remove):
     assert data[channels[0]].span == Segment(start, end)
     nptest.assert_array_equal(data[channels[0]].value,
                               HOFT.crop(start, end).value)
-
-
-def test_fail_on_no_frametype():
-    channel = 'X1:TEST-STRAIN'
-    with pytest.raises(HTTPError):
-        datafind.get_data(channel, start=0, end=32)


### PR DESCRIPTION
This PR fixes a bug in the `get_data` utility by adding protections against nonexistent frame files when attempting to build a frame file cache, and falling back to `TimeSeries{Dict}.get` rather than `fetch` when that fails. Unit tests are also updated to reflect these changes.

Other changes include:
* Remove redundant `obs` keyword argument from `get_data`, and infer the observatory from the `frametype` (when applicable) using a regular expression
* Remove references to `obs` from a few scripts
* Simplify a couple of unit tests
* Update docstrings
* Misc. typo fix in `gwdetchar-conlog`

cc @duncanmmacleod 