### PR TITLE
Enhanced 'About' page HTML constructor

### DIFF
--- a/gwdetchar/io/html.py
+++ b/gwdetchar/io/html.py
@@ -292,7 +292,7 @@ def about_this_page(config, packagelist=True):
             page.a.close()
             page.div(id_='file%d' % i, class_='panel-collapse collapse')
             page.div(class_='panel-body')
-            with open(cpfile, 'r') as fobj:                                           
+            with open(cpfile, 'r') as fobj:
                 contents = fobj.read()
             page.add(render_code(contents, 'ini'))
             page.div.close()
@@ -565,8 +565,8 @@ def scaffold_omega_scans(times, channel, plot_durations=[1, 4, 16],
         page.div(class_='row')
         page.div(class_='pull-right')
         page.a("[full scan]",
-           href='{}/{}'.format(scandir, t),
-           class_='text-dark')
+               href='{}/{}'.format(scandir, t),
+               class_='text-dark')
         page.div.close()  # pull-right
         page.h4(t)
         page.div.close()  # row
@@ -620,7 +620,7 @@ def write_footer(about=None, link=None, issues=None, content=None):
     if issues is None:
         report = 'https://github.com/gwdetchar/gwdetchar/issues'
         issues = markup.oneliner.a('Report an issue', href=report,
-                                  target='_blank')
+                                   target='_blank')
     page.div(class_='row')
     page.div(class_='col-md-12')
     now = datetime.datetime.now()

