### PR TITLE
Datafind protection for running scripts on laptops

### DIFF
--- a/gwdetchar/io/datafind.py
+++ b/gwdetchar/io/datafind.py
@@ -22,6 +22,7 @@
 import re
 import warnings
 from six.moves.urllib.error import HTTPError
+from json.decoder import JSONDecodeError
 
 import gwdatafind
 
@@ -195,7 +196,7 @@ def get_data(channel, start, end, frametype=None, source=None,
         except AttributeError:
             raise AttributeError(
                 'Could not determine observatory from frametype')
-        except HTTPError:  # frame files not found
+        except (HTTPError, JSONDecodeError):  # frame files not found
             pass
     if isinstance(source, list) and isinstance(channel, (list, tuple)):
         channel = remove_missing_channels(channel, source)

--- a/gwdetchar/io/datafind.py
+++ b/gwdetchar/io/datafind.py
@@ -22,7 +22,11 @@
 import re
 import warnings
 from six.moves.urllib.error import HTTPError
-from json.decoder import JSONDecodeError
+
+try:  # python >= 3
+    from json.decoder import JSONDecodeError
+except ImportError:  # python == 2.7
+    JSONDecodeError = ValueError
 
 import gwdatafind
 


### PR DESCRIPTION
This PR adds a JSON exception to the logic of `gwdetchar.io.datafind.get_data`, which is needed to be able to run `gwdetchar` scripts on a laptop.

cc @duncanmmacleod 