### PR TITLE
Datafind bug fix

### DIFF
--- a/gwdetchar/io/datafind.py
+++ b/gwdetchar/io/datafind.py
@@ -198,6 +198,8 @@ def get_data(channel, start, end, frametype=None, source=None,
                 'Could not determine observatory from frametype')
         except (HTTPError, JSONDecodeError):  # frame files not found
             pass
+    if len(source) == 0: #if no frames found
+        source = None
     if isinstance(source, list) and isinstance(channel, (list, tuple)):
         channel = remove_missing_channels(channel, source)
     if source is not None:  # read from frame files

--- a/gwdetchar/io/datafind.py
+++ b/gwdetchar/io/datafind.py
@@ -198,7 +198,7 @@ def get_data(channel, start, end, frametype=None, source=None,
                 'Could not determine observatory from frametype')
         except (HTTPError, JSONDecodeError):  # frame files not found
             pass
-    if len(source) == 0: #if no frames found
+    if len(source) == 0: # reset if no frames found
         source = None
     if isinstance(source, list) and isinstance(channel, (list, tuple)):
         channel = remove_missing_channels(channel, source)

--- a/gwdetchar/io/datafind.py
+++ b/gwdetchar/io/datafind.py
@@ -198,11 +198,9 @@ def get_data(channel, start, end, frametype=None, source=None,
                 'Could not determine observatory from frametype')
         except (HTTPError, JSONDecodeError):  # frame files not found
             pass
-    if len(source) == 0: # reset if no frames found
-        source = None
-    if isinstance(source, list) and isinstance(channel, (list, tuple)):
+    if source and isinstance(source, list) and isinstance(channel, (list, tuple)):
         channel = remove_missing_channels(channel, source)
-    if source is not None:  # read from frame files
+    if source:  # read from frame files
         return series_class.read(
             source, channel, start=start, end=end, nproc=nproc,
             verbose=verbose, **kwargs)


### PR DESCRIPTION
This PR fixes a bug in how the `datafind.get_data()` module operates. If a frame type is provided, but no files are found by `gwdatafind`, the `source` variable is overridden and causes an index error. This can be avoided by ensuring that when no files are found, we reset `source = None`. 

An example of the error that currently occurs with the LIGO Conda ligo-py27 (and ligo-py37) environment is below:

```
RuntimeError: /home/derek.davis/.conda/envs/ligo-py27-clone/lib/python2.7/site-packages/gwdatafind/http.py:431: UserWarning: Missing segments: 
[1240215246.02 ... 1240215760.02)
warnings.warn(msg)
Traceback (most recent call last):
File "/home/derek.davis/.conda/envs/ligo-py27-clone/bin/gwdetchar-omega", line 221, in 
nproc=args.nproc, verbose='Reading block:'.rjust(30))
File "/home/derek.davis/.conda/envs/ligo-py27-clone/lib/python2.7/site-packages/gwdetchar/io/datafind.py", line 206, in get_data
channel = remove_missing_channels(channel, source)
File "/home/derek.davis/.conda/envs/ligo-py27-clone/lib/python2.7/site-packages/gwdetchar/io/datafind.py", line 114, in remove_missing_channels
available = set(io_gwf.iter_channel_names(gwfcache[0]))
IndexError: list index out of range
```

This can be reproduced by providing `gwdetchar-omega` a frame type for a gps time that does not exist.

Alternatively, this error could be fixed by changes to `gwdatafind` itself.