### PR TITLE
PEP-8 compliance fix for datafind.py

### DIFF
--- a/gwdetchar/io/datafind.py
+++ b/gwdetchar/io/datafind.py
@@ -198,7 +198,8 @@ def get_data(channel, start, end, frametype=None, source=None,
                 'Could not determine observatory from frametype')
         except (HTTPError, JSONDecodeError):  # frame files not found
             pass
-    if source and isinstance(source, list) and isinstance(channel, (list, tuple)):
+    if source and (isinstance(source, list) and
+                   isinstance(channel, (list, tuple))):
         channel = remove_missing_channels(channel, source)
     if source:  # read from frame files
         return series_class.read(


### PR DESCRIPTION
This PR fixes a PEP-8 compliance issue found in `gwdetchar.io.datafind`.

cc @dethodav 