### PR TITLE
HTML navigation bars

### DIFF
--- a/bin/gwdetchar-lasso-correlation
+++ b/bin/gwdetchar-lasso-correlation
@@ -619,7 +619,10 @@ def style_table(html_table):
 
 # write html
 title = '%s Lasso Slow Correlations: %d-%d' % (args.ifo, start, end)
-page = htmlio.new_bootstrap_page(title=title)
+links = [(s, '#%s' % s.lower()) for s in ['Parameters', 'Model', 'Results']]
+(brand, class_) = htmlio.get_brand(args.ifo, 'Lasso', start)
+navbar = htmlio.navbar(links, class_=class_, brand=brand)
+page = htmlio.new_bootstrap_page(title=title, navbar=navbar)
 
 page.div(class_='page-header')
 page.h1(title)
@@ -644,7 +647,7 @@ if args.band_pass:
          'Flow = {} Hz, Fhigh = {} Hz '.format(flower, fupper)))
 page.add(htmlio.write_arguments(content, start=start, end=end))
 
-page.h2('Model Information')
+page.h2('Model Information', id_='model')
 
 page.div(class_='model')
 page.div(class_='model-body')
@@ -703,7 +706,7 @@ page.div.close()  # model-body
 page.div.close()  # model
 
 # results
-page.h2('Top Channels')
+page.h2('Top Channels', id_='results')
 
 page.div(class_='panel-group', id_='results')
 

--- a/bin/gwdetchar-overflow
+++ b/bin/gwdetchar-overflow
@@ -240,9 +240,15 @@ if args.html:
         args.output_file = os.path.relpath(
             args.output_file, os.path.dirname(args.html))
     if os.path.basename(args.html) == 'index.html':
+        links = [(s, '#%s' % s.lower())
+                 for s in ['Parameters', 'Segments', 'Results']]
+        (brand, class_) = htmlio.get_brand(args.ifo, 'Overflows',
+                                           args.gpsstart)
+        navbar = htmlio.navbar(links, class_=class_, brand=brand)
         page = htmlio.new_bootstrap_page(
             title='%s Overflows: %d-%d' % (
-                args.ifo, int(args.gpsstart), int(args.gpsend)))
+                args.ifo, int(args.gpsstart), int(args.gpsend)),
+            navbar=navbar)
     else:
         page = htmlio.markup.page()
         page.div(class_='container')
@@ -276,7 +282,7 @@ if args.html:
         content, start=args.gpsstart, end=args.gpsend, flag=args.state_flag))
 
     # -- segments
-    page.h2('Segments')
+    page.h2('Segments', id_='segments')
     # link XML file
     if args.output_file:
         page.p()
@@ -322,7 +328,7 @@ if args.html:
         page.div.close()
 
     # -- results table
-    page.h2('Results summary')
+    page.h2('Results summary', id_='results')
     page.table(class_='table table-striped table-hover')
     # write table header
     page.thead()

--- a/bin/gwdetchar-scattering
+++ b/bin/gwdetchar-scattering
@@ -232,7 +232,14 @@ logger.debug("%d read" % len(trigs))
 
 # -- prepare HTML -------------------------------------------------------------
 
-page = htmlio.new_bootstrap_page(title='%s Scattering' % args.ifo)
+links = [(s, '#%s' % s.lower()) for s in ['Parameters', 'Segments']]
+if args.omega_scans:
+    links.append(('Omega Scans', '#omega-scans'))
+(brand, class_) = htmlio.get_brand(args.ifo, 'Scattering', args.gpsstart)
+navbar = htmlio.navbar(links, class_=class_, brand=brand)
+page = htmlio.new_bootstrap_page(
+    title='%s Scattering' % args.ifo,
+    navbar=navbar)
 page.div(class_='page-header')
 page.h1('%s Scattering: %d-%d'
         % (args.ifo, int(args.gpsstart), int(args.gpsend)))
@@ -247,7 +254,7 @@ page.add(htmlio.write_arguments(
     [], start=int(args.gpsstart), end=int(args.gpsend), flag=args.state_flag))
 
 # link segments file
-page.h2('Segments')
+page.h2('Segments', id_='segments')
 page.p()
 page.add('Full output segments are recorded in HDF5 format here:')
 page.a(os.path.basename(segfile), href=segfile, target='_blank')
@@ -584,7 +591,7 @@ if nscans > 0:
                                 outdir=scandir, condor_commands=condorcmds)
     logger.info('Launched {} omega scans to condor'.format(nscans))
     # render HTML
