### PR TITLE
Include a top-of-page button for ease of navigation

### DIFF
--- a/gwdetchar/io/html.py
+++ b/gwdetchar/io/html.py
@@ -323,10 +323,10 @@ def new_bootstrap_page(base=os.path.curdir, path=os.path.curdir, lang='en',
     page.head.close()
     # open body and container
     page.body()
-    if navbar is not None:
-        page.add(navbar)
     page.button('Top', title='Return to top',
                 onclick='topScroll()', id_='topBtn')
+    if navbar is not None:
+        page.add(navbar)
     page.div(class_='container')
     return page
 

--- a/gwdetchar/io/html.py
+++ b/gwdetchar/io/html.py
@@ -325,6 +325,8 @@ def new_bootstrap_page(base=os.path.curdir, path=os.path.curdir, lang='en',
     page.body()
     if navbar is not None:
         page.add(navbar)
+    page.button('Top', title='Return to top',
+                onclick='topScroll()', id_='topBtn')
     page.div(class_='container')
     return page
 

--- a/gwdetchar/io/html.py
+++ b/gwdetchar/io/html.py
@@ -267,7 +267,7 @@ def finalize_static_urls(static, base, cssfiles, jsfiles):
 
 
 def new_bootstrap_page(base=os.path.curdir, path=os.path.curdir, lang='en',
-                       refresh=False, navbar=None, **kwargs):
+                       refresh=False, topbtn=True, navbar=None, **kwargs):
     """Create a new `~markup.page` with custom twitter bootstrap CSS and
     JS headers
 
@@ -284,6 +284,10 @@ def new_bootstrap_page(base=os.path.curdir, path=os.path.curdir, lang='en',
 
     refresh : `bool`, optional
         boolean switch to enable periodic page refresh, default: False
+
+    topbtn : `bool`, optional
+        boolean switch to include or exclude a floating button that scrolls
+        to the top of the page, default: True
 
     navbar : `str`, optional
         HTML enconding of a floating navbar, will be ignored if not given,
@@ -323,8 +327,9 @@ def new_bootstrap_page(base=os.path.curdir, path=os.path.curdir, lang='en',
     page.head.close()
     # open body and container
     page.body()
-    page.button('Top', title='Return to top',
-                onclick='topScroll()', id_='topBtn')
+    if topbtn:
+        page.button('Top', title='Return to top',
+                    onclick='topScroll()', id_='topBtn')
     if navbar is not None:
         page.add(navbar)
     page.div(class_='container')

--- a/gwdetchar/io/html.py
+++ b/gwdetchar/io/html.py
@@ -328,8 +328,8 @@ def new_bootstrap_page(base=os.path.curdir, path=os.path.curdir, lang='en',
     # open body and container
     page.body()
     if topbtn:
-        page.button('Top', title='Return to top',
-                    onclick='topScroll()', id_='topBtn')
+        page.button('&#8679;', title='Return to top', id_='topBtn',
+                    onclick='$("#topBtn").scrollView();')
     if navbar is not None:
         page.add(navbar)
     page.div(class_='container')

--- a/gwdetchar/io/tests/test_html.py
+++ b/gwdetchar/io/tests/test_html.py
@@ -71,6 +71,7 @@ NEW_BOOTSTRAP_PAGE = """<!DOCTYPE HTML>
 <script src="static/gwdetchar.min.js" type="text/javascript"></script>
 </head>
 <body>
+<button onclick="topScroll()" id="topBtn" title="Return to top">Top</button>
 <div class="container">
 </body>
 </html>"""  # nopep8

--- a/gwdetchar/io/tests/test_html.py
+++ b/gwdetchar/io/tests/test_html.py
@@ -71,7 +71,6 @@ NEW_BOOTSTRAP_PAGE = """<!DOCTYPE HTML>
 <script src="static/gwdetchar.min.js" type="text/javascript"></script>
 </head>
 <body>
-<button onclick="$("#topBtn").scrollView();" id="topBtn" title="Return to top">&#8679;</button>
 <div class="container">
 </body>
 </html>"""  # nopep8
@@ -252,7 +251,7 @@ def test_finalize_static_urls(tmpdir):
 
 def test_new_bootstrap_page():
     base = os.path.abspath(os.path.curdir)
-    page = html.new_bootstrap_page(base=base, refresh=True)
+    page = html.new_bootstrap_page(base=base, topbtn=False, refresh=True)
     assert parse_html(str(page)) == parse_html(
         NEW_BOOTSTRAP_PAGE.format(base=base))
 

--- a/gwdetchar/io/tests/test_html.py
+++ b/gwdetchar/io/tests/test_html.py
@@ -71,7 +71,7 @@ NEW_BOOTSTRAP_PAGE = """<!DOCTYPE HTML>
 <script src="static/gwdetchar.min.js" type="text/javascript"></script>
 </head>
 <body>
-<button onclick="topScroll()" id="topBtn" title="Return to top">Top</button>
+<button onclick="topScroll()" id="topBtn" title="Return to top">&#8679;</button>
 <div class="container">
 </body>
 </html>"""  # nopep8

--- a/gwdetchar/io/tests/test_html.py
+++ b/gwdetchar/io/tests/test_html.py
@@ -71,7 +71,7 @@ NEW_BOOTSTRAP_PAGE = """<!DOCTYPE HTML>
 <script src="static/gwdetchar.min.js" type="text/javascript"></script>
 </head>
 <body>
-<button onclick="topScroll()" id="topBtn" title="Return to top">&#8679;</button>
+<button onclick="$("#topBtn").scrollView();" id="topBtn" title="Return to top">&#8679;</button>
 <div class="container">
 </body>
 </html>"""  # nopep8

--- a/gwdetchar/omega/html.py
+++ b/gwdetchar/omega/html.py
@@ -467,16 +467,6 @@ def write_block(blockkey, block, context,
     page.div(class_='panel well panel-%s' % context)
     # -- make heading
     page.div(class_='panel-heading clearfix')
-    # link to top of page
-    page.div(class_='pull-right')
-    if context == 'primary':
-        page.a("<small>[top]</small>", href='#', class_='text-light')
-    elif context == 'default':
-        page.a("<small>[top]</small>", href='#', class_='text-dark')
-    else:
-        page.a("<small>[top]</small>", href='#', class_='text-%s' % context)
-    page.div.close()  # pull-right
-    # heading
     page.h3(': '.join([blockkey, block['name']]), class_='panel-title')
     page.div.close()  # panel-heading
 

--- a/gwdetchar/omega/tests/test_html.py
+++ b/gwdetchar/omega/tests/test_html.py
@@ -145,9 +145,6 @@ for channel in ANALYZED['GW']['channels']:
 
 BLOCK_HTML = """<div class="panel well panel-info">
 <div class="panel-heading clearfix">
-<div class="pull-right">
-<a href="#" class="text-info"><small>[top]</small></a>
-</div>
 <h3 class="panel-title">GW: Gravitational-Wave Strain</h3>
 </div>
 <ul class="list-group">

--- a/share/js/gwdetchar.js
+++ b/share/js/gwdetchar.js
@@ -17,6 +17,21 @@
  * along with GWDetChar.  If not, see <http://www.gnu.org/licenses/>
  */
 
+window.onscroll = function() {scrollAction()};
+
+function scrollAction() {
+  if (document.body.scrollTop > 20 || document.documentElement.scrollTop > 20) {
+    document.getElementById("topBtn").style.display = "block";
+  } else {
+    document.getElementById("topBtn").style.display = "none";
+  }
+}
+
+function topScroll() {
+  document.body.scrollTop = 0; // Safari
+  document.documentElement.scrollTop = 0; // Chrome, Firefox, IE and Opera
+}
+
 // expand fancybox plots
 $(document).ready(function() {
   $(".fancybox").fancybox({

--- a/share/js/gwdetchar.js
+++ b/share/js/gwdetchar.js
@@ -18,16 +18,6 @@
  */
 
 // include a return-to-top button
-window.onscroll = function() {scrollAction()};
-
-function scrollAction() {
-  if (document.body.scrollTop > 50 || document.documentElement.scrollTop > 50) {
-    document.getElementById("topBtn").style.display = "block";
-  } else {
-    document.getElementById("topBtn").style.display = "none";
-  }
-}
-
 $.fn.scrollView = function () {
   return this.each(function () {
     $('html, body').animate({

--- a/share/js/gwdetchar.js
+++ b/share/js/gwdetchar.js
@@ -28,17 +28,33 @@ function scrollAction() {
   }
 }
 
-function topScroll() {
-  document.body.scrollTop = 0; // Safari
-  document.documentElement.scrollTop = 0; // Chrome, Firefox, IE and Opera
+$.fn.scrollView = function () {
+  return this.each(function () {
+    $('html, body').animate({
+      scrollTop: 0
+    }, 800);
+  });
 }
 
-// expand fancybox plots
+// all-document actions
 $(document).ready(function() {
+  // expand fancybox plots
   $(".fancybox").fancybox({
     nextEffect: 'none',
     prevEffect: 'none',
     helpers: {title: {type: 'inside'}}
+  });
+  // smooth scrolling on all intra-page links
+  $("a").on('click', function(event) {
+    if (this.hash !== "") {
+      event.preventDefault();
+      var hash = this.hash;
+      $("html, body").animate({
+        scrollTop: $(hash).offset().top
+      }, 800, function(){
+        window.location.hash = hash;
+      });
+    };
   });
 });
 

--- a/share/js/gwdetchar.js
+++ b/share/js/gwdetchar.js
@@ -17,10 +17,11 @@
  * along with GWDetChar.  If not, see <http://www.gnu.org/licenses/>
  */
 
+// include a return-to-top button
 window.onscroll = function() {scrollAction()};
 
 function scrollAction() {
-  if (document.body.scrollTop > 20 || document.documentElement.scrollTop > 20) {
+  if (document.body.scrollTop > 50 || document.documentElement.scrollTop > 50) {
     document.getElementById("topBtn").style.display = "block";
   } else {
     document.getElementById("topBtn").style.display = "none";

--- a/share/sass/gwdetchar.scss
+++ b/share/sass/gwdetchar.scss
@@ -124,17 +124,18 @@ img {
 		@media(min-width:992px) {
 				position: fixed;
 				bottom: 50px;
-				right: 50px;
+				right: 5%;
 				z-index: 99;
 				border-radius: 50%;
 				border: 1px solid #555;
 				outline: none;
 				cursor: pointer;
-				padding: 15px;
-				font-family: 'Roboto', sans-serif;
-				font-size: 15px;
+				padding-left: 9px;
+				padding-right: 9px;
+				-webkit-transition-duration: 0.4s; // Safari
+				transition-duration: 0.4s;
+				font-size: 32px;
 				font-weight: 400;
-				-webkit-font-smoothing: antialiased;
 				background-color: white;
 				color: #555;
 				box-shadow: 0 1px 10px rgba(0, 0, 0, 0.23), 0 1px 10px rgba(0, 0, 0, 0.16);

--- a/share/sass/gwdetchar.scss
+++ b/share/sass/gwdetchar.scss
@@ -120,8 +120,11 @@ img {
 }
 
 #topBtn {
-		display: none;
+		@media(max-width:991px) {
+				display: none;
+		}
 		@media(min-width:992px) {
+				display: block;
 				position: fixed;
 				bottom: 50px;
 				right: 5%;

--- a/share/sass/gwdetchar.scss
+++ b/share/sass/gwdetchar.scss
@@ -53,8 +53,8 @@ img {
 		.navbar-nav > li > a,
 		.navbar-nav > li.disabled > a {
 				font-family: 'Roboto', sans-serif;
-				font-size:15px;
-				font-weight:400;
+				font-size: 15px;
+				font-weight: 400;
 				-webkit-font-smoothing: antialiased;
 		}
 		.navbar-brand {
@@ -117,4 +117,29 @@ img {
 		@media(max-width:991px) {
 				display:none;
 		}
+}
+
+#topBtn {
+		display: none;
+		position: fixed;
+		bottom: 20px;
+		right: 30px;
+		z-index: 99;
+		border-radius: 50%;
+		border: 1px solid #555;
+		outline: none;
+		cursor: pointer;
+		padding: 15px;
+		font-family: 'Roboto', sans-serif;
+		font-size: 15px;
+		font-weight: 400;
+		-webkit-font-smoothing: antialiased;
+		background-color: white;
+		color: #555
+}
+
+#topBtn:hover {
+		color: white;
+		background-color: #555;
+		border: 1px solid white
 }

--- a/share/sass/gwdetchar.scss
+++ b/share/sass/gwdetchar.scss
@@ -121,25 +121,30 @@ img {
 
 #topBtn {
 		display: none;
-		position: fixed;
-		bottom: 20px;
-		right: 30px;
-		z-index: 99;
-		border-radius: 50%;
-		border: 1px solid #555;
-		outline: none;
-		cursor: pointer;
-		padding: 15px;
-		font-family: 'Roboto', sans-serif;
-		font-size: 15px;
-		font-weight: 400;
-		-webkit-font-smoothing: antialiased;
-		background-color: white;
-		color: #555
+		@media(min-width:992px) {
+				position: fixed;
+				bottom: 50px;
+				right: 50px;
+				z-index: 99;
+				border-radius: 50%;
+				border: 1px solid #555;
+				outline: none;
+				cursor: pointer;
+				padding: 15px;
+				font-family: 'Roboto', sans-serif;
+				font-size: 15px;
+				font-weight: 400;
+				-webkit-font-smoothing: antialiased;
+				background-color: white;
+				color: #555;
+				box-shadow: 0 1px 10px rgba(0, 0, 0, 0.23), 0 1px 10px rgba(0, 0, 0, 0.16);
+		}
 }
 
 #topBtn:hover {
-		color: white;
-		background-color: #555;
-		border: 1px solid white
+		@media(min-width:992px) {
+				color: white;
+				background-color: #555;
+				border: 1px solid white;
+		}
 }

--- a/share/sass/gwdetchar.scss
+++ b/share/sass/gwdetchar.scss
@@ -127,7 +127,7 @@ img {
 				display: block;
 				position: fixed;
 				bottom: 20px;
-				right: 5%;
+				right: 20px;
 				z-index: 99;
 				border-radius: 50%;
 				border: 1px solid #555;

--- a/share/sass/gwdetchar.scss
+++ b/share/sass/gwdetchar.scss
@@ -126,7 +126,7 @@ img {
 		@media(min-width:992px) {
 				display: block;
 				position: fixed;
-				bottom: 50px;
+				bottom: 20px;
 				right: 5%;
 				z-index: 99;
 				border-radius: 50%;


### PR DESCRIPTION
This PR adds a sticky go-to-top-of-page button on all HTML output. The button is fixed to the lower-right corner of the page, appears only after scrolling down, is color-coded to match the HTML footer, and inverts its colors on hover. Changes include HTML, CSS, and JS.

A related change is to remove explicit links to the top of the page, particularly from panel headers in omega scan pages.

Example output is available for an [**omega scan**](https://ldas-jobs.ligo.caltech.edu/~alexander.urban/wdq/Network_1187008882.0/) and the [**summary pages**](https://ldas-jobs.ligo.caltech.edu/~alexander.urban/summary/testing/1242522018-1242526618/).

cc @duncanmmacleod, @areeda 