### PR TITLE
Add a utility to construct a bootstrap alert box

### DIFF
--- a/bin/gwdetchar-overflow
+++ b/bin/gwdetchar-overflow
@@ -41,6 +41,8 @@ from gwdetchar.io.datafind import get_data
 from gwdetchar.utils import table_from_segments
 
 SITE_MAP = {
+    'H1': 'LIGO-Hanford',
+    'L1': 'LIGO-Livingston',
     'K1': 'KAGRA',
     'V1': 'Virgo',
 }
@@ -242,8 +244,13 @@ if args.html:
         args.output_file = os.path.relpath(
             args.output_file, os.path.dirname(args.html))
     if os.path.basename(args.html) == 'index.html':
-        links = [(s, '#%s' % s.lower())
-                 for s in ['Parameters', 'Segments', 'Results']]
+        links = [
+            ('Parameters', '#parameters'),
+            ('Segments', [('Overflows', '#overflows')]),
+            ('Results', '#results'),
+        ]
+        if args.state_flag:
+            links[1][1].insert(0, ('State flag', '#state-flag'))
         (brand, class_) = htmlio.get_brand(args.ifo, 'Overflows',
                                            args.gpsstart)
         navbar = htmlio.navbar(links, class_=class_, brand=brand)
@@ -259,14 +266,6 @@ if args.html:
     page.div(class_='page-header')
     page.h1('%s ADC/DAC Overflows: %d-%d'
             % (args.ifo, int(args.gpsstart), int(args.gpsend)))
-    page.p("This analysis searched for digital-to-analogue (DAC) or "
-           "analogue-to-digital (ADC) conversion overflows in the {0} "
-           "real-time controls system.".format(SITE_MAP.get(args.ifo, 'LIGO')))
-    if args.deep:
-        page.p("A hierarchichal search was performed, with a single "
-               "cumulative overflow counter checked per front-end controller "
-               "(FEC); for those models that indicate an overflow, the "
-               "card/slot-specific channels were then checked.")
     page.div.close()
 
     # -- paramters
@@ -287,9 +286,24 @@ if args.html:
                                    simulink, args.ifo)))
     page.add(htmlio.write_arguments(
         content, start=args.gpsstart, end=args.gpsend, flag=args.state_flag))
+    page.add('<hr class="row-divider">')
 
     # -- segments
     page.h2('Segments', id_='segments')
+    # give contextual information
+    msg = ["This analysis searched for digital-to-analogue (DAC) or "
+           "analogue-to-digital (ADC) conversion overflows in the {0} "
+           "real-time controls system.".format(
+               SITE_MAP.get(args.ifo, 'LIGO')),]
+    if args.deep:
+        msg.append("A hierarchichal search was performed, with one cumulative "
+                   "overflow counter checked per front-end controller "
+                   "(FEC). For those models that indicated an overflow, the "
+                   "card- and slot-specific channels were then checked.")
+    msg.append("Consant overflow is shown as yellow, while transient overflow "
+               "is shown as red. If a data-quality flag was loaded for this "
+               "analysis, it will be displayed in green.")
+    page.add(htmlio.alert(msg))
     # link XML file
     if args.output_file:
         page.p()
@@ -299,7 +313,7 @@ if args.html:
         page.p.close()
     # record state segments
     if args.state_flag:
-        page.p('This analysis was done over the following data-quality flag:')
+        page.h3('State flag', id_='state-flag')
         page.div(class_='panel-group', id_='accordion1')
         page.add(htmlio.write_flag_html(
             state, span, 'state', parent='accordion1', context='success',
@@ -309,8 +323,6 @@ if args.html:
         page.div.close()
     # record overflow segments
     if sum(abs(s.active) for s in overflows.values()):
-        page.p('The following channels indicated an overflow (constant '
-               'overflow is yellow, otherwise red):')
         page.div(class_='panel-group', id_='accordion2')
         for i, (c, flag) in enumerate(list(overflows.items())):
             if abs(flag.active) == 0:
@@ -332,6 +344,7 @@ if args.html:
     else:
         page.add(htmlio.alert('No overflows were found in this analysis',
                               dismiss=False))
+    page.add('<hr class="row-divider">')
 
     # -- results table
     page.h2('Results summary', id_='results')

--- a/bin/gwdetchar-overflow
+++ b/bin/gwdetchar-overflow
@@ -323,6 +323,7 @@ if args.html:
         page.div.close()
     # record overflow segments
     if sum(abs(s.active) for s in overflows.values()):
+        page.h3('Overflows', id_='overflows')
         page.div(class_='panel-group', id_='accordion2')
         for i, (c, flag) in enumerate(list(overflows.items())):
             if abs(flag.active) == 0:

--- a/bin/gwdetchar-overflow
+++ b/bin/gwdetchar-overflow
@@ -330,9 +330,8 @@ if args.html:
                 context=context, plotdir=args.plot))
         page.div.close()
     else:
