### PR TITLE
Use Roboto font in HTML

### DIFF
--- a/gwdetchar/io/html.py
+++ b/gwdetchar/io/html.py
@@ -141,6 +141,9 @@ FANCYBOX_JS = "{0}/jquery.fancybox.min.js".format(_FANCYBOX_CDN)
 MOMENT_JS = (
     "https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.13.0/moment.min.js")
 
+GOOGLE_FONT_CSS = ("https://fonts.googleapis.com/css?"
+                   "family=Roboto:300,400,400i,700%7CRoboto+Mono")
+
 BOOTSTRAP_LIGO_CSS = resource_filename(
     'gwdetchar',
     '_static/bootstrap-ligo.min.css',
@@ -162,6 +165,7 @@ GWDETCHAR_JS = resource_filename(
 CSS_FILES = [
     BOOTSTRAP_CSS,
     FANCYBOX_CSS,
+    GOOGLE_FONT_CSS,
     BOOTSTRAP_LIGO_CSS,
     GWDETCHAR_CSS
 ]

--- a/gwdetchar/io/tests/test_html.py
+++ b/gwdetchar/io/tests/test_html.py
@@ -60,6 +60,7 @@ NEW_BOOTSTRAP_PAGE = """<!DOCTYPE HTML>
 <base href="{base}" />
 <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css" rel="stylesheet" type="text/css" media="all" />
 <link href="https://cdnjs.cloudflare.com/ajax/libs/fancybox/2.1.5/jquery.fancybox.min.css" rel="stylesheet" type="text/css" media="all" />
+<link href="https://fonts.googleapis.com/css?family=Roboto:300,400,400i,700%7CRoboto+Mono" rel="stylesheet" type="text/css" media="all" />
 <link href="static/bootstrap-ligo.min.css" rel="stylesheet" type="text/css" media="all" />
 <link href="static/gwdetchar.min.css" rel="stylesheet" type="text/css" media="all" />
 <script src="https://code.jquery.com/jquery-1.12.3.min.js" type="text/javascript"></script>
@@ -230,6 +231,8 @@ def test_finalize_static_urls(tmpdir):
             'bootstrap.min.css',  # nopep8
         'https://cdnjs.cloudflare.com/ajax/libs/fancybox/2.1.5/'
             'jquery.fancybox.min.css',  # nopep8
+        'https://fonts.googleapis.com/css?'
+	        'family=Roboto:300,400,400i,700%7CRoboto+Mono',  # nopep8
         'static/bootstrap-ligo.min.css',
         'static/gwdetchar.min.css']
     assert js == [

--- a/gwdetchar/omega/plot.py
+++ b/gwdetchar/omega/plot.py
@@ -142,7 +142,7 @@ def timeseries_plot(data, gps, span, channel, output, ylabel=None,
     ax.set_yscale('linear')
     ax.set_ylabel(ylabel)
     # set title
-    title = '%s at %.3f' % (texify(channel), gps)
+    title = r'$\mathtt{%s}$ at %.3f' % (texify(channel), gps)
     ax.set_title(title, y=1.1)
     # save plot and close
     plot.savefig(output, bbox_inches='tight')
@@ -206,7 +206,7 @@ def spectral_plot(data, gps, span, channel, output, colormap='viridis',
     # set colorbar properties
     _format_color_axis(ax, colormap=colormap, clim=clim, norm=norm)
     # set title
-    title = ('%s at %.3f with $Q$ of %.1f'
+    title = (r'$\mathtt{%s}$ at %.3f with $Q$ of %.1f'
              % (texify(channel), gps, Q))
     ax.set_title(title, y=1.05)
     # save plot and close

--- a/gwdetchar/omega/plot.py
+++ b/gwdetchar/omega/plot.py
@@ -22,8 +22,7 @@
 from matplotlib import (cm, rcParams)
 
 from gwpy.plot.colors import GW_OBSERVATORY_COLORS
-
-from ..plot import texify
+from gwpy.plot.tex import label_to_latex
 
 __author__ = 'Alex Urban <alexander.urban@ligo.org>'
 __credits__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
@@ -142,7 +141,7 @@ def timeseries_plot(data, gps, span, channel, output, ylabel=None,
     ax.set_yscale('linear')
     ax.set_ylabel(ylabel)
     # set title
-    title = r'$\mathtt{%s}$ at %.3f' % (texify(channel), gps)
+    title = r'$\mathtt{%s}$ at %.3f' % (label_to_latex(channel), gps)
     ax.set_title(title, y=1.1)
     # save plot and close
     plot.savefig(output, bbox_inches='tight')
@@ -207,7 +206,7 @@ def spectral_plot(data, gps, span, channel, output, colormap='viridis',
     _format_color_axis(ax, colormap=colormap, clim=clim, norm=norm)
     # set title
     title = (r'$\mathtt{%s}$ at %.3f with $Q$ of %.1f'
-             % (texify(channel), gps, Q))
+             % (label_to_latex(channel), gps, Q))
     ax.set_title(title, y=1.05)
     # save plot and close
     plot.savefig(output, bbox_inches='tight')

--- a/share/sass/gwdetchar.scss
+++ b/share/sass/gwdetchar.scss
@@ -58,7 +58,7 @@ img {
 				color:white;
 		}
 		.navbar-brand {
-				font-size:16px;
+				font-size: 16px;
 		}
 		.ifo-links  {
 				.dropdown-header {

--- a/share/sass/gwdetchar.scss
+++ b/share/sass/gwdetchar.scss
@@ -18,8 +18,9 @@
  */
 
 body {
-		font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+		font-family: 'Roboto', sans-serif;
 		font-weight: 300;
+		-webkit-font-smoothing: antialiased;
 }
 
 h1, h2, h3, h4, h5, h6 {
@@ -52,12 +53,10 @@ img {
 		.navbar-text,
 		.navbar-nav > li > a,
 		.navbar-nav > li.disabled > a {
-				font-family: Tahoma, Geneva, sans-serif;
-				font-weight: 500;
-				font-size: 14px;
-		}
-		.navbar-brand {
-				font-size: 16px;
+				font-family: 'Roboto', sans-serif;
+				font-size:16px;
+				font-weight:400;
+				color:white
 		}
 		.ifo-links  {
 				.dropdown-header {

--- a/share/sass/gwdetchar.scss
+++ b/share/sass/gwdetchar.scss
@@ -75,6 +75,11 @@ img {
 		}
 }
 
+.footer {
+		color: white;
+		font-weight: 400;
+}
+
 .dropdown-1-col {
 		white-space: nowrap;
 		max-height: 700px;

--- a/share/sass/gwdetchar.scss
+++ b/share/sass/gwdetchar.scss
@@ -56,6 +56,7 @@ img {
 				font-size:15px;
 				font-weight:400;
 				color:white;
+				-webkit-font-smoothing: antialiased;
 		}
 		.navbar-brand {
 				font-size: 16px;

--- a/share/sass/gwdetchar.scss
+++ b/share/sass/gwdetchar.scss
@@ -56,7 +56,7 @@ img {
 				font-family: 'Roboto', sans-serif;
 				font-size:16px;
 				font-weight:400;
-				color:white
+				color:white;
 		}
 		.ifo-links  {
 				.dropdown-header {

--- a/share/sass/gwdetchar.scss
+++ b/share/sass/gwdetchar.scss
@@ -18,16 +18,11 @@
  */
 
 body {
-		font-family: 'Roboto', sans-serif;
+		font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
 		font-weight: 300;
-		-webkit-font-smoothing: antialiased;
 }
 
-h2, h3, h4, h5, h6 {
-		font-weight: 400;
-}
-
-h1 {
+h1, h2, h3, h4, h5, h6 {
 		font-weight: 300;
 }
 
@@ -58,9 +53,12 @@ img {
 		.navbar-nav > li > a,
 		.navbar-nav > li.disabled > a {
 				font-family: 'Roboto', sans-serif;
-				font-size:16px;
+				font-size:15px;
 				font-weight:400;
 				color:white;
+		}
+		.navbar-brand {
+				font-size:16px;
 		}
 		.ifo-links  {
 				.dropdown-header {
@@ -73,11 +71,6 @@ img {
 						right: 0;
 				}
 		}
-}
-
-.footer {
-		color: white;
-		font-weight: 400;
 }
 
 .dropdown-1-col {

--- a/share/sass/gwdetchar.scss
+++ b/share/sass/gwdetchar.scss
@@ -23,7 +23,11 @@ body {
 		-webkit-font-smoothing: antialiased;
 }
 
-h1, h2, h3, h4, h5, h6 {
+h2, h3, h4, h5, h6 {
+		font-weight: 400;
+}
+
+h1 {
 		font-weight: 300;
 }
 


### PR DESCRIPTION
This PR uses the Roboto font to render HTML, and restores the use of `\mathtt{}` to render channel names for omega scans.

cc @duncanmmacleod 