### PR TITLE
HTML table constructors from downstream

### DIFF
--- a/gwdetchar/io/html.py
+++ b/gwdetchar/io/html.py
@@ -209,8 +209,8 @@ def new_bootstrap_page(base=os.path.curdir, lang='en', refresh=False,
         default: None
     """
     # get kwargs with sensible defaults
-    css = kwargs.get('css', CSS_FILES)
-    script = kwargs.get('script', JS_FILES)
+    css = CSS_FILES.extend(kwargs.get('css', []))
+    script = JS_FILES.extend(kwargs.get('script', []))
     # write CSS to static dir
     css, script = finalize_static_urls(
         os.path.join(os.path.curdir, 'static'),

--- a/gwdetchar/io/html.py
+++ b/gwdetchar/io/html.py
@@ -209,8 +209,8 @@ def new_bootstrap_page(base=os.path.curdir, lang='en', refresh=False,
         default: None
     """
     # get kwargs with sensible defaults
-    css = CSS_FILES.extend(kwargs.get('css', []))
-    script = JS_FILES.extend(kwargs.get('script', []))
+    css = CSS_FILES + kwargs.get('css', [])
+    script = JS_FILES + kwargs.get('script', [])
     # write CSS to static dir
     css, script = finalize_static_urls(
         os.path.join(os.path.curdir, 'static'),

--- a/gwdetchar/io/html.py
+++ b/gwdetchar/io/html.py
@@ -209,8 +209,8 @@ def new_bootstrap_page(base=os.path.curdir, lang='en', refresh=False,
         default: None
     """
     # get kwargs with sensible defaults
-    css = CSS_FILES + kwargs.get('css', [])
-    script = JS_FILES + kwargs.get('script', [])
+    css = kwargs.get('css', CSS_FILES)
+    script = kwargs.get('script', JS_FILES)
     # write CSS to static dir
     css, script = finalize_static_urls(
         os.path.join(os.path.curdir, 'static'),
@@ -527,7 +527,7 @@ def table(headers, data, caption=None, separator='', id=None, **class_):
 
     Returns
     -------
-    table : `markup.page`
+    table : `~MarkupPy.markup.page`
         a formatted HTML page object containing the `<table>`
     """
     class_.setdefault('table',
@@ -563,7 +563,7 @@ def table(headers, data, caption=None, separator='', id=None, **class_):
     page.tbody.close()
     page.table.close()
     # add export button
-    if id is not None:
+    if id:
         page.button(
             'Export to CSV', class_='btn btn-default btn-table',
             onclick="exportTableToCSV('{name}.csv', '{name}')".format(

--- a/gwdetchar/io/html.py
+++ b/gwdetchar/io/html.py
@@ -506,6 +506,71 @@ def write_arguments(content, start, end, flag=None, section='Parameters',
     return page()
 
 
+def table(headers, data, caption=None, separator='', id=None, **class_):
+    """Write a <table> with one row of headers and many rows of data
+
+    Parameters
+    ----------
+    headers : `list`
+        list of column header names
+
+    data : `list` of `lists`
+        list of column data lists, for ``m`` rows and ``n`` columns, this
+        should have dimensions ``m x n``
+
+    caption : `str`, optional
+        content for this table's `<caption>`
+
+    **class_
+        class attribute declarations for each tag used in the table,
+        any of `table`, `thead`, `tbody`, `tr`, `th`, `td`, `caption`
+
+    Returns
+    -------
+    table : `markup.page`
+        a formatted HTML page object containing the `<table>`
+    """
+    class_.setdefault('table',
+                      'table table-hover table-condensed table-responsive')
+    # unwrap class declarations (so we don't get empty class attributes)
+    kwargs = {}
+    for tag in ['table', 'thead', 'tbody', 'tr', 'th', 'td', 'caption']:
+        try:
+            kwargs[tag] = {'class_': class_.pop(tag)}
+        except KeyError:
+            kwargs[tag] = {}
+    # create table and add caption
+    page = markup.page(separator=separator)
+    if id is not None:
+        kwargs['table']['id_'] = id
+    page.table(**kwargs['table'])
+    if caption:
+        page.caption(caption, **kwargs['caption'])
+    # write headers
+    page.thead(**kwargs['thead'])
+    page.tr(**kwargs['tr'])
+    for th in headers:
+        page.th(th, scope='col', **kwargs['th'])
+    page.tr.close()
+    page.thead.close()
+    # write body
+    page.tbody(**kwargs['tbody'])
+    for row in data:
+        page.tr(**kwargs['tr'])
+        for td in row:
+            page.td(td, **kwargs['td'])
+        page.tr.close()
+    page.tbody.close()
+    page.table.close()
+    # add export button
+    if id is not None:
+        page.button(
+            'Export to CSV', class_='btn btn-default btn-table',
+            onclick="exportTableToCSV('{name}.csv', '{name}')".format(
+                name=id))
+    return page()
+
+
 def write_flag_html(flag, span=None, id=0, parent='accordion',
                     context='warning', title=None, plotdir=None,
                     plot_func=plot_segments, **kwargs):
@@ -704,6 +769,7 @@ def package_table(
         h2="Environment",
         class_="table table-hover table-condensed table-responsive",
         caption="Table of packages installed in the production environment",
+        id_="package-table",
 ):
     """Write a table listing packages installed in the current environment
 
@@ -726,27 +792,12 @@ def package_table(
         cols = ("name", "version", "channel", "build_string")
     else:  # pip list installed
         cols = ("name", "version")
-
     # create page and write <table>
     page = markup.page(separator="")
     if h2 is not None:
         page.h2(h2)
-    page.table(class_=class_)
-    if caption is not None:
-        page.caption(caption)
-    page.thead()
-    page.tr()
-    for head in cols:
-        page.th(head.title(), scope="col")
-    page.tr.close()
-    page.thead.close()
-    page.tbody()
-    for pkg in sorted(pkgs, key=itemgetter("name")):
-        page.tr()
-        for col in cols:
-            page.td(pkg[col.lower()])
-        page.tr.close()
-    page.tbody.close()
-    page.table.close()
-
+    headers = [head.title() for head in cols]
+    data = [[pkg[col.lower()] for col in cols]
+            for pkg in sorted(pkgs, key=itemgetter("name"))]
+    page.add(table(headers, data, caption=caption, id=id_, table=class_))
     return page()

--- a/gwdetchar/io/tests/test_html.py
+++ b/gwdetchar/io/tests/test_html.py
@@ -138,21 +138,6 @@ HTML_CLOSE = """</div>
 </body>
 </html>""" % HTML_FOOTER  # nopep8
 
-TABLE = """<table class="table table-hover table-condensed table-responsive" id="test">
-<caption>This is a test table.</caption>
-<thead>
-<tr>
-<th scope="col">Test</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>test</td>
-</tr>
-</tbody>
-</table>
-<button class="btn btn-default btn-table" onclick="exportTableToCSV(&quot;test.csv&quot;, &quot;test&quot;)">Export to CSV</button>"""  # nopep8
-
 FLAG_CONTENT = """<div class="panel panel-warning">
 <div class="panel-heading">
 <a class="panel-title" href="#flag0" data-toggle="collapse" data-parent="#accordion">X1:TEST_FLAG</a>
@@ -386,9 +371,14 @@ def test_table():
     headers = ['Test']
     data = [['test']]
     caption = 'This is a test table.'
-    page = html.table(headers=headers, data=data, caption=caption,
-                      separator='\n', id='test')
-    assert parse_html(page) == parse_html(TABLE)
+    page = html.table(headers=headers, data=data, caption=caption, id='test')
+    assert parse_html(page) == parse_html(
+        '<table class="table table-hover table-condensed table-responsive" '
+        'id="test"><caption>This is a test table.</caption><thead><tr>'
+        '<th scope="col">Test</th></tr></thead><tbody><tr><td>test</td></tr>'
+        '</tbody></table><button class="btn btn-default btn-table" '
+        'onclick="exportTableToCSV(&quot;test.csv&quot;, &quot;test&quot;)">'
+        'Export to CSV</button>')
 
 
 def test_write_flag_html():
@@ -466,7 +456,6 @@ def test_package_list(check_output, is_dir, isdir, cmd):
     ],
 )
 def test_package_table(package_list):
-    print(html.package_table(class_="test", caption="Test"))
     assert parse_html(
         html.package_table(class_="test", caption="Test"),
     ) == parse_html(

--- a/gwdetchar/io/tests/test_html.py
+++ b/gwdetchar/io/tests/test_html.py
@@ -88,7 +88,7 @@ ABOUT = """<div class="row">
 <span style="color: #7D9029">key</span> <span style="color: #666666">=</span> <span style="color: #BA2121">value</span>
 </pre></div>
 
-<h2>Environment</h2><table class="table table-hover table-condensed table-responsive"><caption>Table of packages installed in the production environment</caption><thead><tr><th scope="col">Name</th><th scope="col">Version</th></tr></thead><tbody><tr><td>gwdetchar</td><td>1.2.3</td></tr><tr><td>gwpy</td><td>1.0.0</td></tr></tbody></table>
+<h2>Environment</h2><table class="table table-hover table-condensed table-responsive" id="package-table"><caption>Table of packages installed in the production environment</caption><thead><tr><th scope="col">Name</th><th scope="col">Version</th></tr></thead><tbody><tr><td>gwdetchar</td><td>1.2.3</td></tr><tr><td>gwpy</td><td>1.0.0</td></tr></tbody></table><button class="btn btn-default btn-table" onclick="exportTableToCSV(&quot;package-table.csv&quot;, &quot;package-table&quot;)">Export to CSV</button>
 </div>
 </div>"""  # nopep8
 
@@ -118,7 +118,7 @@ ABOUT_WITH_CONFIG_LIST = """<div class="row">
 </div>
 </div>
 </div>
-<h2>Environment</h2><table class="table table-hover table-condensed table-responsive"><caption>Table of packages installed in the production environment</caption><thead><tr><th scope="col">Name</th><th scope="col">Version</th></tr></thead><tbody><tr><td>gwdetchar</td><td>1.2.3</td></tr><tr><td>gwpy</td><td>1.0.0</td></tr></tbody></table>
+<h2>Environment</h2><table class="table table-hover table-condensed table-responsive" id="package-table"><caption>Table of packages installed in the production environment</caption><thead><tr><th scope="col">Name</th><th scope="col">Version</th></tr></thead><tbody><tr><td>gwdetchar</td><td>1.2.3</td></tr><tr><td>gwpy</td><td>1.0.0</td></tr></tbody></table><button class="btn btn-default btn-table" onclick="exportTableToCSV(&quot;package-table.csv&quot;, &quot;package-table&quot;)">Export to CSV</button>
 </div>
 </div>"""  # nopep8
 

--- a/gwdetchar/io/tests/test_html.py
+++ b/gwdetchar/io/tests/test_html.py
@@ -138,6 +138,21 @@ HTML_CLOSE = """</div>
 </body>
 </html>""" % HTML_FOOTER  # nopep8
 
+TABLE = """<table class="table table-hover table-condensed table-responsive" id="test">
+<caption>This is a test table.</caption>
+<thead>
+<tr>
+<th scope="col">Test</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>test</td>
+</tr>
+</tbody>
+</table>
+<button class="btn btn-default btn-table" onclick="exportTableToCSV(&quot;test.csv&quot;, &quot;test&quot;)">Export to CSV</button>"""  # nopep8
+
 FLAG_CONTENT = """<div class="panel panel-warning">
 <div class="panel-heading">
 <a class="panel-title" href="#flag0" data-toggle="collapse" data-parent="#accordion">X1:TEST_FLAG</a>
@@ -367,6 +382,15 @@ def test_write_arguments():
     assert '<strong>Command line: </strong>' in page
 
 
+def test_table():
+    headers = ['Test']
+    data = [['test']]
+    caption = 'This is a test table.'
+    page = html.table(headers=headers, data=data, caption=caption,
+                      separator='\n', id='test')
+    assert parse_html(page) == parse_html(TABLE)
+
+
 def test_write_flag_html():
     page = html.write_flag_html(FLAG)
     assert parse_html(str(page)) == parse_html(FLAG_HTML)
@@ -442,14 +466,19 @@ def test_package_list(check_output, is_dir, isdir, cmd):
     ],
 )
 def test_package_table(package_list):
+    print(html.package_table(class_="test", caption="Test"))
     assert parse_html(
         html.package_table(class_="test", caption="Test"),
     ) == parse_html(
-        "<h2>Environment</h2><table class=\"test\"><caption>Test</caption>"
+        "<h2>Environment</h2><table class=\"test\" id=\"package-table\">"
+        "<caption>Test</caption>"
         "<thead>"
         "<tr><th scope=\"col\">Name</th><th scope=\"col\">Version</th></tr>"
         "</thead><tbody>"
         "<tr><td>gwdetchar</td><td>1.2.3</td></tr>"
         "<tr><td>gwpy</td><td>1.0.0</td></tr>"
-        "</tbody></table>",
+        "</tbody></table>"
+        "<button class=\"btn btn-default btn-table\" "
+        "onclick=\"exportTableToCSV(&quot;package-table.csv&quot;, "
+        "&quot;package-table&quot;)\">Export to CSV</button>",
     )

--- a/gwdetchar/omega/html.py
+++ b/gwdetchar/omega/html.py
@@ -531,16 +531,9 @@ def write_ranking(toc, primary, thresh=6.5,
     tlink = markup.oneliner.a(primary, href='plots/primary.png', **aparams)
     page.p('Below are the top 5 channels ranked by matched-filter correlation '
            'within 100 ms of %s.' % tlink)
-    page.table(class_=tableclass)
-    page.thead()
-    page.tr()
-    for column in entries.keys():
-        page.th(column, scope='col')
-    page.tr.close()
-    page.thead.close()
-    page.tbody()
     # range over channels
     k = 0
+    data = []
     for i in ind_sorted:
         if k > 5:
             break
@@ -553,24 +546,24 @@ def write_ranking(toc, primary, thresh=6.5,
             'style': "font-family: Monaco, \"Courier New\", monospace; "
                      "color: black;",
         }
-        page.tr()
-        page.td(markup.oneliner.a(entries['Channel'][i], **params))
-        page.td(str(entries['GPS Time'][i]))
-        page.td('%.1f Hz' % entries['Frequency'][i])
-        page.td(str(entries['Q'][i]))
-        page.td(str(entries['Energy'][i]))
-        page.td(str(entries['SNR'][i]))
+        row = [
+            markup.oneliner.a(entries['Channel'][i], **params),
+            str(entries['GPS Time'][i]),
+            '%.1f Hz' % entries['Frequency'][i],
+            str(entries['Q'][i]),
+            str(entries['Energy'][i]),
+            str(entries['SNR'][i]),
+        ]
         if entries['Channel'][i] == primary:
-            page.td('&mdash;')
-            page.td('&mdash;')
+            row.extend(['&mdash;', '&mdash;'])
         else:
-            page.td(str(entries['Correlation'][i]))
-            page.td('%s ms' % entries['Delay'][i])
-        page.tr.close()
+            row.extend([str(entries['Correlation'][i]),
+                        '%s ms' % entries['Delay'][i]])
         # increment counter
+        data.append(row)
         k += 1
-    page.tbody.close()
-    page.table.close()
+    page.add(htmlio.table(
+        headers=entries.keys(), data=data, separator='\n', table=tableclass))
     page.div.close()  # col-md-12
     page.div.close()  # row
     return page()
@@ -637,30 +630,18 @@ def write_block(blockkey, block, context,
 
         # summary table
         page.div(class_='col-md-7')
-        page.table(class_=tableclass)
         try:
             columns = ['GPS Time', 'Frequency', 'Q', 'Energy', 'SNR',
                        'Correlation', 'Delay']
-            entries = [str(channel.t), '%s Hz' % channel.f, str(channel.Q),
-                       str(channel.energy), str(channel.snr),
-                       str(channel.corr), '%s ms' % channel.delay]
+            entries = [[str(channel.t), '%s Hz' % channel.f, str(channel.Q),
+                        str(channel.energy), str(channel.snr),
+                        str(channel.corr), '%s ms' % channel.delay]]
         except:
             columns = ['GPS Time', 'Frequency', 'Q', 'Energy', 'SNR']
-            entries = [str(channel.t), '%s Hz' % channel.f, str(channel.Q),
-                       str(channel.energy), str(channel.snr)]
-        page.thead()
-        page.tr()
-        for column in columns:
-            page.th(column, scope='col')
-        page.tr.close()
-        page.thead.close()
-        page.tbody()
-        page.tr()
-        for entry in entries:
-            page.td(entry)
-        page.tr.close()
-        page.tbody.close()
-        page.table.close()
+            entries = [[str(channel.t), '%s Hz' % channel.f, str(channel.Q),
+                        str(channel.energy), str(channel.snr)]]
+        page.add(
+            htmlio.table(columns, entries, separator='\n', table=tableclass))
         page.div.close()  # col-sm-7
 
         # plot toggle buttons

--- a/share/js/gwdetchar.js
+++ b/share/js/gwdetchar.js
@@ -17,6 +17,7 @@
  * along with GWDetChar.  If not, see <http://www.gnu.org/licenses/>
  */
 
+// expand fancybox plots
 $(document).ready(function() {
   $(".fancybox").fancybox({
     nextEffect: 'none',
@@ -25,6 +26,7 @@ $(document).ready(function() {
   });
 });
 
+// expose alternative image types
 function showImage(channelName, tRanges, imageType, captions) {
   for (var tIndex in tRanges) {
     var idBase = channelName + "_" + tRanges[tIndex];
@@ -37,3 +39,34 @@ function showImage(channelName, tRanges, imageType, captions) {
     document.getElementById("img_" + idBase).alt = fileBase + ".png";
   };
 };
+
+// download a CSV table
+function downloadCSV(csv, filename) {
+  var csvFile;
+  var downloadLink;
+  // set download attributes
+  csvFile = new Blob([csv], {type: "text/csv"});
+  downloadLink = document.createElement("a");
+  downloadLink.download = filename;
+  downloadLink.href = window.URL.createObjectURL(csvFile);
+  downloadLink.style.display = "none";
+  document.body.appendChild(downloadLink);
+  // download action
+  downloadLink.click();
+}
+
+// export a table to CSV
+function exportTableToCSV(filename, tableId) {
+  var csv = [];
+  var table = document.getElementById(tableId);
+  var rows = table.querySelectorAll("table tr");
+  // get table rows
+  for (var i = 0; i < rows.length; i++) {
+    var row = [], cols = rows[i].querySelectorAll("td, th");
+    for (var j = 0; j < cols.length; j++) 
+        row.push(cols[j].innerText);
+    csv.push(row.join(","));        
+  }
+  // download CSV record
+  downloadCSV(csv.join("\n"), filename);
+}

--- a/share/js/gwdetchar.js
+++ b/share/js/gwdetchar.js
@@ -63,9 +63,9 @@ function exportTableToCSV(filename, tableId) {
   // get table rows
   for (var i = 0; i < rows.length; i++) {
     var row = [], cols = rows[i].querySelectorAll("td, th");
-    for (var j = 0; j < cols.length; j++) 
+    for (var j = 0; j < cols.length; j++)
         row.push(cols[j].innerText);
-    csv.push(row.join(","));        
+    csv.push(row.join(","));
   }
   // download CSV record
   downloadCSV(csv.join("\n"), filename);

--- a/share/sass/gwdetchar.scss
+++ b/share/sass/gwdetchar.scss
@@ -87,6 +87,11 @@ a {
 		}
 }
 
+.btn-table {
+		margin-top: -15px;
+		margin-bottom: 15px;
+}
+
 .desktop-only {
 		@media(max-width:991px) {
 				display:none;


### PR DESCRIPTION
This PR brings in a few HTML table constructors from downstream:

* Move `gwsumm.html.table` into `gwdetchar.io.html`
* Move some `gwsumm` JavaScript and CSS lines into `gwdetchar/share/`

A few related things are changed within `gwdetchar`:

* Use `gwdetchar.io.html.table` to construct tables, with an "Export to CSV" button for the list of packages
* PEP-8 compliance fixes for `gwdetchar.io.html`

This is related to #288.

cc @duncanmmacleod 