### PR TITLE
Disable matplotlib logging from gwdetchar.cli

### DIFF
--- a/bin/gwdetchar-scattering
+++ b/bin/gwdetchar-scattering
@@ -22,7 +22,6 @@
 
 from __future__ import division
 
-import logging
 import os.path
 import re
 import random
@@ -32,8 +31,8 @@ from six.moves import StringIO
 
 import numpy
 
-import matplotlib
-matplotlib.use('agg')  # noqa
+from matplotlib import (use, rcParams)
+use('agg')  # noqa
 
 import gwtrigfind
 
@@ -55,7 +54,6 @@ __credits__ = 'Siddharth Soni <siddharth.soni@ligo.org>' \
               'Alex Urban <alexander.urban@ligo.org>'
 
 # TeX settings
-rcParams = matplotlib.rcParams
 tex_settings = get_gwpy_tex_settings()
 rcParams.update(tex_settings)
 rcParams.update({
@@ -68,9 +66,6 @@ rcParams.update({
     'image.cmap': 'viridis',
     'svg.fonttype': 'none',
 })
-
-# disable matplotlib logging
-logging.getLogger("matplotlib").setLevel(logging.CRITICAL)
 
 # -- parse command line -------------------------------------------------------
 

--- a/gwdetchar/cli.py
+++ b/gwdetchar/cli.py
@@ -59,6 +59,9 @@ TIMEZONE = reference.LocalTimezone().tzname(NOW)
 DATEFMT = '%Y-%m-%d %H:%M:%S {}'.format(TIMEZONE)
 FMT = '%(name)s %(asctime)s %(levelname)+8s: %(message)s'
 
+# disable matplotlib logging
+logging.getLogger("matplotlib").setLevel(logging.CRITICAL)
+
 
 # -- logging and parsing utilities --------------------------------------------
 


### PR DESCRIPTION
This PR disables `matplotlib` logging from `gwdetchar.cli`, where the `gwdetchar` logger utility is initialized.

cc @duncanmmacleod 