### PR TITLE
Update to bootstrap-3.3.4, fancybox-3.5.7, and jquery-3.4.1

### DIFF
--- a/gwdetchar/io/html.py
+++ b/gwdetchar/io/html.py
@@ -127,56 +127,45 @@ OBSERVATORY_MAP = {
 
 # -- HTML URLs
 
-JQUERY_JS = "https://code.jquery.com/jquery-1.12.3.min.js"
+JQUERY_JS = "https://code.jquery.com/jquery-1.12.4.min.js"
 
-BOOTSTRAP_CSS = (
-    "https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css")
-BOOTSTRAP_JS = (
-    "https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js")
+_BOOTSTRAP_CDN = "https://stackpath.bootstrapcdn.com/bootstrap/3.4.1"
+BOOTSTRAP_CSS = "{}/css/bootstrap.min.css".format(_BOOTSTRAP_CDN)
+BOOTSTRAP_JS = "{}/js/bootstrap.min.js".format(_BOOTSTRAP_CDN)
 
-_FANCYBOX_CDN = "https://cdnjs.cloudflare.com/ajax/libs/fancybox/2.1.5"
+_FANCYBOX_CDN = "https://cdnjs.cloudflare.com/ajax/libs/fancybox/3.5.7"
 FANCYBOX_CSS = "{0}/jquery.fancybox.min.css".format(_FANCYBOX_CDN)
 FANCYBOX_JS = "{0}/jquery.fancybox.min.js".format(_FANCYBOX_CDN)
 
-MOMENT_JS = (
-    "https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.13.0/moment.min.js")
-
 GOOGLE_FONT_CSS = ("https://fonts.googleapis.com/css?"
-                   "family=Roboto:500%7CRoboto+Mono")
+                   "family=Roboto:400,500%7CRoboto+Mono")
 
 BOOTSTRAP_LIGO_CSS = resource_filename(
     'gwdetchar',
-    '_static/bootstrap-ligo.min.css',
-)
+    '_static/bootstrap-ligo.min.css')
 BOOTSTRAP_LIGO_JS = resource_filename(
     'gwdetchar',
-    '_static/bootstrap-ligo.min.js',
-)
+    '_static/bootstrap-ligo.min.js')
 
 GWDETCHAR_CSS = resource_filename(
     'gwdetchar',
-    '_static/gwdetchar.min.css',
-)
+    '_static/gwdetchar.min.css')
 GWDETCHAR_JS = resource_filename(
     'gwdetchar',
-    '_static/gwdetchar.min.js',
-)
+    '_static/gwdetchar.min.js')
 
 CSS_FILES = [
     BOOTSTRAP_CSS,
     FANCYBOX_CSS,
     GOOGLE_FONT_CSS,
     BOOTSTRAP_LIGO_CSS,
-    GWDETCHAR_CSS
-]
+    GWDETCHAR_CSS]
 JS_FILES = [
     JQUERY_JS,
-    MOMENT_JS,
     BOOTSTRAP_JS,
     FANCYBOX_JS,
     BOOTSTRAP_LIGO_JS,
-    GWDETCHAR_JS,
-]
+    GWDETCHAR_JS]
 
 FORMATTER = HtmlFormatter(noclasses=True)
 

