### PR TITLE
Scaffold lasso plots to conserve space on the page

### DIFF
--- a/bin/gwdetchar-lasso-correlation
+++ b/bin/gwdetchar-lasso-correlation
@@ -741,9 +741,10 @@ for i, (ch, lassocoef, plot4, plot5, plot6, ts) in enumerate(results):
         page.p('Lasso coefficient below the threshold of %g.'
                % (args.threshold))
     else:
-        for p in (plot4, plot5, plot6):
-            pimg = htmlio.FancyPlot(p)
-            page.add(htmlio.fancybox_img(pimg))
+        plot4 = htmlio.FancyPlot(plot4)
+        plot5 = htmlio.FancyPlot(plot5)
+        plot6 = htmlio.FancyPlot(plot6)
+        page.add(htmlio.scaffold_plots([plot4, plot5, plot6]))
         if args.no_cluster is False:
             if clusters[i][0] is None:
                 page.p("<font size = '3'><br />No channels were highly"


### PR DESCRIPTION
This PR scaffolds the first three plots under panels in 'Top Channels', so that they all appear in one row and take up less space on the page.

cc @duncanmmacleod, @uberpye, @macedo22, @jrsmith02 