-        page.div(class_='alert alert-info')
-        page.p('No overflows were found')
-        page.div.close()
+        page.add(htmlio.alert('No overflows were found in this analysis',
+                              dismiss=False))
 
     # -- results table
     page.h2('Results summary', id_='results')

--- a/bin/gwdetchar-scattering
+++ b/bin/gwdetchar-scattering
@@ -659,7 +659,7 @@ actives = actives.coalesce()  # merge contiguous segments
 if statea and not actives:
     page.add(htmlio.alert(
         'No evidence of scattering found in the channels analyzed',
-        dismiss=False)
+        dismiss=False))
 page.add('<hr class="row-divider">')
 
 # identify triggers during active segments

--- a/bin/gwdetchar-scattering
+++ b/bin/gwdetchar-scattering
@@ -269,7 +269,7 @@ page.button.close()
 page.ul(class_='dropdown-menu', role='menu',
         **{'aria-labelledby': 'summary_table_download'})
 for text, path in zip(
-    ['Segments', 'Triggers'],
+    ['Segments (HDF)', 'Triggers (CSV)'],
     [segfile, summfile]
 ):
     page.li(markup.oneliner.a(text, href=path, download=path))
@@ -280,24 +280,22 @@ page.div.close()  # btn-group
 page.h2('Segments', id_='segments')
 
 if statea:  # contextual information
-    page.div(class_='alert alert-info')
     paper = markup.oneliner.a(
         'Accadia et al. (2010)', target='_blank', class_='alert-link',
         href='http://iopscience.iop.org/article/10.1088/0264-9381/27'
              '/19/194011')
-    page.p("Segments marked \"optical sensors\" below show evidence of beam "
+    msg = ("Segments marked \"optical sensors\" below show evidence of beam "
            "scattering between {0} and {1} Hz based on the velocity of optic "
            "motion, with fringe frequencies projected using equation (3) of "
            "{2}. Segments marked \"transmons\" are based on whitened, "
            "band-limited RMS trends of transmon sensors. In both cases, "
            "yellow panels denote weak evidence for scattering, while red "
-           "panels denote strong evidence.".format(
-               args.fmin, multiplier * args.frequency_threshold, str(paper)))
-    page.div.close()  # alert alert-info
+           "panels denote strong evidence.").format(
+               args.fmin, multiplier * args.frequency_threshold, str(paper))
+    page.add(htmlio.alert(msg))
 else:  # null segments
-    page.div(class_='alert alert-warning')
-    page.p('No active analysis segments were found')
-    page.div.close()
+    page.add(htmlio.alert('No active analysis segments were found',
+                          context='warning', dismiss=False))
 
 # record state segments
 if args.state_flag is not None:
@@ -658,10 +656,10 @@ if statea:  # close accordion
     page.div.close()
 
 actives = actives.coalesce()  # merge contiguous segments
-if not actives:
-    page.div(class_='alert alert-info')
-    page.p('No evidence of scattering found in the channels analyzed')
-    page.div.close()
+if statea and not actives:
+    page.add(htmlio.alert(
+        'No evidence of scattering found in the channels analyzed',
+        dismiss=False)
 page.add('<hr class="row-divider">')
 
 # identify triggers during active segments
@@ -700,14 +698,12 @@ if nscans > 0:
     logger.info('Launched {} omega scans to condor'.format(nscans))
     # render HTML
     page.h2('Omega scans', id_='omega-scans')
-    page.div(class_='alert alert-default')
-    page.p('The following event times correspond to significant Omicron '
+    msg = ('The following event times correspond to significant Omicron '
            'triggers that occur during the scattering segments found above. '
            'To compare these against fringe frequency projections, please '
-           'use the scattering module:')
-    code = markup.oneliner.pre('$ python -m gwdetchar.scattering --help')
-    page.p(code)
-    page.div.close()  # alert alert-default
+           'use the scattering module:',
+           markup.oneliner.pre('$ python -m gwdetchar.scattering --help'))
+    page.add(htmlio.alert(msg, context='default'))
     page.add(htmlio.scaffold_omega_scans(
         omegatimes, args.main_channel, scandir=scandir))
 elif args.omega_scans:

--- a/bin/gwdetchar-software-saturations
+++ b/bin/gwdetchar-software-saturations
@@ -257,9 +257,8 @@ if args.html:
                     plotdir=args.plot))
         page.div.close()
     else:
-        page.div(class_='alert alert-info')
-        page.p('No software saturations were found')
-        page.div.close()
+        page.add(htmlio.alert('No software saturations were found in this '
+                              'analysis', dismiss=False))
     # -- results table
     page.h2('Results summary', id_='results')
     page.table(class_='table table-striped table-hover')

--- a/bin/gwdetchar-software-saturations
+++ b/bin/gwdetchar-software-saturations
@@ -202,8 +202,13 @@ if args.html:
         args.plot = base
     segfile = os.path.relpath(outfile, os.path.dirname(args.html))
     if os.path.basename(args.html) == 'index.html':
-        links = [(s, '#%s' % s.lower())
-                 for s in ['Parameters', 'Segments', 'Results']]
+        links = [
+            ('Parameters', '#parameters'),
+            ('Segments', [('Software saturations', '#software-saturations')]),
+            ('Results', '#results'),
+        ]
+        if args.state_flag:
+            links[1][1].insert(0, ('State flag', '#state-flag'))
         (brand, class_) = htmlio.get_brand(ifo, 'Software Saturations',
                                            args.gpsstart)
         navbar = htmlio.navbar(links, class_=class_, brand=brand)
@@ -215,12 +220,6 @@ if args.html:
     page.div(class_='page-header')
     page.h1('%s Software Saturations: %d-%d'
             % (ifo, int(args.gpsstart), int(args.gpsend)))
-    page.p("This analysis searched %d channels for times during which their "
-           "OUTPUT value matched the LIMIT value set in software. Only "
-           "those signals achieving saturation are recorded in the Segments "
-           "section below, while all channels for which the LIMIT was active "
-           "are included in the Results summary and the output file."
-           % sum(map(len, channels)))
     page.div.close()
     # -- paramters
     content = [
@@ -228,8 +227,15 @@ if args.html:
         ('Skip', ', '.join(map(repr, args.skip)))]
     page.add(htmlio.write_arguments(
         content, start=args.gpsstart, end=args.gpsend, flag=args.state_flag))
+    page.add('<hr class="row-divider">')
     # -- segments
     page.h2('Segments', id_='segments')
+    msg = ("This analysis searched {0} filter bank readback channels for "
+           "time periods during which their OUTPUT value matched or exceeded "
+           "the LIMIT value set in software. Signals that achieve saturation "
+           "are shown below, and saturation segments are available by "
+           "expanding a given panel.").format(sum(map(len, channels)))
+    page.add(htmlio.alert(msg))
     # link output file
     page.p()
     page.add('Full output segments are recorded in HDF5 format here:')
@@ -237,7 +243,7 @@ if args.html:
     page.p.close()
     # record state segments
     if args.state_flag:
-        page.p('This analysis was done over the following data-quality flag:')
+        page.h3('State flag', id_='state-flag')
         page.div(class_='panel-group', id_='accordion1')
         page.add(htmlio.write_flag_html(
             state, span, 'state', parent='accordion1', context='success',
@@ -247,7 +253,7 @@ if args.html:
         page.div.close()
     # record saturation segments
     if len(bad):
-        page.p('The following channels indicated a software saturation:')
+        page.h3('Software saturations', id_='software-saturations')
         page.div(class_='panel-group', id_='accordion2')
         for i, (c, flag) in enumerate(saturations.items()):
             if abs(flag.active) > 0:
@@ -259,8 +265,11 @@ if args.html:
     else:
         page.add(htmlio.alert('No software saturations were found in this '
                               'analysis', dismiss=False))
+    page.add('<hr class="row-divider">')
     # -- results table
     page.h2('Results summary', id_='results')
+    page.add(htmlio.alert("All channels for which the LIMIT setting was "
+                          "active are shown below."))
     page.table(class_='table table-striped table-hover')
     # write table header
     page.thead()

--- a/gwdetchar/io/html.py
+++ b/gwdetchar/io/html.py
@@ -858,8 +858,9 @@ def alert(text, context='info', dismiss=True):
 
     Parameters
     ----------
-    text : `str`
-        text to enclose within the box
+    text : `str` or `list` of `str`
+        text to enclose within the box, if a `list` then each item will
+        be rendered in a separate `<p>` tag
 
     context : `str`, optional
         Bootstrap context type, default: ``info``
@@ -874,6 +875,7 @@ def alert(text, context='info', dismiss=True):
         the rendered dialog box object
     """
     page = markup.page()
+    text = (text,) if isinstance(text, str) else text
     class_ = ('alert alert-{} alert-dismissable'.format(context) if
               dismiss else 'alert alert-{}'.format(context))
     page.div(class_=class_)
@@ -882,7 +884,8 @@ def alert(text, context='info', dismiss=True):
         page.span('&times;', **{'aria-hidden': "true"})
         page.span('Close', class_="sr-only")
         page.button.close()
-    page.p(text)
+    for msg in text:
+        page.p(msg)
     page.div.close()
     return page()
 

--- a/gwdetchar/io/html.py
+++ b/gwdetchar/io/html.py
@@ -234,6 +234,7 @@ def finalize_static_urls(static, base, cssfiles, jsfiles):
     -------
     cssurls : `list` of `str`
         the finalised list of CSS files
+
     jsurls : `list` of `str`
         the finalised list of javascript files
     """
@@ -292,6 +293,11 @@ def new_bootstrap_page(base=os.path.curdir, path=os.path.curdir, lang='en',
     navbar : `str`, optional
         HTML enconding of a floating navbar, will be ignored if not given,
         default: None
+
+    Returns
+    -------
+    page : `~MarkupPy.markup.page`
+        a populated HTML page object, which can be appended to as desired
     """
     # get kwargs with sensible defaults
     css = kwargs.pop('css', CSS_FILES)
@@ -649,6 +655,11 @@ def render_code(code, language):
 
     language : `str`
         language the code is written in, e.g. `'python'`
+
+    Returns
+    -------
+    code : `~MarkupPy.markup.page`
+        fully rendered command-line call
     """
     lexer = get_lexer_by_name(language, stripall=True)
     return highlight(code, lexer, FORMATTER)
@@ -822,6 +833,11 @@ def write_arguments(content, start, end, flag=None, section='Parameters',
 
     section: `str`
         name of the section, will appear as a header with an <h2> tag
+
+    Returns
+    -------
+    page : `~MarkupPy.markup.page`
+        a fully rendered list of parameters
     """
     content.insert(0, ('Start time', '{} ({})'.format(start, from_gps(start))))
     content.insert(1, ('End time', '{} ({})'.format(end, from_gps(end))))
@@ -834,6 +850,40 @@ def write_arguments(content, start, end, flag=None, section='Parameters',
         page.add(write_param(*item))
     page.add(write_param('Command-line', ''))
     page.add(get_command_line())
+    return page()
+
+
+def alert(text, context='info', dismiss=True):
+    """Enclose text within a bootstrap dialog box
+
+    Parameters
+    ----------
+    text : `str`
+        text to enclose within the box
+
+    context : `str`, optional
+        Bootstrap context type, default: ``info``
+
+    dismiss : `bool`, optional
+        boolean switch to enable (`True`) or disable (`False`) a dismiss
+        button, default: `True`
+
+    Returns
+    -------
+    page : `~MarkupPy.markup.page`
+        the rendered dialog box object
+    """
+    page = markup.page()
+    class_ = ('alert alert-{} alert-dismissable'.format(context) if
+              dismiss else 'alert alert-{}'.format(context))
+    page.div(class_=class_)
+    if dismiss:  # add close button
+        page.button(type="button", class_="close", **{'data-dismiss': "alert"})
+        page.span('&times;', **{'aria-hidden': "true"})
+        page.span('Close', class_="sr-only")
+        page.button.close()
+    page.p(text)
+    page.div.close()
     return page()
 
 
@@ -905,13 +955,47 @@ def table(headers, data, caption=None, separator='', id=None, **class_):
 def write_flag_html(flag, span=None, id=0, parent='accordion',
                     context='warning', title=None, plotdir=None,
                     plot_func=plot_segments, **kwargs):
-    """Write HTML for data quality flags
+    """Write HTML for data-quality flags
+
+    Parameters
+    ----------
+    flag : `~gwpy.segments.DataQualityFlag`
+        the flag object to represent
+
+    span : `~gwpy.sements.Segment`, optional
+        GPS start and stop time of flag duration
+
+    id : `int`, optional
+        unique identifier for the flag, default: 0
+
+    parent : `str`, optional
+        HTML identifier of the parent object, default: ``accordion``
+
+    context : `str`, optional
+        Bootstrap context type, default: ``warning``
+
+    title : `str`, optional
+        title of the flag, defaults to `flag.name`
+
+    plotdir : `str`, optional
+        path to directory containing plots, required if plotting segments
+
+    plot_func : `func`, optional
+        function used to plot segments,
+        default: `~gwdetchar.plot.plot_segments`
+
+    **kwargs : `dict`, optional
+        additional keyword arguments to `plot_func`
+
+    Returns
+    -------
+    page : `~MarkupPy.markup.page`
+        fully rendered HTML with a panel object for the flag
     """
     page = markup.page()
     page.div(class_='panel panel-%s' % context)
     page.div(class_='panel-heading')
-    if title is None:
-        title = flag.name
+    title = title or flag.name
     page.a(title, class_="panel-title", href='#flag%s' % id,
            **{'data-toggle': 'collapse', 'data-parent': '#%s' % parent})
     page.div.close()
@@ -948,6 +1032,25 @@ def write_flag_html(flag, span=None, id=0, parent='accordion',
 def scaffold_omega_scans(times, channel, plot_durations=[1, 4, 16],
                          scandir=os.path.curdir):
     """Preview a batch of omega scans in HTML
+
+    Parameters
+    ----------
+    times : `list` of `float`
+        a list of GPS times to scan
+
+    channel : `str`
+        name of the channel being scanned, e.g. ``H1:GDS-CALIB_STRAIN``
+
+    plot_durations : `list` of `int`
+        list of plot durations in seconds, default: `[1, 4, 16]`
+
+    scandir : `str`
+        path to the directory containing omega scans, default: `.`
+
+    Returns
+    -------
+    page : `~MarkupPy.markup.page`
+        rendered scaffold of omega scan plots
     """
     page = markup.page()
     page.div(class_='panel well panel-default')

--- a/gwdetchar/io/tests/test_html.py
+++ b/gwdetchar/io/tests/test_html.py
@@ -447,6 +447,16 @@ def test_write_arguments():
     assert '<strong>Command-line: </strong>' in page
 
 
+def test_alert():
+    page = html.alert('test')
+    assert parse_html(page) == parse_html(
+        '<div class="alert alert-info alert-dismissable">\n'
+        '<button type="button" class="close" data-dismiss="alert">\n'
+        '<span aria-hidden="true">&times;</span>\n'
+        '<span class="sr-only">Close</span>\n'
+        '</button>\n<p>test</p>\n</div>')
+
+
 def test_table():
     headers = ['Test']
     data = [['test']]

--- a/gwdetchar/omega/html.py
+++ b/gwdetchar/omega/html.py
@@ -319,12 +319,10 @@ def write_summary(
 
     # write alert
     if incomplete:
-        page.div(class_='row')
-        page.div(class_='alert alert-%s' % context)
-        page.p('<strong>Note</strong>: This scan is in progress, and will '
-               'auto-refresh every 60 seconds until completion.')
-        page.div.close()  # alert
-        page.div.close()  # row
+        page.add(htmlio.alert(
+            ('<strong>Note</strong>: This scan is in progress, and will '
+             'auto-refresh every 60 seconds until completion.'),
+            context=context))
     return page()
 
 
@@ -607,10 +605,7 @@ def write_null_page(reason, context='default'):
         the path of the HTML written for this analysis
     """
     page = markup.page()
-    # write alert
-    page.div(class_='alert alert-%s' % context)
-    page.p(reason)
-    page.div.close()  # alert
+    page.add(htmlio.alert(reason, context, dismiss=False))
     return page
 
 

--- a/gwdetchar/omega/tests/test_html.py
+++ b/gwdetchar/omega/tests/test_html.py
@@ -285,10 +285,13 @@ def test_write_summary():
             'csv</a></li>\n'
         '<li><a href="data/summary.tex" download="L1_0_summary.tex">'
             'tex</a></li>\n'
-        '</ul>\n</div>\n</div>\n</div>\n<div class="row">\n'
-        '<div class="alert alert-default">\n<p><strong>Note</strong>: '
-            'This scan is in progress, and will auto-refresh every 60 seconds '
-            'until completion.</p>\n</div>\n</div>'
+        '</ul>\n</div>\n</div>\n</div>\n'
+        '<div class="alert alert-default alert-dismissable">\n'
+        '<button type="button" class="close" data-dismiss="alert">\n'
+        '<span aria-hidden="true">&times;</span>\n'
+        '<span class="sr-only">Close</span>\n'
+        '</button>\n<p><strong>Note</strong>: This scan is in progress, and '
+        'will auto-refresh every 60 seconds until completion.</p>\n</div>'
     )
     assert h1 == h2
 


### PR DESCRIPTION
This PR adds a utility, `gwdetchar.io.html.alert`, which constructs a bootstrap dialog box of the given `context`. This utility optionally adds a button to dismiss the dialog box when it shows up in a web browser.

This PR also includes:
* Unit test for the new utility
* Round out docstrings for all other utilities in the `io.html` module
* Update references to alert box div classes across gwdetchar
* Tidy up paragraph-style text across all scripts so that it stays mostly confined to dismissible dialog boxes

cc @duncanmmacleod 