### PR TITLE
Handle all context in get_command_line

### DIFF
--- a/gwdetchar/io/html.py
+++ b/gwdetchar/io/html.py
@@ -350,15 +350,12 @@ def get_command_line(language='bash'):
     page.p('This page was generated with the following command-line call:')
     if sys.argv[0].endswith('__main__.py'):
         module = getmodule(stack()[1][0]).__name__
-        which = sys.argv[0]
         cmdline = '$ python -m {0} {1}'.format(module, ' '.join(sys.argv[1:]))
     else:
         script = os.path.basename(sys.argv[0])
-        which = '$ which {0}\n{1}'.format(script, sys.argv[0])
-        cmdline = '$ ' + script + ' ' + ' '.join(sys.argv[1:])
+        cmdline = ' '.join(['$', script, ' '.join(sys.argv[1:])])
     page.add(render_code(cmdline.replace(' --html-only', ''), language))
-    page.p('The following install path was used:')
-    page.add(render_code(which, language))
+    page.p('The install path used was <code>{}</code>.'.format(sys.prefix))
     return page()
 
 

--- a/gwdetchar/io/html.py
+++ b/gwdetchar/io/html.py
@@ -38,6 +38,7 @@ except ImportError:  # python >= 3.6
 from six.moves import StringIO
 from six.moves.urllib.parse import urlparse
 
+from inspect import (getmodule, stack)
 from pkg_resources import resource_filename
 
 from MarkupPy import markup
@@ -348,18 +349,16 @@ def get_command_line(language='bash'):
     page = markup.page()
     page.p('This page was generated with the following command-line call:')
     if sys.argv[0].endswith('__main__.py'):
-        package = sys.argv[0].rsplit(os.path.sep, 2)[1]
-        commandline = '$ python -m {0} {1}'.format(
-            package, ' '.join(sys.argv[1:]))
-        page.add(render_code(commandline, language))
+        module = getmodule(stack()[1][0]).__name__
+        which = sys.argv[0]
+        cmdline = '$ python -m {0} {1}'.format(module, ' '.join(sys.argv[1:]))
     else:
         script = os.path.basename(sys.argv[0])
         which = '$ which {0}\n{1}'.format(script, sys.argv[0])
-        commandline = '$ ' + script + ' ' + ' '.join(sys.argv[1:])
-        page.add(render_code(
-            commandline.replace(' --html-only', ''), language))
-        page.p('The following build path was used:')
-        page.add(render_code(which, language))
+        cmdline = '$ ' + script + ' ' + ' '.join(sys.argv[1:])
+    page.add(render_code(cmdline.replace(' --html-only', ''), language))
+    page.p('The following install path was used:')
+    page.add(render_code(which, language))
     return page()
 
 

--- a/gwdetchar/io/html.py
+++ b/gwdetchar/io/html.py
@@ -270,7 +270,6 @@ def about_this_page(config, packagelist=True):
     page.div(class_='row')
     page.div(class_='col-md-12')
     page.h2('On the command-line')
-    page.p('This page was generated with the following command-line call:')
     page.add(get_command_line())
     # render config file(s)
     page.h2('Configuration files')
@@ -340,18 +339,28 @@ def get_command_line(language='bash'):
     ----------
     language : `str`, optional
         type of environment the code is run in, default: `'bash'`
