### PR TITLE
Bugfixes for scattering HTML

### DIFF
--- a/bin/gwdetchar-scattering
+++ b/bin/gwdetchar-scattering
@@ -532,10 +532,10 @@ for i, channel in enumerate(sorted(osems)):
         continue
     page.div(class_='panel panel-%s' % context)
     page.div(class_='panel-heading')
-    page.a(channel, class_="panel-title", href='#flag%s' % i,
+    page.a(channel, class_="panel-title", href='#osem%s' % i,
            **{'data-toggle': 'collapse', 'data-parent': '#accordion'})
     page.div.close()
-    page.div(id_='flag%s' % i, class_='panel-collapse collapse')
+    page.div(id_='osem%s' % i, class_='panel-collapse collapse')
     img = htmlio.FancyPlot(
         png, caption=scattering.SCATTER_CAPTION.format(CHANNEL=channel))
     page.add(htmlio.fancybox_img(img))

--- a/bin/gwdetchar-scattering
+++ b/bin/gwdetchar-scattering
@@ -437,7 +437,7 @@ for i, channel in enumerate(sorted(osems)):
     name = texify(channel)
     axes['position'].set_title("Scattering evidence in %s" % name)
     axes['position'].set_xlabel('')
-    axes['position'].set_ylabel(r'Position [\textmu m]')
+    axes['position'].set_ylabel(r'Position [$\mu$m]')
     axes['position'].text(
         0.01, 0.95, 'Optic position',
         transform=axes['position'].transAxes, va='top', ha='left',

--- a/share/js/gwdetchar.js
+++ b/share/js/gwdetchar.js
@@ -34,19 +34,6 @@ $(document).ready(function() {
     prevEffect: 'none',
     helpers: {title: {type: 'inside'}}
   });
-  // smooth scrolling on all intra-page links
-  $("a").on('click', function(event) {
-    if (this.hash !== "") {
-      event.preventDefault();
-      var hash = this.hash;
-      $("html, body").animate({
-        scrollTop: $(hash).offset().top
-      }, 800, function(){
-        window.location.hash = hash;
-      });
-    };
-  });
-});
 
 // expose alternative image types
 function showImage(channelName, tRanges, imageType, captions) {

--- a/share/js/gwdetchar.js
+++ b/share/js/gwdetchar.js
@@ -33,7 +33,7 @@ $(document).ready(function() {
     prevEffect: 'none',
     helpers: {title: {type: 'inside'}}
   });
-}
+});
 
 // expose alternative image types
 function showImage(channelName, tRanges, imageType, captions) {
@@ -47,7 +47,7 @@ function showImage(channelName, tRanges, imageType, captions) {
       "plots/" + fileBase + ".png";
     document.getElementById("img_" + idBase).alt = fileBase + ".png";
   };
-};
+}
 
 // download a CSV table
 function downloadCSV(csv, filename) {

--- a/share/js/gwdetchar.js
+++ b/share/js/gwdetchar.js
@@ -26,14 +26,14 @@ $.fn.scrollView = function () {
   });
 }
 
-// all-document actions
+// expand fancybox plots
 $(document).ready(function() {
-  // expand fancybox plots
   $(".fancybox").fancybox({
     nextEffect: 'none',
     prevEffect: 'none',
     helpers: {title: {type: 'inside'}}
   });
+}
 
 // expose alternative image types
 function showImage(channelName, tRanges, imageType, captions) {


### PR DESCRIPTION
This PR implements a couple of bugfixes discovered after testing with #342:

* Uniquely name all HTML panel objects
* Do not animate scrolling for all links, since it affects the way panels open and close

Test output is available [**here**](https://ldas-jobs.ligo-la.caltech.edu/~aurban/scattering/day/20190514/).

Thanks to @siddharth101 for reporting the first issue.

cc @duncanmmacleod