### PR TITLE
Command-line module for gwdetchar.scattering

### DIFF
--- a/bin/gwdetchar-scattering
+++ b/bin/gwdetchar-scattering
@@ -21,7 +21,8 @@
 
 This tool identifies time segments when evidence for scattering is strong,
 to compare projected fringes against spectrogram measurements for a specific
-time please use the command-line module: `python gwdetchar.scattering --help`
+time please use the command-line module:
+`python -m gwdetchar.scattering --help`
 """
 
 from __future__ import division

--- a/bin/gwdetchar-scattering
+++ b/bin/gwdetchar-scattering
@@ -18,6 +18,10 @@
 # along with GW DetChar.  If not, see <http://www.gnu.org/licenses/>.
 
 """Search for evidence of beam scattering based on optic velocity
+
+This tool identifies time segments when evidence for scattering is strong,
+to compare projected fringes against spectrogram measurements for a specific
+time please use the command-line module: `python gwdetchar.scattering --help`
 """
 
 from __future__ import division
@@ -233,7 +237,7 @@ page.h1('%s Scattering: %d-%d'
         % (args.ifo, int(args.gpsstart), int(args.gpsend)))
 page.p("This analysis searched for evidence of beam scattering between {} and "
        "{} Hz based on the velocity of optic motion. The fringe frequency is "
-       "predicted using equation (3) of <a href=\"http://iopscience.iop.org/"
+       "projected using equation (3) of <a href=\"http://iopscience.iop.org/"
        "article/10.1088/0264-9381/27/19/194011\" target=\"_blank\">Accadia "
        "et al. (2010)</a>.".format(args.fmin,
                                    multiplier * args.frequency_threshold))
@@ -569,7 +573,10 @@ if nscans > 0:
     # render HTML
     page.h2('Omega Scans')
     page.p('The following event times correspond to significant Omicron '
-           'triggers that occurr during the scattering segments found above:')
+           'triggers that occurr during the scattering segments found above. '
+           'To compare these against fringe frequency projections, please '
+           'use the scattering module:')
+    page.pre('$ python -m gwdetchar.scattering --help')
     page.add(htmlio.scaffold_omega_scans(
         omegatimes, args.main_channel, scandir=scandir))
 elif args.omega_scans:

--- a/ci/test-bin.sh
+++ b/ci/test-bin.sh
@@ -26,6 +26,14 @@ for EXE in bin/*; do
     fi
 done
 
+# test scattering module
+MODULE=gwdetchar.scattering
+echo "$ python -m ${MODULE} --help..."
+python -m coverage run --append --source=gwdetchar -m ${MODULE} --help;
+if [ "$?" -ne 0 ]; then                                                     
+    FAILED+=("${MODULE}")                                                  
+fi
+
 if [ ${#FAILED[@]} -ne 0 ]; then
     echo "---- The following scripts failed: ----"
     for failure in "${FAILED[@]}"; do

--- a/gwdetchar/scattering/__init__.py
+++ b/gwdetchar/scattering/__init__.py
@@ -16,7 +16,15 @@
 # You should have received a copy of the GNU General Public License
 # along with GW DetChar.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Tests for :mod:`gwdetchar.lasso`
+"""Methods and utilties for optical scattering
 """
 
 __author__ = 'Alex Urban <alexander.urban@ligo.org>'
+__credits__ = 'Duncan Macleod <duncan.macleod@ligo.org>' \
+              'Joshua Smith <joshua.smith@ligo.org>' \
+              'Andrew Lundgren <andrew.lundgren>@ligo.org>'
+
+# -- imports ------------------------------------------------------------------
+
+# import scattering utils
+from .core import *

--- a/gwdetchar/scattering/__main__.py
+++ b/gwdetchar/scattering/__main__.py
@@ -99,7 +99,7 @@ def main(args=None):
                         help='Output directory for analysis, '
                              'default: %(default)s')
     parser.add_argument('-c', '--colormap', default='viridis',
-                    help='name of colormap to use, default: %(default)s')
+                        help='name of colormap to use, default: %(default)s')
 
     # parse arguments
     args = parser.parse_args(args)
@@ -129,8 +129,8 @@ def main(args=None):
 
     # process channels
     channels = [':'.join([ifo, c]) for c in MOTION_CHANNELS]
-    data = get_data(                                                      
-        channels, start=gpsstart, end=gpsend, frametype=args.aux_frametype,  
+    data = get_data(
+        channels, start=gpsstart, end=gpsend, frametype=args.aux_frametype,
         verbose='Reading auxiliary sensors:'.rjust(30))
     count = 0  # running count of plots written
     for channel in channels:
@@ -155,7 +155,8 @@ def main(args=None):
         output = os.path.join(
             args.output_dir,
             '%s-%s-%s-{}.png' % (
-                channel.replace(':', '-'), gps, args.duration)
+                channel.replace('-', '_').replace(':', '-', 1),
+                gps, args.duration)
         )
         logger.debug('Plotting spectra and projected fringe frequencies')
         plot.spectral_comparison(

--- a/gwdetchar/scattering/__main__.py
+++ b/gwdetchar/scattering/__main__.py
@@ -1,0 +1,173 @@
+# coding=utf-8
+# Copyright (C) Alex Urban (2019)
+#
+# This file is part of the GW DetChar python package.
+#
+# GW DetChar is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GW DetChar is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GW DetChar.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Simple command-line interface to gwdetchar.scattering
+
+This module scans through records of optic motion and projects scattering
+fringe frequencies. For those channels with fringes above a user-specified
+threshold, a plot is created comparing the fringes to a high-resolution Q-scan
+spectrogram.
+
+To identify time segments where scattering is likely, please use the
+command-line script: `gwdetchar-scattering --help`
+"""
+
+import os
+import sys
+
+from matplotlib import use
+use('agg')  # noqa
+
+from gwpy.time import to_gps
+
+from .. import (cli, const)
+from ..omega import highpass
+from ..io.datafind import get_data
+
+from . import *
+from . import plot
+
+__author__ = 'Alex Urban <alexander.urban@ligo.org>'
+__credits__ = 'Joshua Smith <joshua.smith@ligo.org>' \
+              'Andrew Lundgren <andrew.lundgren>@ligo.org>' \
+              'Duncan Macleod <duncan.macleod@ligo.org>'
+
+# global variables
+
+ASD_KW = {
+    'method': 'median',
+    'fftlength': 8,
+    'overlap': 4,
+}
+
+MOTION_CHANNELS = [channel for key in OPTIC_MOTION_CHANNELS.keys()
+                   for channel in OPTIC_MOTION_CHANNELS[key]]
+
+logger = cli.logger('gwdetchar.scattering')
+
+
+# -- main function ------------------------------------------------------------
+
+def main(args=None):
+    """Parse command-line arguments, process optics, and write plots
+    """
+    # define command-line arguments
+    parser = cli.create_parser(description=__doc__)
+    parser.add_argument('gpstime', type=to_gps,
+                        help='GPS time or datestring to analyze')
+    cli.add_ifo_option(parser, ifo=const.IFO)
+    parser.add_argument('-d', '--duration', type=float, default=60,
+                        help='Duration (seconds) of analysis, default: 60')
+    parser.add_argument('-t', '--frequency-threshold', type=float, default=15,
+                        help='critical fringe frequency threshold (Hz), '
+                             'default: %(default)s')
+    parser.add_argument('-m', '--multipliers', default='1,2,4,8',
+                        help='harmonic numbers to plot projected motion for, '
+                             'should be given as a comma-separated list of '
+                             'numbers, default: %(default)s')
+    parser.add_argument('-x', '--multiplier-for-threshold', type=int,
+                        default=4,
+                        help='frequency multiplier to use when applying '
+                             '--frequency-threshold, default: %(default)s')
+    parser.add_argument('-w', '--primary-channel',
+                        default='GDS-CALIB_STRAIN',
+                        help='name of primary channel (without IFO prefix), '
+                             'default: %(default)s')
+    parser.add_argument('-W', '--primary-frametype', default='{IFO}_HOFT_C00',
+                        help='frametype from which to read primary channel, '
+                             'default: %(default)s')
+    parser.add_argument('-a', '--aux-frametype', default='{IFO}_R',
+                        help='frametype from which to read aux channels, '
+                             'default: %(default)s')
+    parser.add_argument('-o', '--output-dir', type=os.path.abspath,
+                        default=os.curdir,
+                        help='Output directory for analysis, '
+                             'default: %(default)s')
+    parser.add_argument('-c', '--colormap', default='viridis',
+                    help='name of colormap to use, default: %(default)s')
+
+    # parse arguments
+    args = parser.parse_args(args)
+    ifo = args.ifo
+    gps = float(args.gpstime)
+    gpsstart = gps - 0.5 * args.duration
+    gpsend = gps + 0.5 * args.duration
+    primary = ':'.join([ifo, args.primary_channel])
+    thresh = args.frequency_threshold
+    multipliers = [int(x) for x in args.multipliers.split(',')]
+    harmonic = args.multiplier_for_threshold
+    if '{IFO}' in args.primary_frametype:
+        args.primary_frametype = args.primary_frametype.format(IFO=ifo)
+    if '{IFO}' in args.aux_frametype:
+        args.aux_frametype = args.aux_frametype.format(IFO=ifo)
+    logger.info('{0} Scattering: {1}'.format(ifo, gps))
+
+    # set up spectrogram
+    logger.debug('Setting up a Q-scan spectrogram of {}'.format(primary))
+    hoft = get_data(primary, start=gps-34, end=gps+34,
+                    frametype=args.primary_frametype,
+                    verbose='Reading primary channel:'.rjust(30))
+    hoft = highpass(hoft, f_low=thresh).resample(256)
+    qspecgram = hoft.q_transform(qrange=(4, 150), frange=(0, 60), gps=gps,
+                                 fres=0.1, outseg=(gpsstart, gpsend), **ASD_KW)
+    qspecgram.name = primary
+
+    # process channels
+    channels = [':'.join([ifo, c]) for c in MOTION_CHANNELS]
+    data = get_data(                                                      
+        channels, start=gpsstart, end=gpsend, frametype=args.aux_frametype,  
+        verbose='Reading auxiliary sensors:'.rjust(30))
+    count = 0  # running count of plots written
+    for channel in channels:
+        logger.info(' -- Processing {} -- '.format(channel))
+        try:
+            motion = data[channel].detrend().resample(128)
+        except KeyError:
+            logger.warning('Skipping {}'.format(channel))
+            pass
+        # project scattering frequencies
+        fringe = get_fringe_frequency(motion, multiplier=1)
+        ind = fringe.argmax()
+        fmax = fringe.value[ind]
+        tmax = fringe.times.value[ind]
+        logger.debug('Maximum scatter frequency {0:.2f} Hz at GPS second '
+                     '{1:.2f}'.format(fmax, tmax))
+        if harmonic * fmax < thresh:
+            logger.warning('No significant evidence of scattering '
+                           'found in {}'.format(channel))
+            continue
+        # plot spectrogram and fringe frequency
+        output = os.path.join(
+            args.output_dir,
+            '%s-%s-%s-{}.png' % (
+                channel.replace(':', '-'), gps, args.duration)
+        )
+        logger.debug('Plotting spectra and projected fringe frequencies')
+        plot.spectral_comparison(
+            gps, qspecgram, fringe, output.format('comparison'), thresh=thresh,
+            multipliers=multipliers, colormap=args.colormap)
+        plot.spectral_overlay(
+            gps, qspecgram, fringe, output.format('overlay'),
+            multipliers=multipliers)
+        logger.info(' -- Channel complete -- ')
+        count += 1  # increment counter
+    logger.info('{0:g} chanels plotted in {1}'.format(count, args.output_dir))
+
+
+if __name__ == "__main__":  # pragma: no-cover
+    sys.exit(main())