+
+    Returns
+    -------
+    page : `~MarkupPy.markup.page`
+        fully rendered command-line arguments
     """
+    page = markup.page()
+    page.p('This page was generated with the following command-line call:')
     if sys.argv[0].endswith('__main__.py'):
         package = sys.argv[0].rsplit(os.path.sep, 2)[1]
         commandline = '$ python -m {0} {1}'.format(
             package, ' '.join(sys.argv[1:]))
+        page.add(render_code(commandline, language))
     else:
         script = os.path.basename(sys.argv[0])
-        which = '$ which {}'.format(script)
-        commandline = '{0}\n{1}\n\n{2}'.format(
-            which, sys.argv[0],
-            '$ ' + script + ' ' + ' '.join(sys.argv[1:]))
-    return render_code(commandline.replace(' --html-only', ''), language)
+        which = '$ which {0}\n{1}'.format(script, sys.argv[0])
+        commandline = '$ ' + script + ' ' + ' '.join(sys.argv[1:])
+        page.add(render_code(
+            commandline.replace(' --html-only', ''), language))
+        page.p('The following build path was used:')
+        page.add(render_code(which, language))
+    return page()
 
 
 def html_link(href, txt, target="_blank", **params):
@@ -505,7 +514,7 @@ def write_arguments(content, start, end, flag=None, section='Parameters',
     page.p(info)
     for item in content:
         page.add(write_param(*item))
-    page.add(write_param('Command line', ''))
+    page.add(write_param('Command-line', ''))
     page.add(get_command_line())
     return page()
 

--- a/gwdetchar/io/tests/test_html.py
+++ b/gwdetchar/io/tests/test_html.py
@@ -79,10 +79,12 @@ ABOUT = """<div class="row">
 <div class="col-md-12">
 <h2>On the command-line</h2>
 <p>This page was generated with the following command-line call:</p>
+<div class="highlight" style="background: #f8f8f8"><pre style="line-height: 125%"><span></span>$ gwdetchar-scattering -i X1
+</pre></div>
+
+<p>The following build path was used:</p>
 <div class="highlight" style="background: #f8f8f8"><pre style="line-height: 125%"><span></span>$ which gwdetchar-scattering
 /opt/bin/gwdetchar-scattering
-
-$ gwdetchar-scattering -i X1
 </pre></div>
 
 <h2>Configuration files</h2>
@@ -99,10 +101,12 @@ ABOUT_WITH_CONFIG_LIST = """<div class="row">
 <div class="col-md-12">
 <h2>On the command-line</h2>
 <p>This page was generated with the following command-line call:</p>
+<div class="highlight" style="background: #f8f8f8"><pre style="line-height: 125%"><span></span>$ gwdetchar-scattering -i X1
+</pre></div>
+
+<p>The following build path was used:</p>
 <div class="highlight" style="background: #f8f8f8"><pre style="line-height: 125%"><span></span>$ which gwdetchar-scattering
 /opt/bin/gwdetchar-scattering
-
-$ gwdetchar-scattering -i X1
 </pre></div>
 
 <h2>Configuration files</h2>
@@ -288,10 +292,13 @@ def test_get_command_line():
     with mock.patch.object(sys, 'argv', testargs):
         cmdline = html.get_command_line()
         assert parse_html(cmdline) == parse_html(
-            '<div class="highlight" style="background: #f8f8f8">'
-            '<pre style="line-height: 125%"><span></span>'
-            '$ which gwdetchar-conlog\n/opt/bin/gwdetchar-conlog\n\n'
-            '$ gwdetchar-conlog -i X1\n</pre></div>\n')
+            '<p>This page was generated with the following command-line call:'
+            '</p>\n<div class="highlight" style="background: #f8f8f8">'
+            '<pre style="line-height: 125%"><span></span>$ gwdetchar-conlog '
+            '-i X1\n</pre></div>\n\n<p>The following build path was used:'
+            '</p>\n<div class="highlight" style="background: #f8f8f8">'
+            '<pre style="line-height: 125%"><span></span>$ which '
+            'gwdetchar-conlog\n/opt/bin/gwdetchar-conlog\n</pre></div>\n')
 
 
 def test_get_command_line_module():
@@ -299,9 +306,10 @@ def test_get_command_line_module():
     with mock.patch.object(sys, 'argv', testargs):
         cmdline = html.get_command_line()
         assert parse_html(cmdline) == parse_html(
-            '<div class="highlight" style="background: #f8f8f8">'
-            '<pre style="line-height: 125%"><span></span>'
-            '$ python -m omega\n</pre></div>\n')
+            '<p>This page was generated with the following command-line call:'
+            '</p>\n<div class="highlight" style="background: #f8f8f8">'
+            '<pre style="line-height: 125%"><span></span>$ python -m omega '
+            '--html-only\n</pre></div>\n')
 
 
 @pytest.mark.parametrize('args, kwargs, result', [
@@ -372,7 +380,7 @@ def test_write_arguments():
     assert '<strong>End time: </strong>\n1 (1980-01-06 00:00:01)' in page
     assert '<strong>State flag: </strong>\nX1:TEST' in page
     assert '<strong>test: </strong>\ntest' in page
-    assert '<strong>Command line: </strong>' in page
+    assert '<strong>Command-line: </strong>' in page
 
 
 def test_table():

--- a/gwdetchar/io/tests/test_html.py
+++ b/gwdetchar/io/tests/test_html.py
@@ -82,7 +82,7 @@ ABOUT = """<div class="row">
 <div class="highlight" style="background: #f8f8f8"><pre style="line-height: 125%"><span></span>$ gwdetchar-scattering -i X1
 </pre></div>
 