--- a/gwdetchar/io/html.py
+++ b/gwdetchar/io/html.py
@@ -247,6 +247,66 @@ def new_bootstrap_page(base=os.path.curdir, lang='en', refresh=False,
     return page
 
 
+def about_this_page(config, packagelist=True):
+    """Write a blurb documenting how a page was generated, including the
+    command-line arguments and configuration files used
+
+    Parameters
+    ----------
+    config : `str`, `list`, optional
+        the absolute path(s) to one or a number of INI files used in this
+        process
+
+    packagelist : `bool`, optional
+        boolean switch to include (`True`) or exclude (`False`) a
+        comprehensive list of system packages
+
+    Returns
+    -------
+    page : :class:`~MarkupPy.markup.page`
+        the HTML page to be inserted into the #main <div>.
+    """
+    page = markup.page()
+    page.div(class_='row')
+    page.div(class_='col-md-12')
+    page.h2('On the command-line')
+    page.p('This page was generated with the following command-line call:')
+    page.add(get_command_line())
+    # render config file(s)
+    page.h2('Configuration files')
+    page.p('The following INI-format configuration file(s) were passed '
+           'on the comand-line and are reproduced in full:')
+    if isinstance(config, str):
+        with open(config, 'r') as fobj:
+            contents = fobj.read()
+        page.add(htmlio.render_code(contents, 'ini'))
+    elif isinstance(config, list):
+        page.div(class_='panel-group', id="accordion")
+        for i, cpfile in enumerate(config):
+            page.div(class_='panel panel-default')
+            page.a(href='#file%d' % i, **{'data-toggle': 'collapse',
+                                          'data-parent': '#accordion'})
+            page.div(class_='panel-heading')
+            page.h4(os.path.basename(cpfile), class_='panel-title')
+            page.div.close()
+            page.a.close()
+            page.div(id_='file%d' % i, class_='panel-collapse collapse')
+            page.div(class_='panel-body')
+            with open(cpfile, 'r') as fobj:                                           
+                contents = fobj.read()
+            page.add(render_code(contents, 'ini'))
+            page.div.close()
+            page.div.close()
+            page.div.close()
+        page.div.close()
+    # render package list
+    if packagelist:
+        page.add(package_table())
+    page.div.close()
+    page.div.close()
+    return page()
+
+
 def write_param(param, value):
     """Format a parameter value with HTML
     """

--- a/gwdetchar/io/html.py
+++ b/gwdetchar/io/html.py
@@ -279,10 +279,15 @@ def get_command_line(language='bash'):
     Parameters
     ----------
     language : `str`, optional
-        language the code is written in, default: `'bash'`
+        type of environment the code is run in, default: `'bash'`
     """
-    commandline = ' '.join(sys.argv)
-    return render_code(commandline, language)
+    if sys.argv[0].endswith('__main__.py'):
+        package = sys.argv[0].rsplit(os.path.sep, 2)[1]
+        commandline = '$ python -m {0} {1}'.format(
+            package, ' '.join(sys.argv[1:]))
+    else:
+        commandline = '$ ' + ' '.join(sys.argv)
+    return render_code(commandline.replace(' --html-only', ''), language)
 
 
 def html_link(href, txt, target="_blank", **params):

--- a/gwdetchar/io/html.py
+++ b/gwdetchar/io/html.py
@@ -275,11 +275,11 @@ def about_this_page(config, packagelist=True):
     # render config file(s)
     page.h2('Configuration files')
     page.p('The following INI-format configuration file(s) were passed '
-           'on the comand-line and are reproduced in full:')
+           'on the comand-line and are reproduced here in full:')
     if isinstance(config, str):
         with open(config, 'r') as fobj:
             contents = fobj.read()
-        page.add(htmlio.render_code(contents, 'ini'))
+        page.add(render_code(contents, 'ini'))
     elif isinstance(config, list):
         page.div(class_='panel-group', id="accordion")
         for i, cpfile in enumerate(config):

--- a/gwdetchar/io/tests/test_html.py
+++ b/gwdetchar/io/tests/test_html.py
@@ -72,6 +72,56 @@ NEW_BOOTSTRAP_PAGE = """<!DOCTYPE HTML>
 </body>
 </html>"""  # nopep8
 
+TEST_CONFIGURATION = """[section]
+key = value"""
+
+ABOUT = """<div class="row">
+<div class="col-md-12">
+<h2>On the command-line</h2>
+<p>This page was generated with the following command-line call:</p>
+<div class="highlight" style="background: #f8f8f8"><pre style="line-height: 125%"><span></span>$ gwdetchar-scattering -i X1
+</pre></div>
+
+<h2>Configuration files</h2>
+<p>The following INI-format configuration file(s) were passed on the comand-line and are reproduced here in full:</p>
+<div class="highlight" style="background: #f8f8f8"><pre style="line-height: 125%"><span></span><span style="color: #008000; font-weight: bold">[section]</span>
+<span style="color: #7D9029">key</span> <span style="color: #666666">=</span> <span style="color: #BA2121">value</span>
+</pre></div>
+
+<h2>Environment</h2><table class="table table-hover table-condensed table-responsive"><caption>Table of packages installed in the production environment</caption><thead><tr><th scope="col">Name</th><th scope="col">Version</th></tr></thead><tbody><tr><td>gwdetchar</td><td>1.2.3</td></tr><tr><td>gwpy</td><td>1.0.0</td></tr></tbody></table>
+</div>
+</div>"""  # nopep8
+
+ABOUT_WITH_CONFIG_LIST = """<div class="row">
+<div class="col-md-12">
+<h2>On the command-line</h2>
+<p>This page was generated with the following command-line call:</p>
+<div class="highlight" style="background: #f8f8f8"><pre style="line-height: 125%"><span></span>$ gwdetchar-scattering -i X1
+</pre></div>
+
+<h2>Configuration files</h2>
+<p>The following INI-format configuration file(s) were passed on the comand-line and are reproduced here in full:</p>
+<div class="panel-group" id="accordion">
+<div class="panel panel-default">
+<a href="#file0" data-toggle="collapse" data-parent="#accordion">
+<div class="panel-heading">
+<h4 class="panel-title">test.ini</h4>
+</div>
+</a>
+<div id="file0" class="panel-collapse collapse">
+<div class="panel-body">
+<div class="highlight" style="background: #f8f8f8"><pre style="line-height: 125%"><span></span><span style="color: #008000; font-weight: bold">[section]</span>
+<span style="color: #7D9029">key</span> <span style="color: #666666">=</span> <span style="color: #BA2121">value</span>
+</pre></div>
+
+</div>
+</div>
+</div>
+</div>
+<h2>Environment</h2><table class="table table-hover table-condensed table-responsive"><caption>Table of packages installed in the production environment</caption><thead><tr><th scope="col">Name</th><th scope="col">Version</th></tr></thead><tbody><tr><td>gwdetchar</td><td>1.2.3</td></tr><tr><td>gwpy</td><td>1.0.0</td></tr></tbody></table>
+</div>
+</div>"""  # nopep8
+
 HTML_FOOTER = """<footer class="footer">
 <div class="container">
 <div class="row">
@@ -195,6 +245,30 @@ def test_new_bootstrap_page():
     page = html.new_bootstrap_page(base=base, refresh=True)
     assert parse_html(str(page)) == parse_html(
         NEW_BOOTSTRAP_PAGE.format(base=base))
+
+
+@mock.patch(
+    "gwdetchar.io.html.package_list",
+    return_value=[
+        {"name": "gwpy", "version": "1.0.0"},
+        {"name": "gwdetchar", "version": "1.2.3"},
+    ],
+)
+def test_about_this_page(package_list, tmpdir):
+    outdir = str(tmpdir)
+    config_file = os.path.join(outdir, 'test.ini')
+    with open(config_file, 'w') as fobj:
+        fobj.write(TEST_CONFIGURATION)
+    testargs = ['gwdetchar-scattering', '-i', 'X1']
+    with mock.patch.object(sys, 'argv', testargs):
+        # test with a single config file
+        about = html.about_this_page(config_file)
+        assert parse_html(about) == parse_html(ABOUT)
+        # test with a list of config files
+        about = html.about_this_page([config_file])
+        assert parse_html(about) == parse_html(ABOUT_WITH_CONFIG_LIST)
+    # clean up
+    shutil.rmtree(outdir, ignore_errors=True)
 
 
 def test_write_param():

--- a/gwdetchar/io/tests/test_html.py
+++ b/gwdetchar/io/tests/test_html.py
@@ -203,6 +203,25 @@ def test_write_param():
         '<p>\n<strong>test: </strong>\ntest\n</p>')
 
 
