### PR TITLE
Pop CSS and JS files when constructing defaults

### DIFF
--- a/gwdetchar/io/html.py
+++ b/gwdetchar/io/html.py
@@ -282,8 +282,8 @@ def new_bootstrap_page(base=os.path.curdir, lang='en', refresh=False,
         default: None
     """
     # get kwargs with sensible defaults
-    css = kwargs.get('css', CSS_FILES)
-    script = kwargs.get('script', JS_FILES)
+    css = kwargs.pop('css', CSS_FILES)
+    script = kwargs.pop('script', JS_FILES)
     # write CSS to static dir
     css, script = finalize_static_urls(
         os.path.join(os.path.curdir, 'static'),


### PR DESCRIPTION
This PR uses `kwargs.pop` rather than `kwargs.get` when constructing default paths to CSS and JS files. This functionality is needed downstream when using a custom set of stylesheets, see gwpy/gwsumm#251.

Test output demonstrating that this change doesn't affect a script that already works is available [**here**](https://ldas-jobs.ligo-la.caltech.edu/~aurban/pyomega-test/Network_170817/).

cc @duncanmmacleod 