### PR TITLE
Use the arrow glyph for return-to-top button

### DIFF
--- a/gwdetchar/io/html.py
+++ b/gwdetchar/io/html.py
@@ -330,7 +330,8 @@ def new_bootstrap_page(base=os.path.curdir, path=os.path.curdir, lang='en',
     # open body and container
     page.body()
     if topbtn:
-        page.button('&#8679;', title='Return to top', class_='btn-float',
+        glyph = markup.oneliner.i('', class_='fas fa-arrow-up')
+        page.button(glyph, title='Return to top', class_='btn-float',
                     id_='top-btn', onclick='$("#top-btn").scrollView();')
     if navbar is not None:
         page.add(navbar)

--- a/share/sass/gwdetchar.scss
+++ b/share/sass/gwdetchar.scss
@@ -145,15 +145,15 @@ img {
 				z-index: 99;
 				// text elements
 				color: #555;
-				font-size: 32px;
-				font-weight: 400;
+				font-size: 30px;
+				font-weight: 300;
 				align-items: center;
 				justify-content: center;
 				text-decoration: none;
 				// appearance
 				outline: none;
 				cursor: pointer;
-				border: 1px solid #555;
+				border: 2px solid #555;
 				background-color: white;
 				transition-duration: 0.4s;
 				-webkit-transition-duration: 0.4s;
@@ -165,7 +165,7 @@ img {
 		@media(min-width:992px) {
 				color: white;
 				background-color: #555;
-				border: 1px solid white;
+				border: 2px solid white;
 		}
 }
 

--- a/share/sass/gwdetchar.scss
+++ b/share/sass/gwdetchar.scss
@@ -140,8 +140,8 @@ img {
 				position: fixed;
 				width: 50px;
 				height: 50px;
-				bottom: 20px;
-				right: 20px;
+				bottom: 37px;
+				right: 90px;
 				z-index: 99;
 				// text elements
 				color: #555;

--- a/share/sass/gwdetchar.scss
+++ b/share/sass/gwdetchar.scss
@@ -145,7 +145,7 @@ img {
 				z-index: 99;
 				// text elements
 				color: #555;
-				font-size: 30px;
+				font-size: 28px;
 				font-weight: 300;
 				align-items: center;
 				justify-content: center;


### PR DESCRIPTION
This PR uses the up-arrow glyph from [**Font Awesome**](https://fontawesome.com) when rendering the new return-to-top button.

cc @duncanmmacleod 