### PR TITLE
Disable LaTeX plot rendering by default

### DIFF
--- a/bin/gwdetchar-lasso-correlation
+++ b/bin/gwdetchar-lasso-correlation
@@ -374,7 +374,7 @@ p4 = (.1, .1, .9, .95)  # global plot defaults for plot4, timeseries subplots
 
 def process_channel(input_,):
     if USETEX:
-        gwplot.configure_mpl()
+        gwplot.configure_mpl_tex()
     chan = input_[1][0]
     ts = input_[1][1]
     lassocoef = nonzerocoef[chan]
@@ -494,7 +494,7 @@ max_correlated_channels = 20
 
 def generate_cluster(input_,):
     if USETEX:
-        gwplot.configure_mpl()
+        gwplot.configure_mpl_tex()
     currentchan = input_[1][0]
     currentts = input_[1][5]
     current = input_[0]

--- a/bin/gwdetchar-lasso-correlation
+++ b/bin/gwdetchar-lasso-correlation
@@ -43,7 +43,6 @@ from gwdetchar import (cli, lasso as gwlasso)
 from gwdetchar.lasso import plot as gwplot
 from gwdetchar.io import html as htmlio
 from gwdetchar.io.datafind import get_data
-from gwdetchar.plot import get_gwpy_tex_settings
 
 
 # default frametypes
@@ -106,10 +105,7 @@ args = parser.parse_args()
 # set up logger
 logger = cli.logger(name=os.path.basename(__file__))
 
-# set TeX settings
-tex_settings = get_gwpy_tex_settings()
-rcParams.update(tex_settings)
-
+# get run params
 start = int(args.gpsstart)
 end = int(args.gpsend)
 pad = args.filter_padding

--- a/bin/gwdetchar-lasso-correlation
+++ b/bin/gwdetchar-lasso-correlation
@@ -45,7 +45,6 @@ from gwdetchar.io.datafind import get_data
 from gwdetchar.io import html as htmlio
 from gwdetchar.plot import texify
 
-
 # LaTeX use
 USETEX = rcParams["text.usetex"]
 
@@ -138,10 +137,8 @@ if not os.path.isdir(args.output_dir):
     os.makedirs(args.output_dir)
 os.chdir(args.output_dir)
 
-if USETEX:  # multiprocessing for plots
-    nprocplot = args.nproc_plot or args.nproc
-else:
-    nprocplot = 1
+# multiprocessing for plots
+nprocplot = (args.nproc_plot or args.nproc) if USETEX else 1
 
 # bandpass primary
 if args.band_pass:

--- a/bin/gwdetchar-lasso-correlation
+++ b/bin/gwdetchar-lasso-correlation
@@ -46,6 +46,9 @@ from gwdetchar.io.datafind import get_data
 from gwdetchar.io import html as htmlio
 
 