-<p>The following build path was used:</p>
+<p>The following install path was used:</p>
 <div class="highlight" style="background: #f8f8f8"><pre style="line-height: 125%"><span></span>$ which gwdetchar-scattering
 /opt/bin/gwdetchar-scattering
 </pre></div>
@@ -104,7 +104,7 @@ ABOUT_WITH_CONFIG_LIST = """<div class="row">
 <div class="highlight" style="background: #f8f8f8"><pre style="line-height: 125%"><span></span>$ gwdetchar-scattering -i X1
 </pre></div>
 
-<p>The following build path was used:</p>
+<p>The following install path was used:</p>
 <div class="highlight" style="background: #f8f8f8"><pre style="line-height: 125%"><span></span>$ which gwdetchar-scattering
 /opt/bin/gwdetchar-scattering
 </pre></div>
@@ -295,21 +295,25 @@ def test_get_command_line():
             '<p>This page was generated with the following command-line call:'
             '</p>\n<div class="highlight" style="background: #f8f8f8">'
             '<pre style="line-height: 125%"><span></span>$ gwdetchar-conlog '
-            '-i X1\n</pre></div>\n\n<p>The following build path was used:'
+            '-i X1\n</pre></div>\n\n<p>The following install path was used:'
             '</p>\n<div class="highlight" style="background: #f8f8f8">'
             '<pre style="line-height: 125%"><span></span>$ which '
             'gwdetchar-conlog\n/opt/bin/gwdetchar-conlog\n</pre></div>\n')
 
 
 def test_get_command_line_module():
-    testargs = ['gwdetchar/omega/__main__.py', '--html-only']
+    testargs = ['__main__.py', '--html-only']
     with mock.patch.object(sys, 'argv', testargs):
         cmdline = html.get_command_line()
         assert parse_html(cmdline) == parse_html(
             '<p>This page was generated with the following command-line call:'
             '</p>\n<div class="highlight" style="background: #f8f8f8">'
-            '<pre style="line-height: 125%"><span></span>$ python -m omega '
-            '--html-only\n</pre></div>\n')
+            '<pre style="line-height: 125%"><span></span>$ python -m '
+            'gwdetchar.io.tests.test_html\n</pre></div>\n\n'
+            '<p>The following install path was used:</p>\n'
+            '<div class="highlight" style="background: #f8f8f8">'
+            '<pre style="line-height: 125%"><span></span>__main__.py\n'
+            '</pre></div>\n')
 
 
 @pytest.mark.parametrize('args, kwargs, result', [

--- a/gwdetchar/io/tests/test_html.py
+++ b/gwdetchar/io/tests/test_html.py
@@ -20,6 +20,7 @@
 """
 
 import os
+import sys
 import shutil
 import datetime
 import sys
@@ -82,11 +83,7 @@ ABOUT = """<div class="row">
 <div class="highlight" style="background: #f8f8f8"><pre style="line-height: 125%"><span></span>$ gwdetchar-scattering -i X1
 </pre></div>
 
-<p>The following install path was used:</p>
-<div class="highlight" style="background: #f8f8f8"><pre style="line-height: 125%"><span></span>$ which gwdetchar-scattering
-/opt/bin/gwdetchar-scattering
-</pre></div>
-
+<p>The install path used was <code>{}</code>.</p>
 <h2>Configuration files</h2>
 <p>The following INI-format configuration file(s) were passed on the comand-line and are reproduced here in full:</p>
 <div class="highlight" style="background: #f8f8f8"><pre style="line-height: 125%"><span></span><span style="color: #008000; font-weight: bold">[section]</span>
@@ -95,7 +92,7 @@ ABOUT = """<div class="row">
 
 <h2>Environment</h2><table class="table table-hover table-condensed table-responsive" id="package-table"><caption>Table of packages installed in the production environment</caption><thead><tr><th scope="col">Name</th><th scope="col">Version</th></tr></thead><tbody><tr><td>gwdetchar</td><td>1.2.3</td></tr><tr><td>gwpy</td><td>1.0.0</td></tr></tbody></table><button class="btn btn-default btn-table" onclick="exportTableToCSV(&quot;package-table.csv&quot;, &quot;package-table&quot;)">Export to CSV</button>
 </div>
