### PR TITLE
Gracefully handle null use cases

### DIFF
--- a/bin/gwdetchar-scattering
+++ b/bin/gwdetchar-scattering
@@ -264,9 +264,14 @@ if args.state_flag is not None:
         known={'facecolor': 'red', 'edgecolor': 'darkred', 'height': 0.4}))
     page.div.close()
 
-page.p("The following channels were searched for evidence of scattering "
-       "(yellow = weak evidence, red = strong evidence):")
-page.div(class_='panel-group', id_='accordion1')
+if statea:
+    page.p("The following channels were searched for evidence of scattering "
+           "(yellow = weak evidence, red = strong evidence):")
+    page.div(class_='panel-group', id_='accordion1')
+else:
+    page.div(class_='alert alert-info')
+    page.p('No active analysis segments were found')
+    page.div.close()
 
 # -- find scattering evidence -------------------------------------------------
 
@@ -285,11 +290,15 @@ for i, seg in enumerate(statea):
     alldata.append(
         get_data(allchannels, seg[0], seg[1], frametype=args.frametype,
                  verbose=msg, nproc=args.nproc).resample(128))
+try:
+    channels = alldata[0].keys()
+except IndexError:
+    channels = []
 
 scatter_segments = DataQualityDict()
 actives = SegmentList()
 
-for i, channel in enumerate(sorted(alldata[0].keys())):
+for i, channel in enumerate(sorted(channels)):
     logger.info("-- Processing %s --" % channel)
     chanstr = re.sub('[:-]', '_', channel).replace('_', '-', 1)
     optic = channel.split('-')[1].split('_')[0]
@@ -523,8 +532,9 @@ for i, channel in enumerate(sorted(alldata[0].keys())):
     page.div.close()
     page.div.close()
 
-# close panel group
-page.div.close()
+if statea:
+    # close panel group
+    page.div.close()
 
 # identify triggers during active segments
 logger.debug('Writing a summary CSV record')

--- a/gwdetchar/tests/test_utils.py
+++ b/gwdetchar/tests/test_utils.py
@@ -76,6 +76,19 @@ def test_table_from_segments():
     )
 
 
+def test_table_from_segments_empty():
+    segs = DataQualityDict()
+    segs['test'] = DataQualityFlag(
+       active=[]
+    )
+    assert_table_equal(
+        utils.table_from_segments(segs),
+        EventTable(
+            names=("time", "frequency", "start_time", "end_time",
+                   "snr", "channel")
+        )
+    )
+
 
 def test_table_from_times():
     times = numpy.array(range(10), dtype=float)

--- a/gwdetchar/utils.py
+++ b/gwdetchar/utils.py
@@ -121,10 +121,7 @@ def table_from_segments(flagdict, sngl_burst=False, snr=10., frequency=100.):
 
     for name, flag in flagdict.items():
         rows.extend(map(partial(row, channel=name), flag.active))
-    if rows:
-        table = EventTable(rows=rows, names=names)
-    else:
-        table = EventTable(names=names)
+    table = EventTable(rows=rows or None, names=names)
     if sngl_burst:  # add tablename for GWpy's ligolw writer
         table.meta["tablename"] = "sngl_burst"
     return table

--- a/gwdetchar/utils.py
+++ b/gwdetchar/utils.py
@@ -121,7 +121,10 @@ def table_from_segments(flagdict, sngl_burst=False, snr=10., frequency=100.):
 
     for name, flag in flagdict.items():
         rows.extend(map(partial(row, channel=name), flag.active))
-    table = EventTable(rows=rows, names=names)
+    if rows:
+        table = EventTable(rows=rows, names=names)
+    else:
+        table = EventTable(names=names)
     if sngl_burst:  # add tablename for GWpy's ligolw writer
         table.meta["tablename"] = "sngl_burst"
     return table


### PR DESCRIPTION
This PR fixes a bug I discovered in online processing, namely that `gwdetchar-overflow` and `gwdetchar-scattering` each fail when run with `--state-flag` over times when the given analysis flag is inactive. The issue is essentially an indexing error when attempting to range over an empty list.

So, the following changes are included:
* `gwdetchar-scattering`: if `state-flag` segments are empty, explicitly set the list of channels to an empty list
* `gwdetchar-overflow`: if overflow segments are all empty, handle that case separately, and provide a unit test

Example output is available for [**scattering**](https://ldas-jobs.ligo-la.caltech.edu/~aurban/scattering/day/20190414/) and [**overflows**](https://ldas-jobs.ligo-la.caltech.edu/~aurban/overflows/day/20190414/) (both require `LIGO.ORG` credentials).

cc @duncanmmacleod 