--- a/gwdetchar/scattering/core.py
+++ b/gwdetchar/scattering/core.py
@@ -87,9 +87,8 @@ def get_fringe_frequency(series, multiplier=2.0):
     scipy.signal.savgol_filter
         for an implementation of the Savitzky-Golay filter
     """
-    velocity = type(series)(numpy.zeros(series.size))
+    velocity = type(series)(savgol_filter(series.value, 5, 2, deriv=1))
     velocity.__array_finalize__(series)
-    velocity[:] = savgol_filter(series.value, 5, 2, deriv=1)
     fringef = numpy.abs(multiplier * 2. / 1.064 * velocity *
                         velocity.sample_rate.value)
     fringef.override_unit('Hz')

--- a/gwdetchar/scattering/core.py
+++ b/gwdetchar/scattering/core.py
@@ -21,6 +21,8 @@
 
 import numpy
 
+from scipy.signal import savgol_filter
+
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
 OPTIC_MOTION_CHANNELS = {
@@ -64,11 +66,30 @@ OPTIC_MOTION_CHANNELS = {
 FREQUENCY_MULTIPLIERS = range(1, 5)
 
 
-def get_fringe_frequency(timeseries, multiplier=2.0):
-    """Calculate the scattering fringe frequency from a optic motion timeseries
+def get_fringe_frequency(series, multiplier=2.0):
+    """Predict scattering fringe frequency from the derivative of a timeseries
+
+    Parameters
+    ----------
+    series : `~gwpy.timeseries.TimeSeries`
+        timeseries record of relative motion
+
+    multiplier : `float`
+        harmonic number of fringe frequency
+
+    Returns
+    -------
+    fringef : `~gwpy.timeseries.TimeSeries`
+        timeseries record of fringe frequency
+
+    See Also
+    --------
+    scipy.signal.savgol_filter
+        for an implementation of the Savitzky-Golay filter
     """