-    page.h2('Omega Scans')
+    page.h2('Omega Scans', id_='omega-scans')
     page.p('The following event times correspond to significant Omicron '
            'triggers that occur during the scattering segments found above. '
            'To compare these against fringe frequency projections, please '

--- a/bin/gwdetchar-slow-correlation
+++ b/bin/gwdetchar-slow-correlation
@@ -361,7 +361,10 @@ with open('results.txt', 'w') as f:
 
 # -- write html
 title = '%s Slow Correlations: %d-%d' % (args.ifo, start, end)
-page = htmlio.new_bootstrap_page(title=title)
+links = [(s, '#%s' % s.lower()) for s in ['Parameters', 'Results']]
+(brand, class_) = htmlio.get_brand(args.ifo, 'Slow Correlations', start)
+navbar = htmlio.navbar(links, class_=class_, brand=brand)
+page = htmlio.new_bootstrap_page(title=title, navbar=navbar)
 
 # header
 if flower:
@@ -387,7 +390,7 @@ contents = [
 page.add(htmlio.write_arguments(content, start=start, end=end))
 
 # results
-page.h2('Results')
+page.h2('Results', id_='results')
 r_blrms = "<i>r<sub>blrms</sub> </i>"
 r_range = "<i>r<sub>range</sub> </i>"
 r = "<i>r</i>"

--- a/bin/gwdetchar-software-saturations
+++ b/bin/gwdetchar-software-saturations
@@ -204,7 +204,12 @@ if args.html:
         args.plot = os.path.dirname(args.html)
     segfile = os.path.relpath(outfile, os.path.dirname(args.html))
     if os.path.basename(args.html) == 'index.html':
-        page = htmlio.new_bootstrap_page()
+        links = [(s, '#%s' % s.lower())
+                 for s in ['Parameters', 'Segments', 'Results']]
+        (brand, class_) = htmlio.get_brand(ifo, 'Software Saturations',
+                                           args.gpsstart)
+        navbar = htmlio.navbar(links, class_=class_, brand=brand)
+        page = htmlio.new_bootstrap_page(navbar=navbar)
     else:
         page = markup.page()
         page.div(class_='container')
@@ -226,7 +231,7 @@ if args.html:
     page.add(htmlio.write_arguments(
         content, start=args.gpsstart, end=args.gpsend, flag=args.state_flag))
     # -- segments
-    page.h2('Segments')
+    page.h2('Segments', id_='segments')
     # link output file
     page.p()
     page.add('Full output segments are recorded in HDF5 format here:')
@@ -258,7 +263,7 @@ if args.html:
         page.p('No software saturations were found')
         page.div.close()
     # -- results table
-    page.h2('Results summary')
+    page.h2('Results summary', id_='results')
     page.table(class_='table table-striped table-hover')
     # write table header
     page.thead()

--- a/gwdetchar/io/html.py
+++ b/gwdetchar/io/html.py
@@ -49,7 +49,7 @@ from pygments import highlight
 from pygments.lexers import get_lexer_by_name
 from pygments.formatters import HtmlFormatter
 
-from gwpy.time import (from_gps, tconvert)
+from gwpy.time import from_gps
 
 from ..plot import plot_segments
 from .._version import get_versions
@@ -541,7 +541,7 @@ def get_brand(ifo, name, gps, about=None):
     page.li('External', class_='dropdown-header')
     for name, url in OBSERVATORY_MAP[ifo]['links'].items():
         if 'Summary' in name:
-            day = str(tconvert(gps).date()).replace('-', '')
+            day = from_gps(gps).strftime(r"%Y%m%d")
             url = '/'.join([url, day])
         page.li()
         page.a(name, href=url, target='_blank')

--- a/gwdetchar/io/html.py
+++ b/gwdetchar/io/html.py
@@ -27,6 +27,7 @@ import subprocess
 from pytz import reference
 from getpass import getuser
 from operator import itemgetter
+from collections import OrderedDict
 from shutil import copyfile
 try:
     from pathlib2 import Path
@@ -35,6 +36,7 @@ except ImportError:  # python >= 3.6
     #       but doesn't work very well
     from pathlib import Path
 
+from six import string_types
 from six.moves import StringIO
 from six.moves.urllib.parse import urlparse
 
@@ -47,7 +49,7 @@ from pygments import highlight
 from pygments.lexers import get_lexer_by_name
 from pygments.formatters import HtmlFormatter
 
-from gwpy.time import from_gps
+from gwpy.time import (from_gps, tconvert)
 
 from ..plot import plot_segments
 from .._version import get_versions
@@ -55,7 +57,77 @@ from .._version import get_versions
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 __credit__ = 'Alex Urban <alexander.urban@ligo.org>'
 
-# -- HTML URLs ----------------------------------------------------------------
+# -- navigation toggle
+
+NAVBAR_TOGGLE = """<button class="navbar-toggle" data-toggle="collapse" type="button" data-target=".navbar-collapse">
+<span class="icon-bar"></span>
+<span class="icon-bar"></span>
+<span class="icon-bar"></span>
+</button>"""  # noqa: E501
+
+# -- give context for ifo names
+
+OBSERVATORY_MAP = {
+    'G1': {
+        'name': 'GEO',
+        'context': 'default',
+        'links': OrderedDict([
+            ('Network Summary Pages', 'https://ldas-jobs.ligo.caltech.edu/'
+                                      '~detchar/summary/day')])
+    },
+    'H1': {
+        'name': 'LIGO Hanford',
+        'context': 'danger',
+        'links': OrderedDict([
+            ('LHO Summary Pages', 'https://ldas-jobs.ligo-wa.caltech.edu/'
+                                  '~detchar/summary/day'),
+            ('LHO Logbook', 'https://alog.ligo-wa.caltech.edu/aLOG')])
+    },
+    'I1': {
+        'name': 'LIGO India',
+        'context': 'success',
+        'links': OrderedDict([
+            ('Network Summary Pages', 'https://ldas-jobs.ligo.caltech.edu/'
+                                      '~detchar/summary/day')])
+    },
+    'K1': {
+        'name': 'KAGRA',
+        'context': 'warning',
+        'links': OrderedDict([
+            ('Network Summary Pages', 'https://ldas-jobs.ligo.caltech.edu/'
+                                      '~detchar/summary/day'),
+            ('KAGRA Logbook', 'http://klog.icrr.u-tokyo.ac.jp/osl')])
+    },
+    'L1': {
+        'name': 'LIGO Livingston',
+        'context': 'info',
+        'links': OrderedDict([
+            ('LLO Summary Pages', 'https://ldas-jobs.ligo-la.caltech.edu/'
+                                  '~detchar/summary/day'),
+            ('LLO Logbook', 'https://alog.ligo-la.caltech.edu/aLOG')])
+    },
+    'V1': {
+        'name': 'Virgo',
+        'context': 'default',
+        'links': OrderedDict([
+            ('Network Summary Pages', 'https://ldas-jobs.ligo.caltech.edu/'
+                                      '~detchar/summary/day/'),
+            ('Virgo Logbook', 'https://logbook.virgo-gw.eu/virgo')])
+    },
+    'Network': {
+        'name': 'Multi-IFO',
+        'context': 'default',
+        'links': OrderedDict([
+            ('Network Summary Pages', 'https://ldas-jobs.ligo.caltech.edu/'
+                                      '~detchar/summary/day'),
+            ('LHO Logbook', 'https://alog.ligo-wa.caltech.edu/aLOG'),
+            ('LLO Logbook', 'https://alog.ligo-la.caltech.edu/aLOG'),
+            ('Virgo Logbook', 'https://logbook.virgo-gw.eu/virgo'),
+            ('KAGRA Logbook', 'http://klog.icrr.u-tokyo.ac.jp/osl')])
+    }
+}
+
+# -- HTML URLs
 
 JQUERY_JS = "https://code.jquery.com/jquery-1.12.3.min.js"
 
@@ -246,6 +318,238 @@ def new_bootstrap_page(base=os.path.curdir, lang='en', refresh=False,
         page.add(navbar)
     page.div(class_='container')
     return page
+
+
+def navbar(links, class_='navbar navbar-fixed-top', brand=None, collapse=True):
+    """Construct a navigation bar in bootstrap format
+
+    Parameters
+    ----------
+    links : `list`
+        list of either (text, URL) tuples or  :class:`~MarkupPy.markup.page`
+        objects. Tuples will be written in ``<a>`` tags while `pages` will
+        be copied directly. Both will be enclosed in a <li> element inside
+        the navbar
+
+    class_ : `str`, optional
+        navbar object class, default: `'navbar navbar-fixed-top'`
+
+    brand : `str` or `~MarkupPy.markup.page`, optional
+        branding for the navigation bar, default: None
+
+    collapse : `bool`, optional
+        whether to toggle all dropdown menus, default: True
+
+    Returns
+    -------
+    page : :class:`~MarkupPy.markup.page`
+        navbar HTML `page` object
+    """
+    # page setup
+    page = markup.page()
+    page.twotags.extend((
+        "footer",
+        "header",
+        "nav",
+    ))
+    markup.element('header', parent=page)(class_=class_)
+    page.div(class_="container")
+
+    # ---- non-collapable part (<div class="navbar-header">) ----
+
+    page.div(class_="navbar-header")
+    # add collapsed menu toggle
+    if collapse:
+        page.add(NAVBAR_TOGGLE)
+    # add branding (generic non-collapsed content)
+    if brand:
+        page.add(str(brand))
+    page.div.close()  # navbar-header
+    if collapse:
+        page.nav(class_="collapse navbar-collapse")
+    else:
+        page.nav()
+
+    # ---- collapsable part (<nav>) ----
+
+    if links:
+        page.ul(class_='nav navbar-nav')
+        for i, link in enumerate(links):
+            if (isinstance(link, (list, tuple)) and
+                    isinstance(link[1], string_types)):
+                page.li()
+                text, link = link
+                page.a(text, href=link)
+            elif (isinstance(link, (list, tuple)) and
+                  isinstance(link[1], (list, tuple))):
+                page.li(class_='dropdown')
+                page.add(dropdown(*link))
+            else:
+                page.li()
+                page.add(str(link))
+            page.li.close()
+        page.ul.close()
+
+    page.nav.close()
+    page.div.close()
+    markup.element('header', parent=page).close()
+    return page()
+
+
+def dropdown(text, links, active=None, class_='dropdown-toggle'):
+    """Construct a dropdown menu in bootstrap format
+
+    Parameters
+    ----------
+    text : `str`
+        dropdown menu header
+
+    links : `list`
+        list of (Link text, linkurl) tuples or dict of such tuples for
+        grouped dropdowns
+
+    active : `int` or `list` of `ints`, optional
+        collection of links to make active, default: None
+
+    class_ : `str`, optional
+        object class of the dropdown menu, default: `'dropdown-toggle'`
+
+    Returns
+    -------
+    page : :class:`~MarkupPy.markup.page`
+        HTML element with the following grammar::
+        .. code:: html
+            <a>text</a>
+            <ul>
+                <li>link</li>
+                <li>link</li>
+            </ul>
+    """
+    page = markup.page()
+    # dropdown header
+    page.a(href='#', class_=class_, **{'data-toggle': 'dropdown'})
+    page.add(text)
+    page.b('', class_='caret')
+    page.a.close()
+
+    # work out columns
+    ngroup = sum([isinstance(x, (tuple, list)) and len(x) and
+                 isinstance(x[1], (tuple, list)) for x in links])
+    if ngroup < 1:
+        column = ''
+    else:
+        ncol = min(ngroup, 4)
+        column = 'col-xs-12 col-sm-%d' % (12 // ncol)
+
+    # dropdown elements
+    if column:
+        page.ul(class_='dropdown-menu dropdown-%d-col row' % ncol)
+    else:
+        page.ul(class_='dropdown-menu')
+    for i, link in enumerate(links):
+        if isinstance(active, int) and i == active:
+            active_ = True
+        elif isinstance(active, (list, tuple)) and i == active[0]:
+            active_ = active[1]
+        else:
+            active_ = False
+        dropdown_link(page, link, active=active_, class_=column)
+    page.ul.close()
+    return page()
+
+
+def dropdown_link(page, link, active=False, class_=''):
+    """Format links within a dropdown menu
+
+    Parameters
+    ----------
+    page : `~MarkupPy.markup.page`
+        a `page` object to format in-place
+
+    link : `~MarkupPy.markup.page` or `list`
+        the link(s) to format
+
+    active : `bool`, optional
+        boolean switch to enable (`True`) or disable (`False`) an active link,
+        default: `False`
+
+    class_ : `str`, optional
+        object class of the link, default: `''`
+    """
+    if link is None:
+        page.li(class_='divider')
+    elif active is True:
+        page.li(class_='active')
+    else:
+        page.li()
+    if isinstance(link, (tuple, list)):
+        if isinstance(link[1], (tuple, list)):
+            page.ul(class_=class_ + ' list-unstyled')
+            page.li(link[0], class_='dropdown-header')
+            for j, link2 in enumerate(link[1]):
+                dropdown_link(page, link2,
+                              active=(type(active) is int and active == j))
+            page.ul.close()
+        else:
+            page.a(link[0], href=link[1])
+    elif link is not None:
+        page.add(str(link))
+    page.li.close()
+
+
+def get_brand(ifo, name, gps, about=None):
+    """Return a brand for navigation bar formatting
+
+    Parameters
+    ----------
+    ifo : `str`
+        interferometer prefix for color-coding, e.g. `'L1'`
+
+    name : `str`
+        name of the analysis, e.g. `'Scattering'`
+
+    gps : `float`
+        GPS second of the analysis
+
+    about : `str`, optional
+        relative path to the `about` page for this analysis, default: None
+
+    Returns
+    -------
+    brand : `~MarkupPy.markup.page`
+        the navbar brand `page` object
+
+    class_ : `str`
+        object class of the navbar
+    """
+    page = markup.page()
+    page.div(ifo, class_='navbar-brand')
+    page.div(name, class_='navbar-brand')
+    page.div(class_='btn-group pull-right ifo-links')
+    page.a(class_='navbar-brand dropdown-toggle', href='#',
+           **{'data-toggle': 'dropdown'})
+    page.add('Links')
+    page.b('', class_='caret')
+    page.a.close()
+    page.ul(class_='dropdown-menu')
+    if about is not None:
+        page.li('Internal', class_='dropdown-header')
+        page.li()
+        page.a('About this page', href=about)
+        page.li.close()
+        page.li('', class_='divider')
+    page.li('External', class_='dropdown-header')
+    for name, url in OBSERVATORY_MAP[ifo]['links'].items():
+        if 'Summary' in name:
+            day = str(tconvert(gps).date()).replace('-', '')
+            url = '/'.join([url, day])
+        page.li()
+        page.a(name, href=url, target='_blank')
+        page.li.close()
+    page.ul.close()
+    page.div.close()  # btn-group pull-right
+    class_ = 'navbar navbar-fixed-top navbar-{}'.format(ifo.lower())
+    return (page(), class_)
 
 
 def about_this_page(config, packagelist=True):
@@ -490,7 +794,8 @@ def scaffold_plots(plots, nperrow=3):
 
 
 def write_arguments(content, start, end, flag=None, section='Parameters',
-                    info='This analysis used the following parameters:'):
+                    info='This analysis used the following parameters:',
+                    id_='parameters'):
     """Render an informative section with run parameters in HTML
 
     Parameters
@@ -506,7 +811,7 @@ def write_arguments(content, start, end, flag=None, section='Parameters',
     if flag is not None:
         content.insert(2, ('State flag', flag))
     page = markup.page()
-    page.h2(section)
+    page.h2(section, id_=id_)
     page.p(info)
     for item in content:
         page.add(write_param(*item))

--- a/gwdetchar/io/tests/test_html.py
+++ b/gwdetchar/io/tests/test_html.py
@@ -26,6 +26,7 @@ import datetime
 import sys
 from pytz import reference
 from getpass import getuser
+from MarkupPy import markup
 try:
     from unittest import mock
 except ImportError:  # python < 3
@@ -250,6 +251,71 @@ def test_new_bootstrap_page():
         NEW_BOOTSTRAP_PAGE.format(base=base))
 
 
+def test_navbar():
+    navbar = html.navbar(['test'], collapse=False)
+    assert parse_html(navbar) == parse_html(
+        '<header class="navbar navbar-fixed-top">\n'
+        '<div class="container">\n<div class="navbar-header">\n'
+        '</div>\n<nav>\n<ul class="nav navbar-nav">\n<li>\ntest\n</li>\n'
+        '</ul>\n</nav>\n</div>\n</header>')
+
+
+def test_dropdown():
+    menu = html.dropdown('test', [])
+    assert parse_html(str(menu)) == parse_html(
+        '<a href="#" class="dropdown-toggle" data-toggle="dropdown">\n'
+        'test\n<b class="caret"></b>\n</a>\n<ul class="dropdown-menu">\n</ul>')
+
+    menu = html.dropdown('test', ['test', '#'], active=0)
+    assert parse_html(str(menu)) == parse_html(
+        '<a href="#" class="dropdown-toggle" data-toggle="dropdown">\n'
+        'test\n<b class="caret"></b>\n</a>\n<ul class="dropdown-menu">\n'
+        '<li class="active">\ntest\n</li>\n<li>\n#\n</li>\n</ul>')
+
+    menu = html.dropdown('test', ['test', '#'], active=[0, 1])
+    assert parse_html(str(menu)) == parse_html(
+        '<a href="#" class="dropdown-toggle" data-toggle="dropdown">\n'
+        'test\n<b class="caret"></b>\n</a>\n<ul class="dropdown-menu">\n'
+        '<li>\ntest\n</li>\n<li>\n#\n</li>\n</ul>')
+
+
+def test_dropdown_link():
+    page = markup.page()
+    html.dropdown_link(page, None)
+    assert parse_html(str(page)) == parse_html(
+        '<li class="divider">\n</li>')
+
+    page = markup.page()
+    html.dropdown_link(page, 'test', active=True)
+    assert parse_html(str(page)) == parse_html(
+        '<li class="active">\ntest\n</li>')
+
+    page = markup.page()
+    html.dropdown_link(page, 'test')
+    assert parse_html(str(page)) == parse_html(
+        '<li>\ntest\n</li>')
+
+
+def test_get_brand():
+    (brand, class_) = html.get_brand('H1', 'Test', 0, about='about')
+    assert class_ == 'navbar navbar-fixed-top navbar-h1'
+    assert parse_html(brand) == parse_html(
+        '<div class="navbar-brand">H1</div>\n'
+        '<div class="navbar-brand">Test</div>\n'
+        '<div class="btn-group pull-right ifo-links">\n'
+        '<a class="navbar-brand dropdown-toggle" href="#" '
+        'data-toggle="dropdown">\nLinks\n<b class="caret"></b>\n</a>\n'
+        '<ul class="dropdown-menu">\n'
+        '<li class="dropdown-header">Internal</li>\n'
+        '<li>\n<a href="about">About this page</a>\n</li>\n'
+        '<li class="divider"></li>\n'
+        '<li class="dropdown-header">External</li>\n'
+        '<li>\n<a href="https://ldas-jobs.ligo-wa.caltech.edu/~detchar/'
+        'summary/day/19800106" target="_blank">LHO Summary Pages</a>\n'
+        '</li>\n<li>\n<a href="https://alog.ligo-wa.caltech.edu/aLOG" '
+        'target="_blank">LHO Logbook</a>\n</li>\n</ul>\n</div>')
+
+
 @mock.patch(
     "gwdetchar.io.html.package_list",
     return_value=[
@@ -368,7 +434,7 @@ def test_scaffold_plots():
 
 def test_write_arguments():
     page = html.write_arguments([('test', 'test')], 0, 1, flag='X1:TEST')
-    assert '<h2>Parameters</h2>' in page
+    assert '<h2 id="parameters">Parameters</h2>' in page
     assert '<strong>Start time: </strong>\n0 (1980-01-06 00:00:00)' in page
     assert '<strong>End time: </strong>\n1 (1980-01-06 00:00:01)' in page
     assert '<strong>State flag: </strong>\nX1:TEST' in page

--- a/gwdetchar/omega/html.py
+++ b/gwdetchar/omega/html.py
@@ -38,76 +38,6 @@ from ..io import html as htmlio
 __author__ = 'Alex Urban <alexander.urban@ligo.org>'
 __credit__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
-# -- give context for ifo names
-
-OBSERVATORY_MAP = {
-    'G1': {
-        'name': 'GEO',
-        'context': 'default',
-        'links': OrderedDict([
-            ('Network Summary Pages', 'https://ldas-jobs.ligo.caltech.edu/'
-                                      '~detchar/summary/day/')
-        ])
-    },
-    'H1': {
-        'name': 'LIGO Hanford',
-        'context': 'danger',
-        'links': OrderedDict([
-            ('LHO Summary Pages', 'https://ldas-jobs.ligo-wa.caltech.edu/'
-                                  '~detchar/summary/day/'),
-            ('LHO Logbook', 'https://alog.ligo-wa.caltech.edu/aLOG/')
-        ])
-    },
-    'I1': {
-        'name': 'LIGO India',
-        'context': 'success',
-        'links': OrderedDict([
-            ('Network Summary Pages', 'https://ldas-jobs.ligo.caltech.edu/'
-                                      '~detchar/summary/day/')
-        ])
-    },
-    'K1': {
-        'name': 'KAGRA',
-        'context': 'warning',
-        'links': OrderedDict([
-            ('Network Summary Pages', 'https://ldas-jobs.ligo.caltech.edu/'
-                                      '~detchar/summary/day/'),
-            ('KAGRA Logbook', 'http://klog.icrr.u-tokyo.ac.jp/osl/')
-        ])
-    },
-    'L1': {
-        'name': 'LIGO Livingston',
-        'context': 'info',
-        'links': OrderedDict([
-            ('LLO Summary Pages', 'https://ldas-jobs.ligo-la.caltech.edu/'
-                                  '~detchar/summary/day/'),
-            ('LLO Logbook', 'https://alog.ligo-la.caltech.edu/aLOG/')
-        ])
-    },
-    'V1': {
-        'name': 'Virgo',
-        'context': 'default',
-        'links': OrderedDict([
-            ('Network Summary Pages', 'https://ldas-jobs.ligo.caltech.edu/'
-                                      '~detchar/summary/day/'),
-            ('Virgo Logbook', 'https://logbook.virgo-gw.eu/virgo/')
-        ])
-    },
-    'Network': {
-        'name': 'Multi-IFO',
-        'context': 'default',
-        'links': OrderedDict([
-            ('Network Summary Pages', 'https://ldas-jobs.ligo.caltech.edu/'
-                                      '~detchar/summary/day/'),
-            ('LHO Logbook', 'https://alog.ligo-wa.caltech.edu/aLOG/'),
-            ('LLO Logbook', 'https://alog.ligo-la.caltech.edu/aLOG/'),
-            ('Virgo Logbook', 'https://logbook.virgo-gw.eu/virgo/'),
-            ('KAGRA Logbook', 'http://klog.icrr.u-tokyo.ac.jp/osl/')
-        ])
-    }
-}
-
-
 # -- HTML construction --------------------------------------------------------
 
 def update_toc(toc, channel, name='GW'):
@@ -141,20 +71,6 @@ def update_toc(toc, channel, name='GW'):
 
 def navbar(ifo, gpstime, toc={}):
     """Initialise a new `markup.page`
-    This method constructs an HTML page with the following structure
-    .. code-block:: html
-        <html>
-        <head>
-            <!-- some stuff -->
-        </head>
-        <body>
-        <div class="container">
-        <div class="page-header">
-        <h1>IFO</h1>
-        <h3>GPSTIME</h3>
-        </div>
-        </div>
-        <div class="container">
 
     Parameters
     ----------
@@ -172,62 +88,16 @@ def navbar(ifo, gpstime, toc={}):
     page : `markup.page`
         the structured markup to open an HTML document
     """
-    page = markup.page()
-    # write banner
-    page.add('<header class="navbar navbar-fixed-top navbar-%s">'
-             % ifo.lower())
-    page.div(class_='container')
-    page.div(class_='navbar-header')
-    page.add('<button class="navbar-toggle" data-toggle="collapse" '
-             'type="button" data-target=".navbar-collapse">')
-    page.add('<span class="icon-bar"></span>')
-    page.add('<span class="icon-bar"></span>')
-    page.add('<span class="icon-bar"></span>')
-    page.add('</button>')
-    page.div(ifo, class_='navbar-brand')
-    page.div(gpstime, class_='navbar-brand')
-    page.div.close()  # navbar-header
-    page.add('<nav class="collapse navbar-collapse">')
-    page.ul(class_='nav navbar-nav')
-    page.li('<a href="#">Summary</a>')
+    (brand, class_) = htmlio.get_brand(ifo, 'Omega Scan',
+                                       gpstime, about='about')
+    # channel navigation
+    links = [['Summary', '#']]
     for key, block in toc.items():
-        page.li(class_='dropdown')
-        page.add('<a class="dropdown-toggle" data-toggle="dropdown">')
-        page.add('%s <b class="caret"></b>' % key)
-        page.add('</a>')
-        page.ul(class_='dropdown-menu', style='max-height: 700px; '
-                                              'overflow-y: scroll;')
-        page.li(block['name'], class_='dropdown-header')
-        for chan in block['channels']:
-            page.li()
-            chanid = chan.name.lower().replace(':', '-')
-            page.a(chan.name, href='#%s' % chanid)
-            page.li.close()
-        page.ul.close()
-        page.li.close()
-    page.li(class_='dropdown')
-    page.add('<a class="dropdown-toggle" data-toggle="dropdown">')
-    page.add('Links <b class="caret"></b>')
-    page.add('</a>')
-    page.ul(class_='dropdown-menu')
-    page.li('Internal', class_='dropdown-header')
-    page.li('<a href="about">About this scan</a>')
-    page.li('', class_='divider')
-    page.li('External', class_='dropdown-header')
-    for name, link in OBSERVATORY_MAP[ifo]['links'].items():
-        page.li()
-        if 'Summary' in name:
-            day = str(tconvert(gpstime).date()).replace('-', '')
-            link = '/'.join([link, day])
-        page.a(name, href=link, target='_blank')
-        page.li.close()
-    page.ul.close()
-    page.li.close()
-    page.ul.close()
-    page.add('</nav>')
-    page.div.close()  # container
-    page.add('</header>')  # navbar
-    return page()
+        channels = [[c.name, '#%s' % c.name.lower().replace(':', '-')]
+                    for c in block['channels']]
+        links.append([key, [[block['name'], channels]]])
+    # return navbar
+    return htmlio.navbar(links, brand=brand, class_=class_)
 
 
 def wrap_html(func):
@@ -278,11 +148,11 @@ def wrap_html(func):
         # (but only on the main results page)
         if about:
             page.add(write_summary(ifo, gpstime, incomplete=refresh,
-                     context=OBSERVATORY_MAP[ifo]['context']))
+                     context=htmlio.OBSERVATORY_MAP[ifo]['context']))
             write_summary_table(toc, correlated)
             if correlated:
                 page.add(write_ranking(toc, primary))
-            kwargs['context'] = OBSERVATORY_MAP[ifo]['context']
+            kwargs['context'] = htmlio.OBSERVATORY_MAP[ifo]['context']
         # write content
         page.div(id_='main')
         # insert inner html directly
@@ -420,7 +290,7 @@ def write_summary(
     page.tbody()
     page.tr()
     page.td("<b>Interferometer</b>", scope='row')
-    page.td("%s (%s)" % (OBSERVATORY_MAP[ifo]['name'], ifo))
+    page.td("%s (%s)" % (htmlio.OBSERVATORY_MAP[ifo]['name'], ifo))
     page.tr.close()
     page.tr()
     page.td("<b>UTC Time</b>", scope='row')

--- a/gwdetchar/omega/tests/test_html.py
+++ b/gwdetchar/omega/tests/test_html.py
@@ -40,7 +40,7 @@ __credits__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 VERSION = get_versions()['version']
 COMMIT = get_versions()['full-revisionid']
 
-HTML_HEADER = """<header class="navbar navbar-fixed-top navbar-l1">
+HTML_HEADER = """<header class="navbar navbar-fixed-top navbar-{ifo}">
 <div class="container">
 <div class="navbar-header">
 <button class="navbar-toggle" data-toggle="collapse" type="button" data-target=".navbar-collapse">
@@ -48,44 +48,54 @@ HTML_HEADER = """<header class="navbar navbar-fixed-top navbar-l1">
 <span class="icon-bar"></span>
 <span class="icon-bar"></span>
 </button>
-<div class="navbar-brand">{ifo}</div>
-<div class="navbar-brand">{gps}</div>
+<div class="navbar-brand">{IFO}</div>
+<div class="navbar-brand">Omega Scan</div>
+<div class="btn-group pull-right ifo-links">
+<a class="navbar-brand dropdown-toggle" href="#" data-toggle="dropdown">
+Links
+<b class="caret"></b>
+</a>
+<ul class="dropdown-menu">
+<li class="dropdown-header">Internal</li>
+<li>
+<a href="about">About this page</a>
+</li>
+<li class="divider"></li>
+<li class="dropdown-header">External</li>
+<li>
+<a href="https://ldas-jobs.ligo-la.caltech.edu/~detchar/summary/day/19800106" target="_blank">LLO Summary Pages</a>
+</li>
+<li>
+<a href="https://alog.ligo-la.caltech.edu/aLOG" target="_blank">LLO Logbook</a>
+</li>
+</ul>
+</div>
 </div>
 <nav class="collapse navbar-collapse">
 <ul class="nav navbar-nav">
-<li><a href="#">Summary</a></li>
+<li>
+<a href="#">Summary</a>
+</li>
 <li class="dropdown">
-<a class="dropdown-toggle" data-toggle="dropdown">
-GW <b class="caret"></b>
+<a href="#" class="dropdown-toggle" data-toggle="dropdown">
+GW
+<b class="caret"></b>
 </a>
-<ul class="dropdown-menu" style="max-height: 700px; overflow-y: scroll;">
+<ul class="dropdown-menu dropdown-1-col row">
+<li>
+<ul class="col-xs-12 col-sm-12 list-unstyled">
 <li class="dropdown-header">Gravitational-Wave Strain</li>
 <li>
 <a href="#x1-test-aux">X1:TEST-AUX</a>
 </li>
 </ul>
 </li>
-<li class="dropdown">
-<a class="dropdown-toggle" data-toggle="dropdown">
-Links <b class="caret"></b>
-</a>
-<ul class="dropdown-menu">
-<li class="dropdown-header">Internal</li>
-<li><a href="about">About this scan</a></li>
-<li class="divider"></li>
-<li class="dropdown-header">External</li>
-<li>
-<a href="https://ldas-jobs.ligo-la.caltech.edu/~detchar/summary/day//19800106" target="_blank">LLO Summary Pages</a>
-</li>
-<li>
-<a href="https://alog.ligo-la.caltech.edu/aLOG/" target="_blank">LLO Logbook</a>
-</li>
 </ul>
 </li>
 </ul>
 </nav>
 </div>
-</header>"""  # nopep8
+</header>"""  # noqa: E501
 
 CONFIGURATION = u"""
 [primary]
@@ -241,7 +251,7 @@ def test_update_toc():
 def test_navbar():
     page = html.navbar('L1', 0, toc=ANALYZED)
     assert parse_html(str(page)) == parse_html(HTML_HEADER.format(
-        ifo='L1', gps='0'))
+        ifo='l1', IFO='L1'))
 
 
 def test_toggle_link():

--- a/share/sass/gwdetchar.scss
+++ b/share/sass/gwdetchar.scss
@@ -17,27 +17,20 @@
  * along with GWDetChar.  If not, see <http://www.gnu.org/licenses/>
  */
 
-html {
-		position: relative;
-		min-height: 100%;
-}
-
 body {
-		margin-bottom: 166px;
-		min-height: 100%;
 		font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
 		font-weight: 300;
 }
 
 h1, h2, h3, h4, h5, h6 {
-		font-weight: normal;
+		font-weight: 300;
 }
 
 h4 {
 		word-break: break-all;
 }
 
-h4::before {
+h2::before, h3::before, h4::before, h5::before, h6::before {
 		display: block;
 		content: "";
 		margin-top: -70px;
@@ -48,6 +41,30 @@ h4::before {
 
 a {
 		cursor: pointer;
+}
+
+img {
+		margin: 0 auto;
+}
+
+.navbar {
+		.ifo-links  {
+				.dropdown-header {
+						padding-left: 20px;
+						padding-right: 20px;
+						white-space: normal;;
+				}
+				@media (min-width: 768px) {
+						position: absolute;
+						right: 0;
+				}
+		}
+}
+
+.dropdown-1-col {
+		white-space: nowrap;
+		max-height: 700px;
+		overflow-y: scroll;
 }
 
 .container {
@@ -62,14 +79,6 @@ a {
 		@media (min-width: 1200px) {
 				max-width: 1400px;
 		}
-}
-
-.with-margin {
-		margin-bottom: 15px;
-}
-
-.fancybox-skin {
-		background: white;
 }
 
 .btn {


### PR DESCRIPTION
This PR introduces a general-purpose bootstrap navbar constructor, originally designed for [`gwsumm`](https://github.com/gwpy/gwsumm/blob/master/gwsumm/html/bootstrap.py#L89-L157). The following changes are included:

* Introduce a few new functions, including `gwdetchar.io.html.navbar`
* Use this to give navbars to the output of every script, including omega scans
* Move dropdown menu style settings into CSS
* Include unit tests

Test output is available here (all require `LIGO.ORG` credentials):

Tool | Output | Notes
-- | -- | --
`gwdetchar-omega` | [**Link**](https://ldas-jobs.ligo-la.caltech.edu/~aurban/pyomega-test/Network_170817/) | Network scan of GW170817, just to check that the page looks similar
`gwdetchar-scattering` | [**Link**](https://ldas-jobs.ligo-la.caltech.edu/~aurban/scattering/day/20190413/) | L1 scattering on 2019-04-13, full L1 omega scans within
`gwdetchar-overflow` | [**Link**](https://ldas-jobs.ligo-la.caltech.edu/~aurban/overflows/day/20190413/) | L1 DAC overflows on 2019-04-13
`gwdetchar-software-saturations` | [**Link**](https://ldas-jobs.ligo-la.caltech.edu/~aurban/software-saturations/day/20190413/) | L1 software saturations on 2019-04-13
`gwdetchar-lasso-correlation` | [**Link**](https://ldas-jobs.ligo-la.caltech.edu/~aurban/lasso/full-results/day/20190413/) | L1 Lasso run from one of the lock stretches on 2019-04-13

This fixes #288.

cc @duncanmmacleod 