+# LaTeX use
+USETEX = bool_env("GWPY_USETEX", False)
+
 # default frametypes
 DEFAULT_FRAMETYPE = {
     'GDS-CALIB_STRAIN': '{ifo}_HOFT_C00',
@@ -63,7 +66,8 @@ cli.add_gps_start_stop_arguments(parser)
 cli.add_ifo_option(parser)
 cli.add_nproc_option(parser, default=1)
 parser.add_argument('-J', '--nproc-plot', type=int, default=None,
-                    help='number of processes to use for plotting')
+                    help='number of processes to use for plot rendering, '
+                         'will be ignored if not using LaTeX')
 parser.add_argument('-o', '--output-dir', default=os.curdir,
                     help='output directory for plots')
 parser.add_argument('-f', '--channel-file', type=os.path.abspath,
@@ -129,12 +133,17 @@ if args.primary_frametype is None:
         raise type(exc)("Could not determine primary channel's frametype, "
                         "please specify with --primary-frametype")
 
-
+# create output directory
 if not os.path.isdir(args.output_dir):
     os.makedirs(args.output_dir)
 os.chdir(args.output_dir)
-nprocplot = args.nproc_plot or args.nproc
 
+if USETEX:  # multiprocessing for plots
+    nprocplot = args.nproc_plot or args.nproc
+else:
+    nprocplot = 1
+
+# bandpass primary
 if args.band_pass:
     try:
         flower, fupper = args.band_pass
@@ -367,7 +376,7 @@ p4 = (.1, .1, .9, .95)  # global plot defaults for plot4, timeseries subplots
 
 
 def process_channel(input_,):
-    if bool_env("GWPY_USETEX", False):
+    if USETEX:
         gwplot.configure_mpl()
     chan = input_[1][0]
     ts = input_[1][1]
@@ -488,7 +497,7 @@ max_correlated_channels = 20
 
 
 def generate_cluster(input_,):
-    if bool_env("GWPY_USETEX", False):
+    if USETEX:
         gwplot.configure_mpl()
     currentchan = input_[1][0]
     currentts = input_[1][5]

--- a/bin/gwdetchar-lasso-correlation
+++ b/bin/gwdetchar-lasso-correlation
@@ -36,7 +36,6 @@ from pandas import set_option
 
 from gwpy.plot import Plot
 from gwpy.time import Time
-from gwpy.utils.env import bool_env
 from gwpy.detector import ChannelList
 from gwpy.io import nds2 as io_nds2
 
@@ -47,7 +46,7 @@ from gwdetchar.io import html as htmlio
 
 
 # LaTeX use
-USETEX = bool_env("GWPY_USETEX", False)
+USETEX = rcParams["text.usetex"]
 
 # default frametypes
 DEFAULT_FRAMETYPE = {

--- a/bin/gwdetchar-lasso-correlation
+++ b/bin/gwdetchar-lasso-correlation
@@ -36,13 +36,14 @@ from pandas import set_option
 
 from gwpy.plot import Plot
 from gwpy.time import Time
+from gwpy.utils.env import bool_env
 from gwpy.detector import ChannelList
 from gwpy.io import nds2 as io_nds2
 
 from gwdetchar import (cli, lasso as gwlasso)
 from gwdetchar.lasso import plot as gwplot
-from gwdetchar.io import html as htmlio
 from gwdetchar.io.datafind import get_data
+from gwdetchar.io import html as htmlio
 
 
 # default frametypes
@@ -366,7 +367,8 @@ p4 = (.1, .1, .9, .95)  # global plot defaults for plot4, timeseries subplots
 
 
 def process_channel(input_,):
-    gwplot.configure_mpl()
+    if bool_env("GWPY_USETEX", False):
+        gwplot.configure_mpl()
     chan = input_[1][0]
     ts = input_[1][1]
     lassocoef = nonzerocoef[chan]
@@ -486,7 +488,8 @@ max_correlated_channels = 20
 
 
 def generate_cluster(input_,):
-    gwplot.configure_mpl()
+    if bool_env("GWPY_USETEX", False):
+        gwplot.configure_mpl()
     currentchan = input_[1][0]
     currentts = input_[1][5]
     current = input_[0]

--- a/bin/gwdetchar-lasso-correlation
+++ b/bin/gwdetchar-lasso-correlation
@@ -19,8 +19,8 @@
 
 import os
 import re
-import multiprocessing
 import sys
+import multiprocessing
 
 import numpy
 
@@ -274,7 +274,7 @@ print(results)
 print('\n\n')
 
 # convert to pandas
-set_option('max_colwidth', 200)
+set_option('max_colwidth', -1)
 df = results.to_pandas()
 df.index += 1
 

--- a/bin/gwdetchar-lasso-correlation
+++ b/bin/gwdetchar-lasso-correlation
@@ -639,7 +639,6 @@ page.add(df.to_html(
     escape=False,
     border=0))
 page.div.close()  # col-md-10 col-md-offset-1
-page.div.close()  # results-table
 page.div.close()  # row
 page.add('<hr class="row-divider">')
 

--- a/bin/gwdetchar-lasso-correlation
+++ b/bin/gwdetchar-lasso-correlation
@@ -43,6 +43,7 @@ from gwdetchar import (cli, lasso as gwlasso)
 from gwdetchar.lasso import plot as gwplot
 from gwdetchar.io.datafind import get_data
 from gwdetchar.io import html as htmlio
+from gwdetchar.plot import texify
 
 
 # LaTeX use
@@ -302,7 +303,7 @@ colors = [cmap(i) for i in numpy.linspace(0, 1, len(nonzerodata)+1)]
 plot = Plot(figsize=(12, 4))
 plot.subplots_adjust(*p1)
 ax = plot.gca(xscale='auto-gps', epoch=start, xlim=xlim)
-ax.plot(times, descaler(target), label=primary.replace('_', r'\_'),
+ax.plot(times, descaler(target), label=texify(primary),
         color='black', linewidth=args.line_size_primary)
 ax.plot(times, descaler(modelFit), label='Lasso model',
         linewidth=args.line_size_aux)
@@ -321,7 +322,7 @@ plot1 = gwplot.save_figure(
 plot = Plot(figsize=(12, 4))
 plot.subplots_adjust(*p1)
 ax = plot.gca(xscale='auto-gps', epoch=start, xlim=xlim)
-ax.plot(times, descaler(target), label=primary.replace('_', r'\_'),  # primary
+ax.plot(times, descaler(target), label=texify(primary),
         color='black', linewidth=args.line_size_primary)
 summed = 0
 for i, name in enumerate(results['Channel']):
@@ -347,7 +348,7 @@ plot2 = gwplot.save_figure(
 plot = Plot(figsize=(12, 4))
 plot.subplots_adjust(*p1)
 ax = plot.gca(xscale='auto-gps', epoch=start, xlim=xlim)
-ax.plot(times, descaler(target), label=primary.replace('_', r'\_'),  # primary
+ax.plot(times, descaler(target), label=texify(primary),
         color='black', linewidth=args.line_size_primary)
 for i, name in enumerate(results['Channel']):
     this = descaler(scale(nonzerodata[name].value) * nonzerocoef[name])
@@ -355,7 +356,7 @@ for i, name in enumerate(results['Channel']):
         label = 'Channels 1-{0}'.format(i+1)
     else:
         label = 'Channel 1'
-    ax.plot(times, this, label=name.replace('_', r'\_'), color=colors[i],
+    ax.plot(times, this, label=texify(name), color=colors[i],
             linewidth=args.line_size_aux)
 if range_is_primary:
     ax.set_ylabel('Sensitive range [Mpc]')
@@ -409,12 +410,11 @@ def process_channel(input_,):
         fig = Plot(figsize=(12, 8))
         fig.subplots_adjust(*p4)
         ax1 = fig.add_subplot(2, 1, 1, xscale='auto-gps', epoch=start)
-        ax1.plot(primaryts, label=primary.replace('_', r'\_'),
-                 color='black', linewidth=args.line_size_primary)
+        ax1.plot(primaryts, label=texify(primary), color='black',
+                 linewidth=args.line_size_primary)
         ax1.set_xlabel(None)
         ax2 = fig.add_subplot(2, 1, 2, sharex=ax1, xlim=xlim)
-        ax2.plot(ts, label=chan.replace('_', r'\_'),
-                 linewidth=args.line_size_aux)
+        ax2.plot(ts, label=texify(chan), linewidth=args.line_size_aux)
         if range_is_primary:
             ax1.set_ylabel('Sensitive range [Mpc]')
         else:
@@ -434,9 +434,9 @@ def process_channel(input_,):
         fig = Plot(figsize=(12, 4))
         fig.subplots_adjust(*p1)
         ax = fig.gca(xscale='auto-gps', epoch=start, xlim=xlim)
-        ax.plot(times, descaler(target), label=primary.replace('_', r'\_'),
+        ax.plot(times, descaler(target), label=texify(primary),
                 color='black', linewidth=args.line_size_primary)
-        ax.plot(times, descaler(tsscaled), label=chan.replace('_', r'\_'),
+        ax.plot(times, descaler(tsscaled), label=texify(chan),
                 linewidth=args.line_size_aux)
         if range_is_primary:
             ax.set_ylabel('Sensitive range [Mpc]')
@@ -456,7 +456,7 @@ def process_channel(input_,):
         fig = Plot(figsize=(12, 4))
         fig.subplots_adjust(*p1)
         ax = fig.gca()
-        ax.set_xlabel(chan.replace('_', r'\_') + ' [Channel units]')
+        ax.set_xlabel(texify(chan) + ' [Channel units]')
         if range_is_primary:
             ax.set_ylabel('Sensitive range [Mpc]')
         else:
@@ -534,8 +534,8 @@ def generate_cluster(input_,):
             ax = fig.gca(xscale='auto-gps')
             ax.plot(
                 times, scale(currentts.value)*numpy.sign(input_[1][1]),
-                label=currentchan.replace('_', r'\_'),
-                linewidth=args.line_size_aux, color=colors[0])
+                label=texify(currentchan), linewidth=args.line_size_aux,
+                color=colors[0])
 
             for i in range(0, ncluster):
                 this = cluster[i]
@@ -546,7 +546,7 @@ def generate_cluster(input_,):
                     color=colors2[i+1],
                     linewidth=args.line_size_aux,
                     label=('{0}, r = {1:.2}'.format(
-                        cluster[i][3].replace('_', r'\_'), cluster[i][2])),
+                        texify(cluster[i][3]), cluster[i][2])),
                 )
 
             ax.margins(x=0)

--- a/bin/gwdetchar-overflow
+++ b/bin/gwdetchar-overflow
@@ -39,7 +39,6 @@ from gwpy.segments import (DataQualityFlag, DataQualityDict,
 from gwdetchar import (cds, cli, const, daq)
 from gwdetchar.io import (html as htmlio)
 from gwdetchar.io.datafind import get_data
-from gwdetchar.plot import get_gwpy_tex_settings
 from gwdetchar.utils import table_from_segments
 
 SITE_MAP = {
@@ -106,10 +105,6 @@ if args.ifo == 'L1':
         simulink = 'https://llocds.ligo-la.caltech.edu/daq/simulink/'
 
 span = Segment(args.gpsstart, args.gpsend)
-
-# set TeX settings
-tex_settings = get_gwpy_tex_settings()
-rcParams.update(tex_settings)
 
 # let's go
 logger.info('{} Overflows {}-{}'.format(

--- a/bin/gwdetchar-overflow
+++ b/bin/gwdetchar-overflow
@@ -25,7 +25,7 @@ import os.path
 import warnings
 import tqdm
 
-from matplotlib import (use, rcParams)
+from matplotlib import use
 use('agg')  # noqa
 
 import h5py

--- a/bin/gwdetchar-scattering
+++ b/bin/gwdetchar-scattering
@@ -49,15 +49,12 @@ from gwdetchar import (cli, const, scattering)
 from gwdetchar.io import html as htmlio
 from gwdetchar.io.datafind import get_data
 from gwdetchar.omega import batch
-from gwdetchar.plot import get_gwpy_tex_settings
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 __credits__ = 'Siddharth Soni <siddharth.soni@ligo.org>' \
               'Alex Urban <alexander.urban@ligo.org>'
 
-# TeX settings
-tex_settings = get_gwpy_tex_settings()
-rcParams.update(tex_settings)
+# rcParams settings
 rcParams.update({
     'axes.labelsize': 20,
     'figure.subplot.bottom': 0.17,

--- a/bin/gwdetchar-scattering
+++ b/bin/gwdetchar-scattering
@@ -39,7 +39,6 @@ use('agg')  # noqa
 import gwtrigfind
 
 from gwpy.plot import Plot
-from gwpy.plot.tex import label_to_latex
 from gwpy.table import (Table, EventTable)
 from gwpy.table.filters import in_segmentlist
 from gwpy.segments import (DataQualityFlag, DataQualityDict,
@@ -48,6 +47,7 @@ from gwpy.segments import (DataQualityFlag, DataQualityDict,
 from gwdetchar import (cli, const, scattering)
 from gwdetchar.io import html as htmlio
 from gwdetchar.io.datafind import get_data
+from gwdetchar.plot import texify
 from gwdetchar.omega import batch
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
@@ -393,7 +393,7 @@ for i, channel in enumerate(sorted(channels)):
 
     # finalize plot
     logger.debug("Plotting")
-    name = label_to_latex(channel) if rcParams["text.usetex"] else channel
+    name = texify(channel)
     axes['position'].set_title("Scattering evidence in %s" % name)
     axes['position'].set_xlabel('')
     axes['position'].set_ylabel(r'Position [\textmu m]')
@@ -423,9 +423,7 @@ for i, channel in enumerate(sorted(channels)):
         c=trigs[names[2]],
         edgecolor='none',
     )
-    name = args.main_channel
-    if rcParams["text.usetex"]:
-        name = label_to_latex(name)
+    name = texify(args.main_channel)
     axes['triggers'].text(
         0.01, 0.95,
         '%s event triggers (Omicron)' % name,

--- a/bin/gwdetchar-slow-correlation
+++ b/bin/gwdetchar-slow-correlation
@@ -25,7 +25,7 @@ import sys
 import numpy
 from scipy.stats import spearmanr
 
-from matplotlib import (use, rcParams)
+from matplotlib import use
 use('agg')
 import matplotlib.pyplot as plt
 

--- a/bin/gwdetchar-slow-correlation
+++ b/bin/gwdetchar-slow-correlation
@@ -36,7 +36,6 @@ from gwpy.io import nds2 as io_nds2
 from gwdetchar import (cli, lasso)
 from gwdetchar.io import html as htmlio
 from gwdetchar.io.datafind import get_data
-from gwdetchar.plot import get_gwpy_tex_settings
 
 from sklearn import linear_model, preprocessing, datasets
 from sklearn.metrics import mean_squared_error, r2_score
@@ -102,10 +101,6 @@ if not os.path.isdir(args.output_dir):
     os.makedirs(args.output_dir)
 os.chdir(args.output_dir)
 nprocplot = args.nproc_plot or args.nproc
-
-# set TeX settings
-tex_settings = get_gwpy_tex_settings()
-rcParams.update(tex_settings)
 
 # load data
 logger.info("-- Loading range data")

--- a/bin/gwdetchar-software-saturations
+++ b/bin/gwdetchar-software-saturations
@@ -37,7 +37,6 @@ from gwpy.segments import (Segment, SegmentList,
 
 from gwdetchar import (cli, const, saturation)
 from gwdetchar.io import html as htmlio
-from gwdetchar.plot import get_gwpy_tex_settings
 
 __author__ = 'Dan Hoak <daniel.hoak@ligo.org>'
 __credits__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
@@ -78,10 +77,6 @@ logger = cli.logger(name=os.path.basename(__file__))
 ifo = args.ifo.upper()
 site = ifo[0]
 frametype = args.frametype or '%s_R' % ifo
-
-# set TeX settings
-tex_settings = get_gwpy_tex_settings()
-rcParams.update(tex_settings)
 
 # let's go
 logger.info('{} Software Saturations {}-{}'.format(

--- a/bin/gwdetchar-software-saturations
+++ b/bin/gwdetchar-software-saturations
@@ -23,7 +23,7 @@
 import os
 import sys
 
-from matplotlib import (use, rcParams)
+from matplotlib import use
 use('agg')
 
 import gwdatafind

--- a/docs/lasso/index.rst
+++ b/docs/lasso/index.rst
@@ -21,7 +21,7 @@ The :mod:`gwdetchar.lasso.plot` module also provides functions for efficiently w
 
 .. autosummary::
 
-   plot.configure_mpl
+   plot.configure_mpl_tex
    plot.save_figure
 
 ====================

--- a/gwdetchar/lasso/plot.py
+++ b/gwdetchar/lasso/plot.py
@@ -20,9 +20,9 @@
 """
 
 import os
+import atexit
 import shutil
 import tempfile
-import atexit
 import warnings
 
 from matplotlib import rcParams
@@ -37,7 +37,7 @@ __credits__ = 'Alex Macedo, Jeff Bidler, Oli Patane, Marissa Walker, ' \
 # -- plotting utilities -------------------------------------------------------
 
 def configure_mpl():
-    """Configure Matplotlib while processing channels with `gwdetchar.lasso`
+    """Configure Matplotlib with LaTeX when using multiprocessing
     """
     import matplotlib
     matplotlib.use('agg')

--- a/gwdetchar/lasso/plot.py
+++ b/gwdetchar/lasso/plot.py
@@ -36,7 +36,7 @@ __credits__ = 'Alex Macedo, Jeff Bidler, Oli Patane, Marissa Walker, ' \
 
 # -- plotting utilities -------------------------------------------------------
 
-def configure_mpl():
+def configure_mpl_tex():
     """Configure Matplotlib with LaTeX when using multiprocessing
     """
     import matplotlib

--- a/gwdetchar/lasso/plot.py
+++ b/gwdetchar/lasso/plot.py
@@ -29,15 +29,9 @@ from matplotlib import rcParams
 
 from gwpy.plot import Plot
 
-from ..plot import get_gwpy_tex_settings
-
 __author__ = 'Alex Urban <alexander.urban@ligo.org>'
 __credits__ = 'Alex Macedo, Jeff Bidler, Oli Patane, Marissa Walker, ' \
               'Josh Smith'
-
-# TeX settings
-tex_settings = get_gwpy_tex_settings()
-rcParams.update(tex_settings)
 
 
 # -- plotting utilities -------------------------------------------------------

--- a/gwdetchar/lasso/tests/test_plot.py
+++ b/gwdetchar/lasso/tests/test_plot.py
@@ -43,8 +43,8 @@ SERIES = TimeSeries(DATA, sample_rate=60, unit='Mpc', name='X1:TEST')
 
 # -- make sure plots run end-to-end -------------------------------------------
 
-def test_configure_mpl():
-    plot.configure_mpl()
+def test_configure_mpl_tex():
+    plot.configure_mpl_tex()
     assert os.environ['HOME'] == os.environ['MPLCONFIGDIR']
     assert rcParams['ps.useafm'] is True
     assert rcParams['pdf.use14corefonts'] is True

--- a/gwdetchar/omega/plot.py
+++ b/gwdetchar/omega/plot.py
@@ -20,6 +20,8 @@
 """
 
 from matplotlib import (cm, rcParams)
+
+from gwpy.plot.tex import label_to_latex
 from gwpy.plot.colors import GW_OBSERVATORY_COLORS
 
 __author__ = 'Alex Urban <alexander.urban@ligo.org>'
@@ -139,7 +141,7 @@ def timeseries_plot(data, gps, span, channel, output, ylabel=None,
     ax.set_yscale('linear')
     ax.set_ylabel(ylabel)
     # set title
-    title = r'$\mathtt{%s}$ at %.3f' % (channel.replace('_', '\_'), gps)
+    title = r'$\mathtt{%s}$ at %.3f' % (label_to_latex(channel), gps)
     ax.set_title(title, y=1.1)
     # save plot and close
     plot.savefig(output, bbox_inches='tight')
@@ -204,7 +206,7 @@ def spectral_plot(data, gps, span, channel, output, colormap='viridis',
     _format_color_axis(ax, colormap=colormap, clim=clim, norm=norm)
     # set title
     title = r'$\mathtt{%s}$ at %.3f with $Q$ of %.1f' \
-            % (channel.replace('_', '\_'), gps, Q)
+            % (label_to_latex(channel), gps, Q)
     ax.set_title(title, y=1.05)
     # save plot and close
     plot.savefig(output, bbox_inches='tight')

--- a/gwdetchar/omega/plot.py
+++ b/gwdetchar/omega/plot.py
@@ -21,8 +21,9 @@
 
 from matplotlib import (cm, rcParams)
 
-from gwpy.plot.tex import label_to_latex
 from gwpy.plot.colors import GW_OBSERVATORY_COLORS
+
+from ..plot import texify
 
 __author__ = 'Alex Urban <alexander.urban@ligo.org>'
 __credits__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
@@ -141,7 +142,7 @@ def timeseries_plot(data, gps, span, channel, output, ylabel=None,
     ax.set_yscale('linear')
     ax.set_ylabel(ylabel)
     # set title
-    title = r'$\mathtt{%s}$ at %.3f' % (label_to_latex(channel), gps)
+    title = '%s at %.3f' % (texify(channel), gps)
     ax.set_title(title, y=1.1)
     # save plot and close
     plot.savefig(output, bbox_inches='tight')
@@ -205,8 +206,8 @@ def spectral_plot(data, gps, span, channel, output, colormap='viridis',
     # set colorbar properties
     _format_color_axis(ax, colormap=colormap, clim=clim, norm=norm)
     # set title
-    title = r'$\mathtt{%s}$ at %.3f with $Q$ of %.1f' \
-            % (label_to_latex(channel), gps, Q)
+    title = ('%s at %.3f with $Q$ of %.1f'
+             % (texify(channel), gps, Q))
     ax.set_title(title, y=1.05)
     # save plot and close
     plot.savefig(output, bbox_inches='tight')

--- a/gwdetchar/plot.py
+++ b/gwdetchar/plot.py
@@ -51,8 +51,7 @@ def texify(text):
     """
     if rcParams['text.usetex']:
         return label_to_latex(text)
-    else:
-        return text or ''
+    return text or ''
 
 
 def plot_segments(flag, span, facecolor='red', edgecolor='darkred', height=0.8,

--- a/gwdetchar/plot.py
+++ b/gwdetchar/plot.py
@@ -21,6 +21,8 @@
 
 from matplotlib import rcParams
 
+from gwpy.plot.tex import label_to_latex
+
 __author__ = 'Alex Urban <alexander.urban@ligo.org>'
 __credits__ = 'Dan Hoak <daniel.hoak@ligo.org>, ' \
               'Duncan Macleod <duncan.macleod@ligo.org>'
@@ -38,12 +40,37 @@ rcParams.update({
 
 # -- plotting utilities -------------------------------------------------------
 
+def texify(text):
+    """Helper utility to detect when LaTeX rendering is used, and convert
+    text to a LaTeX-passable representation if necessary
+
+    Parameters
+    ----------
+    text : str
+        text to convert to LaTeX representation
+
+    Returns
+    -------
+    out : str
+        either a copy or LaTeX representation of `text`
+
+    See Also
+    --------
+    gwpy.plot.tex.label_to_latex
+        the underlying method to convert to a LaTeX representation
+    """
+    if rcParams['text.usetex']:
+        return label_to_latex(text)
+    else:
+        return '' or text
+
+
 def plot_segments(flag, span, facecolor='red', edgecolor='darkred', height=0.8,
                   known={'alpha': 0.6, 'facecolor': 'lightgray',
                          'edgecolor': 'gray', 'height': 0.4}):
     """Plot the saturation segments contained within a flag
     """
-    name = flag.texname if rcParams["text.usetex"] else flag.name
+    name = texify(flag.name)
     plot = flag.plot(
         figsize=[12, 2], facecolor=facecolor, edgecolor=edgecolor,
         height=height, known=known, label=' ', xlim=span, xscale='auto-gps',

--- a/gwdetchar/plot.py
+++ b/gwdetchar/plot.py
@@ -62,7 +62,7 @@ def texify(text):
     if rcParams['text.usetex']:
         return label_to_latex(text)
     else:
-        return '' or text
+        return text or ''
 
 
 def plot_segments(flag, span, facecolor='red', edgecolor='darkred', height=0.8,

--- a/gwdetchar/plot.py
+++ b/gwdetchar/plot.py
@@ -20,40 +20,20 @@
 """
 
 from matplotlib import rcParams
-from gwpy.plot.tex import (has_tex, MACROS as GWPY_TEX_MACROS)
-from gwpy.utils.env import bool_env
 
 __author__ = 'Alex Urban <alexander.urban@ligo.org>'
 __credits__ = 'Dan Hoak <daniel.hoak@ligo.org>, ' \
               'Duncan Macleod <duncan.macleod@ligo.org>'
 
-
-def get_gwpy_tex_settings():
-    """Return a dict of rcParams similar to GWPY_TEX_RCPARAMS
-
-    Returns
-    -------
-    rcParams : `dict`
-        a dictionary of matplotlib rcParams
-    """
-    # custom GW-DetChar formatting
-    params = {
-        'font.size': 10,
-        'xtick.labelsize': 18,
-        'ytick.labelsize': 18,
-        'axes.labelsize': 20,
-        'axes.titlesize': 24,
-        'grid.alpha': 0.5,
-    }
-    if has_tex() and bool_env("GWPY_USETEX", True):
-        params.update({
-            'text.usetex': True,
-            'text.latex.preamble': (
-                rcParams.get('text.latex.preamble', []) + GWPY_TEX_MACROS),
-            'font.family': ['serif'],
-            'axes.formatter.use_mathtext': False,
-        })
-    return params
+# custom GW-DetChar formatting
+rcParams.update({
+    'font.size': 10,
+    'xtick.labelsize': 18,
+    'ytick.labelsize': 18,
+    'axes.labelsize': 20,
+    'axes.titlesize': 24,
+    'grid.alpha': 0.5,
+})
 
 
 # -- plotting utilities -------------------------------------------------------

--- a/gwdetchar/plot.py
+++ b/gwdetchar/plot.py
@@ -27,16 +27,6 @@ __author__ = 'Alex Urban <alexander.urban@ligo.org>'
 __credits__ = 'Dan Hoak <daniel.hoak@ligo.org>, ' \
               'Duncan Macleod <duncan.macleod@ligo.org>'
 
-# custom GW-DetChar formatting
-rcParams.update({
-    'font.size': 10,
-    'xtick.labelsize': 18,
-    'ytick.labelsize': 18,
-    'axes.labelsize': 20,
-    'axes.titlesize': 24,
-    'grid.alpha': 0.5,
-})
-
 
 # -- plotting utilities -------------------------------------------------------
 

--- a/gwdetchar/tests/test_plot.py
+++ b/gwdetchar/tests/test_plot.py
@@ -45,7 +45,7 @@ def test_texify():
 
     # test with LaTeX
     rcParams['text.usetex'] = True
-    assert plot.texify(name) == name.replace('_', '\\_')
+    assert plot.texify(name) == name.replace('_', r'\_')
 
     # test without LaTeX
     rcParams['text.usetex'] = False

--- a/gwdetchar/tests/test_plot.py
+++ b/gwdetchar/tests/test_plot.py
@@ -24,7 +24,7 @@ import shutil
 
 from gwpy.segments import DataQualityFlag
 
-from matplotlib import use
+from matplotlib import (use, rcParams)
 use('agg')
 
 from .. import plot
@@ -36,6 +36,22 @@ __author__ = 'Alex Urban <alexander.urban@ligo.org>'
 
 FLAG = DataQualityFlag(known=[(0, 66)], active=[(16, 42)],
                        name='X1:TEST-FLAG:1')
+
+
+# -- test utilities -----------------------------------------------------------
+
+def test_texify():
+    name = 'X1:TEST-CHANNEL_NAME'
+
+    # test without LaTeX
+    assert plot.texify(name) == name
+
+    # test with LaTeX
+    rcParams['text.usetex'] = True
+    assert plot.texify(name) == name.replace('_', '\\_')
+
+    # null use case
+    assert plot.texify(None) == ''
 
 
 # -- make sure plots run end-to-end -------------------------------------------

--- a/gwdetchar/tests/test_plot.py
+++ b/gwdetchar/tests/test_plot.py
@@ -21,6 +21,7 @@
 
 import os
 import shutil
+from unittest.mock import patch
 
 from gwpy.segments import DataQualityFlag
 
@@ -44,12 +45,12 @@ def test_texify():
     name = 'X1:TEST-CHANNEL_NAME'
 
     # test with LaTeX
-    rcParams['text.usetex'] = True
-    assert plot.texify(name) == name.replace('_', r'\_')
+    with patch.dict(rcParams, {'text.usetex': True}):
+        assert plot.texify(name) == name.replace('_', r'\_')
 
     # test without LaTeX
-    rcParams['text.usetex'] = False
-    assert plot.texify(name) == name
+    with patch.dict(rcParams, {'text.usetex': False}):
+        assert plot.texify(name) == name
 
     # null use case
     assert plot.texify(None) == ''

--- a/gwdetchar/tests/test_plot.py
+++ b/gwdetchar/tests/test_plot.py
@@ -43,12 +43,13 @@ FLAG = DataQualityFlag(known=[(0, 66)], active=[(16, 42)],
 def test_texify():
     name = 'X1:TEST-CHANNEL_NAME'
 
-    # test without LaTeX
-    assert plot.texify(name) == name
-
     # test with LaTeX
     rcParams['text.usetex'] = True
     assert plot.texify(name) == name.replace('_', '\\_')
+
+    # test without LaTeX
+    rcParams['text.usetex'] = False
+    assert plot.texify(name) == name
 
     # null use case
     assert plot.texify(None) == ''

--- a/share/sass/gwdetchar.scss
+++ b/share/sass/gwdetchar.scss
@@ -48,11 +48,19 @@ img {
 }
 
 .navbar {
+		.navbar-brand,
+		.navbar-text,
+		.navbar-nav > li > a,
+		.navbar-nav > li.disabled > a {
+				font-family: Tahoma, Geneva, sans-serif;
+				font-weight: 500;
+				font-size: 15px;
+		}
 		.ifo-links  {
 				.dropdown-header {
 						padding-left: 20px;
 						padding-right: 20px;
-						white-space: normal;;
+						white-space: normal;
 				}
 				@media (min-width: 768px) {
 						position: absolute;


### PR DESCRIPTION
This PR disables plot rendering with LaTeX by default, as is done upstream in gwpy. Users who wish to render with LaTeX may still do so by setting the `GWPY_USETEX` environment variable:

```bash
$ export GWPY_USETEX=true
```

The following related changes are also included:

* Remove redundant function calls
* In lasso runs, configure Matplotlib and use multiprocessing to write plots only when rendering with LaTeX
* Bugfix when converting pandas data frames to HTML tables
* Tweak CSS so that navbar headers are rendered in bold Tahoma

Fully rendered prototypes of various tools are available (all require `LIGO.ORG` credentials):

**Tool** | **IFO** | **Time range** | **Output**
 -- | -- | -- | --
Lasso | H1 | 1242606018-1242623562 | [**Link**](https://ldas-jobs.ligo.caltech.edu/~alexander.urban/lasso/1242606018-1242623562/)
Omega scans | Network | 1187008882 | [**Link**](https://ldas-jobs.ligo.caltech.edu/~alexander.urban/wdq/Network_1187008882.0/)
Summary pages [downstream] | H1 | 1242691218-1242694818 | [**Link**](https://ldas-jobs.ligo-wa.caltech.edu/~aurban/summary/formatting/1242691218-1242694818/)
Summary pages [downstream] | L1 | 1242518418-1242522018 | [**Link**](https://ldas-jobs.ligo-la.caltech.edu/~aurban/summary/formatting/1242518418-1242522018/)
Summary pages [downstream] | Network | 1242518418-1242522018 | [**Link**](https://ldas-jobs.ligo.caltech.edu/~alexander.urban/summary/testing/1242518418-1242522018/)
Summary pages [downstream] | O3 | 1242522018-1242526618 | [**Link**](https://ldas-jobs.ligo.caltech.edu/~alexander.urban/summary/testing/1242522018-1242526618/)

cc @duncanmmacleod, @areeda 