-    velocity = timeseries.diff()
-    velocity.override_unit('m/s')  # just so multiplication works
+    velocity = type(series)(numpy.zeros(series.size))
+    velocity.__array_finalize__(series)
+    velocity[:] = savgol_filter(series.value, 5, 2, deriv=1)
     fringef = numpy.abs(multiplier * 2. / 1.064 * velocity *
                         velocity.sample_rate.value)
     fringef.override_unit('Hz')

--- a/gwdetchar/scattering/plot.py
+++ b/gwdetchar/scattering/plot.py
@@ -1,0 +1,151 @@
+# coding=utf-8
+# Copyright (C) Alex Urban (2018-)
+#
+# This file is part of the GW DetChar python package.
+#
+# GW DetChar is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GW DetChar is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GW DetChar.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Plotting routines for scattering checks
+"""
+
+from gwpy.plot import Plot
+
+__author__ = 'Alex Urban <alexander.urban@ligo.org>'
+__credits__ = 'Joshua Smith <joshua.smith@ligo.org>' \
+              'Andrew Lundgren <andrew.lundgren>@ligo.org>'
+
+
+# -- custom plotting tools ----------------------------------------------------
+
+def _format_timeseries(ax, gps, fringe, multipliers=(1, 2, 4, 8),
+                       linewidth=1, thresh=None):
+    """Helper tool to format a `~gwpy.timeseries.TimeSeries plot axis
+    """
+    t1 = fringe.t0.value
+    t2 = (fringe.t0 + fringe.duration).value
+    if thresh is not None:
+        ax.plot([t1, t2], [thresh, thresh], 'k--')
+    for m in sorted(multipliers, reverse=True):
+        ax.plot(m * fringe, label=r'$f\times %d$' % m, linewidth=linewidth)
+    # format time axis
+    ax.set_xlim([t1, t2])
+    ax.set_xscale('seconds', epoch=gps)
+    ax.grid(True, axis='x', which='major')
+    ax.legend(loc='upper right')
+
+
+def _format_spectrogram(ax, qspecgram, colormap='viridis'):
+    """Helper tool to format a `~gwpy.spectrogram.Spectrogram` plot axis
+    """
+    ax.imshow(qspecgram)
+    ax.colorbar(cmap=colormap, norm='linear', clim=(0, 25),
+                 label='Normalized energy')
+    # format frequency axis
+    ax.set_yscale('linear')
+    ax.set_ylabel('Frequency [Hz]')
+    ax.grid(True, axis='y', which='both')
+
+
+def spectral_comparison(gps, qspecgram, fringe, output, thresh=15,
+                        multipliers=(1, 2, 4, 8), colormap='viridis',
+                        figsize=[12, 8]):
+    """Compare a high-resolution spectrogram with projected fringe frequencies
+
+    Parameters
+    ----------
+    gps : `float`
+        reference GPS time (in seconds) to serve as the origin
+
+    qspecgram : `~gwpy.spectrogram.Spectrogram`
+        an interpolated high-resolution spectrogram
+
+    fringe : `~gwpy.timeseries.TimeSeries`
+        projected fringe frequencies (in Hz)
+
+    output : `str`
+        name of the output file
+
+    thresh : `float`, optional
+        frequency threshold (Hz) for scattering fringes, default: 15
+
+    multipliers : `tuple`, optional
+        collection of fringe harmonic numbers to plot, can be given in
+        any order, default: `(1, 2, 4, 8)`
+
+    colormap : `str`, optional
+        matplotlib colormap to use, default: viridis
+
+    figsize : `tuple`, optional
+        size (width x height) of the final figure, default: `(12, 8)`
+    """
+    plot = Plot(figsize=figsize)
+    # format spectral plot
+    ax1 = plot.add_subplot(211)
+    ax1.set_title('{0} at {1:.2f} with $Q$ of {2:.1f}'.format(
+        qspecgram.name, gps, qspecgram.q))
+    _format_spectrogram(ax1, qspecgram, colormap=colormap)
+    ax1.set_xlabel(None)
+    # format fringe frequency plot
+    ax2 = plot.add_subplot(212, sharex=ax1)
+    ax2.set_title('{} scattering fringes'.format(fringe.name))
+    _format_timeseries(ax2, gps, fringe, multipliers=multipliers,
+                       thresh=thresh)
+    # format timeseries axes
+    ax2.set_ylim([-1, 60])
+    ax2.set_ylabel('Projected Frequency [Hz]')
+    # save plot and close
+    plot.savefig(output, bbox_inches='tight')
+    plot.close()
+
+
+def spectral_overlay(gps, qspecgram, fringe, output,
+                     multipliers=(1, 2, 4, 8), figsize=[12, 4]):
+    """Overlay scattering fringe projections on top of a high-resolution
+    spectrogram
+
+    Parameters
+    ----------
+    gps : `float`
+        reference GPS time (in seconds) to serve as the origin
+
+    qspecgram : `~gwpy.spectrogram.Spectrogram`
+        an interpolated high-resolution spectrogram
+
+    fringe : `~gwpy.timeseries.TimeSeries`
+        projected fringe frequencies (in Hz)
+
+    output : `str`
+        name of the output file
+
+    multipliers : `tuple`, optional
+        collection of fringe harmonic numbers to plot, can be given in
+        any order, default: `(1, 2, 4, 8)`
+
+    figsize : `tuple`, optional
+        size (width x height) of the final figure, default: `(12, 4)`
+    """
+    plot = Plot(figsize=figsize)
+    ax = plot.gca()
+    # format spectrogram plot
+    ax.set_title('Fringes: {0}, Spectrogram: {1}'.format(
+        fringe.name, qspecgram.name))
+    _format_spectrogram(ax, qspecgram, colormap='binary')
+    # overlay fringe frequencies
+    _format_timeseries(ax, gps, fringe, multipliers=multipliers,               
+                       linewidth=1.5)
+    ax.set_ylim([qspecgram.f0.to('Hz').value,
+                 qspecgram.frequencies.max().to('Hz').value])
+    # save plot and close
+    plot.savefig(output, bbox_inches='tight')
+    plot.close()

--- a/gwdetchar/scattering/plot.py
+++ b/gwdetchar/scattering/plot.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright (C) Alex Urban (2018-)
+# Copyright (C) Alex Urban (2018-2019)
 #
 # This file is part of the GW DetChar python package.
 #
@@ -30,7 +30,7 @@ __credits__ = 'Joshua Smith <joshua.smith@ligo.org>' \
 
 def _format_timeseries(ax, gps, fringe, multipliers=(1, 2, 4, 8),
                        linewidth=1, thresh=None):
-    """Helper tool to format a `~gwpy.timeseries.TimeSeries plot axis
+    """Helper tool to format a `~gwpy.timeseries.TimeSeries` plot axis
     """
     t1 = fringe.t0.value
     t2 = (fringe.t0 + fringe.duration).value