--- a/gwdetchar/io/html.py
+++ b/gwdetchar/io/html.py
@@ -127,7 +127,7 @@ OBSERVATORY_MAP = {
 
 # -- HTML URLs
 
-JQUERY_JS = "https://code.jquery.com/jquery-1.12.4.min.js"
+JQUERY_JS = "https://code.jquery.com/jquery-3.4.1.min.js"
 
 _BOOTSTRAP_CDN = "https://stackpath.bootstrapcdn.com/bootstrap/3.4.1"
 BOOTSTRAP_CSS = "{}/css/bootstrap.min.css".format(_BOOTSTRAP_CDN)

--- a/gwdetchar/io/tests/test_html.py
+++ b/gwdetchar/io/tests/test_html.py
@@ -63,7 +63,7 @@ NEW_BOOTSTRAP_PAGE = """<!DOCTYPE HTML>
 <link href="https://fonts.googleapis.com/css?family=Roboto:400,500%7CRoboto+Mono" rel="stylesheet" type="text/css" media="all" />
 <link href="static/bootstrap-ligo.min.css" rel="stylesheet" type="text/css" media="all" />
 <link href="static/gwdetchar.min.css" rel="stylesheet" type="text/css" media="all" />
-<script src="https://code.jquery.com/jquery-1.12.4.min.js" type="text/javascript"></script>
+<script src="https://code.jquery.com/jquery-3.4.1.min.js" type="text/javascript"></script>
 <script src="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js" type="text/javascript"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/fancybox/3.5.7/jquery.fancybox.min.js" type="text/javascript"></script>
 <script src="static/bootstrap-ligo.min.js" type="text/javascript"></script>
@@ -237,7 +237,7 @@ def test_finalize_static_urls(tmpdir):
         'static/bootstrap-ligo.min.css',
         'static/gwdetchar.min.css']
     assert js == [
-        'https://code.jquery.com/jquery-1.12.4.min.js',
+        'https://code.jquery.com/jquery-3.4.1.min.js',
         'https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/js/'
             'bootstrap.min.js',  # nopep8
         'https://cdnjs.cloudflare.com/ajax/libs/fancybox/3.5.7/'

--- a/gwdetchar/io/tests/test_html.py
+++ b/gwdetchar/io/tests/test_html.py
@@ -58,15 +58,14 @@ NEW_BOOTSTRAP_PAGE = """<!DOCTYPE HTML>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <meta content="width=device-width, initial-scale=1.0" name="viewport" />
 <base href="{base}" />
-<link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css" rel="stylesheet" type="text/css" media="all" />
-<link href="https://cdnjs.cloudflare.com/ajax/libs/fancybox/2.1.5/jquery.fancybox.min.css" rel="stylesheet" type="text/css" media="all" />
-<link href="https://fonts.googleapis.com/css?family=Roboto:500%7CRoboto+Mono" rel="stylesheet" type="text/css" media="all" />
+<link href="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css" rel="stylesheet" type="text/css" media="all" />
+<link href="https://cdnjs.cloudflare.com/ajax/libs/fancybox/3.5.7/jquery.fancybox.min.css" rel="stylesheet" type="text/css" media="all" />
+<link href="https://fonts.googleapis.com/css?family=Roboto:400,500%7CRoboto+Mono" rel="stylesheet" type="text/css" media="all" />
 <link href="static/bootstrap-ligo.min.css" rel="stylesheet" type="text/css" media="all" />
 <link href="static/gwdetchar.min.css" rel="stylesheet" type="text/css" media="all" />
-<script src="https://code.jquery.com/jquery-1.12.3.min.js" type="text/javascript"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.13.0/moment.min.js" type="text/javascript"></script>
-<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js" type="text/javascript"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/fancybox/2.1.5/jquery.fancybox.min.js" type="text/javascript"></script>
+<script src="https://code.jquery.com/jquery-1.12.4.min.js" type="text/javascript"></script>
+<script src="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js" type="text/javascript"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/fancybox/3.5.7/jquery.fancybox.min.js" type="text/javascript"></script>
 <script src="static/bootstrap-ligo.min.js" type="text/javascript"></script>
 <script src="static/gwdetchar.min.js" type="text/javascript"></script>
 </head>
@@ -229,20 +228,19 @@ def test_finalize_static_urls(tmpdir):
     css, js = html.finalize_static_urls(
         static, base, html.CSS_FILES, html.JS_FILES)
     assert css == [
-        'https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/'
+        'https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/'
             'bootstrap.min.css',  # nopep8
-        'https://cdnjs.cloudflare.com/ajax/libs/fancybox/2.1.5/'
+        'https://cdnjs.cloudflare.com/ajax/libs/fancybox/3.5.7/'
             'jquery.fancybox.min.css',  # nopep8
         'https://fonts.googleapis.com/css?'
-            'family=Roboto:500%7CRoboto+Mono',  # nopep8
+            'family=Roboto:400,500%7CRoboto+Mono',  # nopep8
         'static/bootstrap-ligo.min.css',
         'static/gwdetchar.min.css']
     assert js == [
-        'https://code.jquery.com/jquery-1.12.3.min.js',
-        'https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.13.0/'
-            'moment.min.js',  # nopep8
-        'https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js',
-        'https://cdnjs.cloudflare.com/ajax/libs/fancybox/2.1.5/'
+        'https://code.jquery.com/jquery-1.12.4.min.js',
+        'https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/js/'
+            'bootstrap.min.js',  # nopep8
+        'https://cdnjs.cloudflare.com/ajax/libs/fancybox/3.5.7/'
             'jquery.fancybox.min.js',  # nopep8
         'static/bootstrap-ligo.min.js',
         'static/gwdetchar.min.js']

--- a/share/sass/gwdetchar.scss
+++ b/share/sass/gwdetchar.scss
@@ -18,12 +18,15 @@
  */
 
 body {
+		background-color: #eee;
 		font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
 		font-weight: 300;
 }
 
 h1, h2, h3, h4, h5, h6 {
-		font-weight: 300;
+		font-family: 'Roboto', sans-serif;
+		-webkit-font-smoothing: antialiased;
+		font-weight: 400;
 }
 
 h4 {
@@ -53,9 +56,9 @@ img {
 		.navbar-nav > li > a,
 		.navbar-nav > li.disabled > a {
 				font-family: 'Roboto', sans-serif;
+				-webkit-font-smoothing: antialiased;
 				font-size: 15px;
 				font-weight: 500;
-				-webkit-font-smoothing: antialiased;
 		}
 		.navbar-brand {
 				font-size: 16px;


### PR DESCRIPTION
This PR updates the used versions of bootstrap, fancybox, and jquery. It also removes moment.js as a dependency (this is only used by gwsumm downstream), and makes minor tweaks of the CSS stylesheet.

Example omega scan output is available [**here**](https://ldas-jobs.ligo.caltech.edu/~alexander.urban/wdq/Network_1246080201.53/).

cc @duncanmmacleod 