### PR TITLE
Upgrade to gwbootstrap-1.0.0

### DIFF
--- a/gwdetchar/io/html.py
+++ b/gwdetchar/io/html.py
@@ -127,31 +127,28 @@ OBSERVATORY_MAP = {
 
 # -- HTML URLs
 
-JQUERY_JS = "https://code.jquery.com/jquery-1.12.4.min.js"
-
-_BOOTSTRAP_CDN = "https://stackpath.bootstrapcdn.com/bootstrap/3.4.1"
-BOOTSTRAP_CSS = "{}/css/bootstrap.min.css".format(_BOOTSTRAP_CDN)
-BOOTSTRAP_JS = "{}/js/bootstrap.min.js".format(_BOOTSTRAP_CDN)
-
-_FANCYBOX_CDN = "https://cdnjs.cloudflare.com/ajax/libs/fancybox/3.5.7"
-FANCYBOX_CSS = "{0}/jquery.fancybox.min.css".format(_FANCYBOX_CDN)
-FANCYBOX_JS = "{0}/jquery.fancybox.min.js".format(_FANCYBOX_CDN)
-
 FONT_AWESOME_CSS = ("https://cdnjs.cloudflare.com/ajax/libs/"
                     "font-awesome/5.10.2/css/fontawesome.min.css")
 FONT_AWESOME_SOLID_CSS = ("https://cdnjs.cloudflare.com/ajax/libs/"
                           "font-awesome/5.10.2/css/solid.min.css")
+
+JQUERY_JS = "https://code.jquery.com/jquery-1.12.4.min.js"
+BOOTSTRAP_JS = ("https://stackpath.bootstrapcdn.com/bootstrap/"
+                "3.4.1/js/bootstrap.min.js")
+FANCYBOX_JS = ("https://cdnjs.cloudflare.com/ajax/libs/"
+               "fancybox/3.5.7/jquery.fancybox.min.js")
 
 GWBOOTSTRAP_CSS = resource_filename(
     'gwdetchar',
     '_static/gwbootstrap.min.css')
 GWBOOTSTRAP_JS = resource_filename(
     'gwdetchar',
-    '_static/gwbootstrap-basic.min.js')
+    '_static/gwbootstrap.min.js')
+GWBOOTSTRAP_EXTRA_JS = resource_filename(
+    'gwdetchar',
+    '_static/gwbootstrap-extra.min.js')
 
 CSS_FILES = [
-    BOOTSTRAP_CSS,
-    FANCYBOX_CSS,
     FONT_AWESOME_CSS,
     FONT_AWESOME_SOLID_CSS,
     GWBOOTSTRAP_CSS,
@@ -309,7 +306,7 @@ def new_bootstrap_page(base=os.path.curdir, path=os.path.curdir, lang='en',
     page._full = True
     # link files
     for f in css:
-        page.link(href=f, rel='stylesheet', type='text/css', media='all')
+        page.link(href=f, rel='stylesheet', media='all')
     for f in script:
         page.script('', src=f, type='text/javascript')
     # add other attributes

--- a/gwdetchar/io/tests/test_html.py
+++ b/gwdetchar/io/tests/test_html.py
@@ -230,12 +230,8 @@ def test_finalize_static_urls(tmpdir):
     css, js = html.finalize_static_urls(
         static, base, html.CSS_FILES, html.JS_FILES)
     assert css == [
-        'https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/'
-            'bootstrap.min.css',  # noqa: E131
-        'https://cdnjs.cloudflare.com/ajax/libs/fancybox/3.5.7/'
-            'jquery.fancybox.min.css',  # noqa: E131
         'https://cdnjs.cloudflare.com/ajax/libs/'
-            'font-awesome/5.10.2/css/fontawesome.min.css',
+            'font-awesome/5.10.2/css/fontawesome.min.css',  # noqa: E131
         'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/'
             '5.10.2/css/solid.min.css',  # noqa: E131
         'static/gwbootstrap.min.css',
@@ -246,7 +242,7 @@ def test_finalize_static_urls(tmpdir):
             'bootstrap.min.js',  # noqa: E131
         'https://cdnjs.cloudflare.com/ajax/libs/fancybox/3.5.7/'
             'jquery.fancybox.min.js',  # noqa E131
-        'static/gwbootstrap-basic.min.js',
+        'static/gwbootstrap.min.js',
     ]
     shutil.rmtree(str(tmpdir), ignore_errors=True)
 

--- a/gwdetchar/io/tests/test_html.py
+++ b/gwdetchar/io/tests/test_html.py
@@ -57,15 +57,13 @@ NEW_BOOTSTRAP_PAGE = """<!DOCTYPE HTML>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <meta content="width=device-width, initial-scale=1.0" name="viewport" />
 <base href="{base}" />
-<link href="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css" rel="stylesheet" type="text/css" media="all" />
-<link href="https://cdnjs.cloudflare.com/ajax/libs/fancybox/3.5.7/jquery.fancybox.min.css" rel="stylesheet" type="text/css" media="all" />
-<link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.10.2/css/fontawesome.min.css" rel="stylesheet" type="text/css" media="all" />
-<link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.10.2/css/solid.min.css" rel="stylesheet" type="text/css" media="all" />
-<link href="static/gwbootstrap.min.css" rel="stylesheet" type="text/css" media="all" />
+<link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.10.2/css/fontawesome.min.css" rel="stylesheet" media="all" />
+<link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.10.2/css/solid.min.css" rel="stylesheet" media="all" />
+<link href="static/gwbootstrap.min.css" rel="stylesheet" media="all" />
 <script src="https://code.jquery.com/jquery-1.12.4.min.js" type="text/javascript"></script>
 <script src="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js" type="text/javascript"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/fancybox/3.5.7/jquery.fancybox.min.js" type="text/javascript"></script>
-<script src="static/gwbootstrap-basic.min.js" type="text/javascript"></script>
+<script src="static/gwbootstrap.min.js" type="text/javascript"></script>
 </head>
 <body>
 <div class="container">


### PR DESCRIPTION
This PR upgrades gwdetchar to rely on the newly released gwbootstrap-1.0.0, including an optional provision to use gwbootstrap-extra, mainly for the benefit of downstream packages (especially gwsumm).

cc @duncanmmacleod 