--- a/gwdetchar/scattering/tests/__init__.py
+++ b/gwdetchar/scattering/tests/__init__.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with GW DetChar.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Tests for :mod:`gwdetchar.lasso`
+"""Tests for :mod:`gwdetchar.scattering`
 """
 
 __author__ = 'Alex Urban <alexander.urban@ligo.org>'

--- a/gwdetchar/scattering/tests/test_core.py
+++ b/gwdetchar/scattering/tests/test_core.py
@@ -24,7 +24,7 @@ from numpy import testing as nptest
 
 from gwpy.timeseries import TimeSeries
 
-from .. import scattering
+from .. import core
 
 __author__ = 'Alex Urban <alexander.urban@ligo.org>'
 
@@ -40,9 +40,9 @@ OPTIC = TimeSeries(numpy.cos(TWOPI*10*TIMES), sample_rate=2048)
 
 def test_get_fringe_frequency():
     # calculate the fringe frequency
-    fringef = scattering.get_fringe_frequency(OPTIC, multiplier=1)
+    fringef = core.get_fringe_frequency(OPTIC, multiplier=1)
     assert str(fringef.unit) == 'Hz'
     assert fringef.sample_rate.value == OPTIC.sample_rate.value
-    assert fringef.size == OPTIC.size - 1
+    assert fringef.size == OPTIC.size
     nptest.assert_almost_equal(
         fringef.value.max() * (1.064 / 2) / TWOPI, 10, decimal=2)

