### PR TITLE
Define a CSS class, rather than an ID reference

### DIFF
--- a/gwdetchar/io/html.py
+++ b/gwdetchar/io/html.py
@@ -328,7 +328,7 @@ def new_bootstrap_page(base=os.path.curdir, path=os.path.curdir, lang='en',
     # open body and container
     page.body()
     if topbtn:
-        page.button('&#8679;', title='Return to top', id_='topBtn',
+        page.button('&#8679;', title='Return to top', class_='btn-float',
                     onclick='$("#topBtn").scrollView();')
     if navbar is not None:
         page.add(navbar)

--- a/gwdetchar/io/html.py
+++ b/gwdetchar/io/html.py
@@ -329,7 +329,7 @@ def new_bootstrap_page(base=os.path.curdir, path=os.path.curdir, lang='en',
     page.body()
     if topbtn:
         page.button('&#8679;', title='Return to top', class_='btn-float',
-                    onclick='$("#topBtn").scrollView();')
+                    id_='topBtn', onclick='$("#topBtn").scrollView();')
     if navbar is not None:
         page.add(navbar)
     page.div(class_='container')

--- a/share/sass/gwdetchar.scss
+++ b/share/sass/gwdetchar.scss
@@ -114,30 +114,37 @@ img {
 }
 
 .btn-float {
-		display: block;
-		position: fixed;
-		bottom: 20px;
-		right: 20px;
-		z-index: 99;
-		border-radius: 50%;
-		border: 1px solid #555;
-		outline: none;
-		cursor: pointer;
-		padding-left: 9px;
-		padding-right: 9px;
-		-webkit-transition-duration: 0.4s; // Safari
-		transition-duration: 0.4s;
-		font-size: 32px;
-		font-weight: 400;
-		background-color: white;
-		color: #555;
-		box-shadow: 0 1px 10px rgba(0, 0, 0, 0.23), 0 1px 10px rgba(0, 0, 0, 0.16);
+		@media(max-width:991px) {
+				display:none;
+        }
+		@media(min-width:992px) {
+				display: block;
+				position: fixed;
+				bottom: 20px;
+				right: 20px;
+				z-index: 99;
+				border-radius: 50%;
+				border: 1px solid #555;
+				outline: none;
+				cursor: pointer;
+				padding-left: 9px;
+				padding-right: 9px;
+				-webkit-transition-duration: 0.4s; // Safari
+				transition-duration: 0.4s;
+				font-size: 32px;
+				font-weight: 400;
+				background-color: white;
+				color: #555;
+				box-shadow: 0 1px 10px rgba(0, 0, 0, 0.23), 0 1px 10px rgba(0, 0, 0, 0.16);
+		}
 }
 
 .btn-float:hover {
-		color: white;
-		background-color: #555;
-		border: 1px solid white;
+		@media(min-width:992px) {
+				color: white;
+				background-color: #555;
+				border: 1px solid white;
+		}
 }
 
 .desktop-only {

--- a/share/sass/gwdetchar.scss
+++ b/share/sass/gwdetchar.scss
@@ -113,42 +113,35 @@ img {
 		margin-bottom: 15px;
 }
 
+.btn-float {
+		display: block;
+		position: fixed;
+		bottom: 20px;
+		right: 20px;
+		z-index: 99;
+		border-radius: 50%;
+		border: 1px solid #555;
+		outline: none;
+		cursor: pointer;
+		padding-left: 9px;
+		padding-right: 9px;
+		-webkit-transition-duration: 0.4s; // Safari
+		transition-duration: 0.4s;
+		font-size: 32px;
+		font-weight: 400;
+		background-color: white;
+		color: #555;
+		box-shadow: 0 1px 10px rgba(0, 0, 0, 0.23), 0 1px 10px rgba(0, 0, 0, 0.16);
+}
+
+.btn-float:hover {
+		color: white;
+		background-color: #555;
+		border: 1px solid white;
+}
+
 .desktop-only {
 		@media(max-width:991px) {
 				display:none;
-		}
-}
-
-#topBtn {
-		@media(max-width:991px) {
-				display: none;
-		}
-		@media(min-width:992px) {
-				display: block;
-				position: fixed;
-				bottom: 20px;
-				right: 20px;
-				z-index: 99;
-				border-radius: 50%;
-				border: 1px solid #555;
-				outline: none;
-				cursor: pointer;
-				padding-left: 9px;
-				padding-right: 9px;
-				-webkit-transition-duration: 0.4s; // Safari
-				transition-duration: 0.4s;
-				font-size: 32px;
-				font-weight: 400;
-				background-color: white;
-				color: #555;
-				box-shadow: 0 1px 10px rgba(0, 0, 0, 0.23), 0 1px 10px rgba(0, 0, 0, 0.16);
-		}
-}
-
-#topBtn:hover {
-		@media(min-width:992px) {
-				color: white;
-				background-color: #555;
-				border: 1px solid white;
 		}
 }


### PR DESCRIPTION
This PR introduces a CSS class for floating buttons (`btn-float`), rather than reference a specific object ID. It also displays the newly-introduced scroll-to-top button (#335) on mobile devices.

cc @duncanmmacleod 