### PR TITLE
Use codecov to estimate coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,12 @@
+coverage:
+  precision: 2
+  range: 50..100
+  round: nearest
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1
+    patch:
+      default:
+        target: 90

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,9 +42,9 @@ script:
   - acorn --silent gwdetchar/_static/gwdetchar.min.js
 
 after_success:
-  - python -m pip install ${PIP_FLAGS} coveralls
+  - python -m pip install ${PIP_FLAGS} codecov
   - python -m coverage report
-  - coveralls
+  - python -m codecov --flags $(uname) python${TRAVIS_PYTHON_VERSION/./}
 
 cache:
   pip: true

--- a/README.rst
+++ b/README.rst
@@ -49,5 +49,5 @@ proposing additions/changes.
    :target: https://pypi.org/project/gwdetchar/
 .. |Build Status| image:: https://travis-ci.org/gwdetchar/gwdetchar.svg?branch=master
    :target: https://travis-ci.org/gwdetchar/gwdetchar
-.. |Coverage Status| image:: https://coveralls.io/repos/github/gwdetchar/gwdetchar/badge.svg?branch=master
-   :target: https://coveralls.io/github/gwdetchar/gwdetchar?branch=master
+.. |Coverage Status| image:: https://codecov.io/gh/gwdetchar/gwdetchar/branch/master/graph/badge.svg
+   :target: https://codecov.io/gh/gwdetchar/gwdetchar


### PR DESCRIPTION
This PR updates the continuous integration build tests to use `codecov` for coverage estimates, since it's got more useful features than `coveralls`.

cc @duncanmmacleod 