-</div>"""  # nopep8
+</div>""".format(sys.prefix)  # nopep8
 
 ABOUT_WITH_CONFIG_LIST = """<div class="row">
 <div class="col-md-12">
@@ -104,11 +101,7 @@ ABOUT_WITH_CONFIG_LIST = """<div class="row">
 <div class="highlight" style="background: #f8f8f8"><pre style="line-height: 125%"><span></span>$ gwdetchar-scattering -i X1
 </pre></div>
 
-<p>The following install path was used:</p>
-<div class="highlight" style="background: #f8f8f8"><pre style="line-height: 125%"><span></span>$ which gwdetchar-scattering
-/opt/bin/gwdetchar-scattering
-</pre></div>
-
+<p>The install path used was <code>{}</code>.</p>
 <h2>Configuration files</h2>
 <p>The following INI-format configuration file(s) were passed on the comand-line and are reproduced here in full:</p>
 <div class="panel-group" id="accordion">
@@ -130,7 +123,7 @@ ABOUT_WITH_CONFIG_LIST = """<div class="row">
 </div>
 <h2>Environment</h2><table class="table table-hover table-condensed table-responsive" id="package-table"><caption>Table of packages installed in the production environment</caption><thead><tr><th scope="col">Name</th><th scope="col">Version</th></tr></thead><tbody><tr><td>gwdetchar</td><td>1.2.3</td></tr><tr><td>gwpy</td><td>1.0.0</td></tr></tbody></table><button class="btn btn-default btn-table" onclick="exportTableToCSV(&quot;package-table.csv&quot;, &quot;package-table&quot;)">Export to CSV</button>
 </div>
-</div>"""  # nopep8
+</div>""".format(sys.prefix)  # nopep8
 
 HTML_FOOTER = """<footer class="footer">
 <div class="container">
@@ -295,10 +288,8 @@ def test_get_command_line():
             '<p>This page was generated with the following command-line call:'
             '</p>\n<div class="highlight" style="background: #f8f8f8">'
             '<pre style="line-height: 125%"><span></span>$ gwdetchar-conlog '
-            '-i X1\n</pre></div>\n\n<p>The following install path was used:'
-            '</p>\n<div class="highlight" style="background: #f8f8f8">'
-            '<pre style="line-height: 125%"><span></span>$ which '
-            'gwdetchar-conlog\n/opt/bin/gwdetchar-conlog\n</pre></div>\n')
+            '-i X1\n</pre></div>\n\n<p>The install path used was <code>{}'
+            '</code>.</p>'.format(sys.prefix))
 
 
 def test_get_command_line_module():
@@ -310,10 +301,8 @@ def test_get_command_line_module():
             '</p>\n<div class="highlight" style="background: #f8f8f8">'
             '<pre style="line-height: 125%"><span></span>$ python -m '
             'gwdetchar.io.tests.test_html\n</pre></div>\n\n'
-            '<p>The following install path was used:</p>\n'
-            '<div class="highlight" style="background: #f8f8f8">'
-            '<pre style="line-height: 125%"><span></span>__main__.py\n'
-            '</pre></div>\n')
+            '<p>The install path used was <code>{}</code>.</p>'.format(
+                sys.prefix))
 
 
 @pytest.mark.parametrize('args, kwargs, result', [


### PR DESCRIPTION
This PR re-organizes contextual paragraphs about command-line usage into the `get_command_line` utility. This makes it so that calling `gwdetchar.io.html.get_command_line()` returns HTML formatted like so:

- - -

This page was generated with the following command-line call:

```bash
$ gwdetchar-omega -i H1 1126259462
```

The install path used was `/path/to/install`.

- - -

cc @duncanmmacleod 