+def test_get_command_line():
+    testargs = ['gwdetchar-conlog', '-i', 'X1']
+    with mock.patch.object(sys, 'argv', testargs):
+        cmdline = html.get_command_line()
+        assert parse_html(cmdline) == parse_html(
+            '<div class="highlight" style="background: #f8f8f8">'
+            '<pre style="line-height: 125%"><span></span>'
+            '$ gwdetchar-conlog -i X1\n</pre></div>\n')
+
+def test_get_command_line_module():
+    testargs = ['gwdetchar/omega/__main__.py', '--html-only']
+    with mock.patch.object(sys, 'argv', testargs):
+        cmdline = html.get_command_line()
+        assert parse_html(cmdline) == parse_html(
+            '<div class="highlight" style="background: #f8f8f8">'
+            '<pre style="line-height: 125%"><span></span>'
+            '$ python -m omega\n</pre></div>\n')
+
+
 @pytest.mark.parametrize('args, kwargs, result', [
     (('test.html', 'Test link'), {},
      '<a href="test.html" target="_blank">Test link</a>'),

--- a/gwdetchar/omega/html.py
+++ b/gwdetchar/omega/html.py
@@ -799,18 +799,8 @@ def write_about_page(configfiles):
         the path of the HTML written for this analysis
     """
     # set up page
-    page = markup.page()
-    page.h2('On the command line')
-    page.p('This page was generated with the command line call shown below.')
-    page.add(htmlio.get_command_line())
-    page.h2('Configuration file')
-    page.p('Omega scans are configured with INI-format files. The '
-           'configuration files for this analysis are shown below in full.')
-    # range over config files
-    for configfile in configfiles:
-        with open(configfile, 'r') as fobj:
-            inifile = fobj.read()
-        page.add(htmlio.render_code(inifile, 'ini'))
-    # add environment listing
-    page.add(str(htmlio.package_table()))
+    if len(configfiles) == 1:
+        page = htmlio.about_this_page(configfiles[0])
+    else:
+        page = htmlio.about_this_page(configfiles)
     return page


### PR DESCRIPTION
This PR enhances construction of "About" pages, motivated by a wish to have gwsumm (and hveto) import it from gwdetchar. Changes include:

* Add a new function `gwdetchar.io.html.about_this_page`, including unit tests
* Use this function to construct omega scan 'About' pages
* Enhance the `get_command_line` utility and add unit tests
* Fix PEP-8 compliance issues in `gwdetchar.io.html`

This is relevant to #288.

cc @duncanmmacleod 