--- a/gwdetchar/scattering/tests/test_plot.py
+++ b/gwdetchar/scattering/tests/test_plot.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Alex Urban (2019)
+#
+# This file is part of the GW DetChar python package.
+#
+# GW DetChar is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GW DetChar is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with gwdetchar.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests for `gwdetchar.scattering.plot`
+"""
+
+import os
+import numpy
+import shutil
+
+from gwpy.timeseries import TimeSeries
+
+from matplotlib import use
+use('agg')
+
+from .. import plot
+
+__author__ = 'Alex Urban <alexander.urban@ligo.org>'
+
+
+# global test objects
+
+TWOPI = 2 * numpy.pi
+TIMES = numpy.arange(0, 16384 * 64)
+NOISE = TimeSeries(
+    numpy.random.normal(loc=1, scale=.5, size=16384 * 64),
+    sample_rate=16384, epoch=-32).zpk([], [0], 1)
+FRINGE = TimeSeries(
+    numpy.cos(TWOPI * TIMES), sample_rate=16384, epoch=-32)
+DATA = NOISE.inject(FRINGE)
+QSPECGRAM = DATA.q_transform(logf=True)
+
+
+# -- make sure plots run end-to-end -------------------------------------------
+
+def test_spectral_comparison(tmpdir):
+    outdir = str(tmpdir)
+    plot1 = os.path.join(outdir, 'test1.png')
+    plot2 = os.path.join(outdir, 'test2.png')
+    # test plotting
+    plot.spectral_comparison(0, QSPECGRAM, FRINGE, plot1)
+    plot.spectral_overlay(0, QSPECGRAM, FRINGE, plot2)
+    # clean up
+    shutil.rmtree(outdir, ignore_errors=True)

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,3 +27,5 @@ omit =
 	gwdetchar/io/tests/*
 	gwdetchar/lasso/tests/*
 	gwdetchar/omega/tests/*
+	gwdetchar/scattering/tests/*
+	gwdetchar/scattering/__main__.py


### PR DESCRIPTION
This PR implements a command-line module for scattering investigations, which can be invoked via

```bash
$ python -m gwdetchar.scattering [OPTIONS] GPSTIME
```

Changes include:
* Move `gwdetchar.scattering` into a proper sub-module with its own `__init__.py`
* Add a module `gwdetchar/scattering/__main__.py`, which projects scattering fringe frequencies of all the default optic motion channels
* For those whose projected fringes are above a given threshold, produce plots comparing these to a Q-scan of _h(t)_
* Include unit tests for the above
* Add help text  pointing to the new module from `gwdetchar-scattering` output
* Typo fix to `gwdetchar.lasso.tests`

This fixes #296.

cc @duncanmmacleod, @jrsmith02, @andrew-lundgren 