### PR TITLE
Use large text in navbar branding

### DIFF
--- a/share/sass/gwdetchar.scss
+++ b/share/sass/gwdetchar.scss
@@ -54,7 +54,7 @@ img {
 		.navbar-nav > li.disabled > a {
 				font-family: Tahoma, Geneva, sans-serif;
 				font-weight: 500;
-				font-size: 15px;
+				font-size: 14px;
 		}
 		.navbar-brand {
 				font-size: 16px;

--- a/share/sass/gwdetchar.scss
+++ b/share/sass/gwdetchar.scss
@@ -56,6 +56,9 @@ img {
 				font-weight: 500;
 				font-size: 15px;
 		}
+		.navbar-brand {
+				font-size: 16px;
+		}
 		.ifo-links  {
 				.dropdown-header {
 						padding-left: 20px;


### PR DESCRIPTION
This PR adjusts navbar brands (i.e., the text on the far-left, listed first before the nav menu) so that they are rendered with `<big>` HTML tags.

Example omega scan output is available [**here**](https://ldas-jobs.ligo.caltech.edu/~alexander.urban/wdq/Network_1187008882.0/) (requires `LIGO.ORG` credentials).

cc @duncanmmacleod, @areeda 