### PR TITLE
Upgrade to jQuery-3.4.1

### DIFF
--- a/_setup_utils.py
+++ b/_setup_utils.py
@@ -34,9 +34,7 @@ import versioneer
 CMDCLASS = versioneer.get_cmdclass()
 
 # specify HTML source files
-JS_FILES = [
-    f for f in glob.glob(os.path.join('gwbootstrap', 'js', '*.js'))
-    if not f.endswith('.min.js')]
+JS_FILES = [os.path.join('gwbootstrap', 'js', 'gwbootstrap.js')]
 SASS_FILES = glob.glob(os.path.join('gwbootstrap', 'sass', '[!_]*.scss'))
 
 # make sure submodule is not empty

--- a/gwdetchar/io/html.py
+++ b/gwdetchar/io/html.py
@@ -127,16 +127,16 @@ OBSERVATORY_MAP = {
 
 # -- HTML URLs
 
-FONT_AWESOME_CSS = ("https://cdnjs.cloudflare.com/ajax/libs/"
-                    "font-awesome/5.10.2/css/fontawesome.min.css")
-FONT_AWESOME_SOLID_CSS = ("https://cdnjs.cloudflare.com/ajax/libs/"
-                          "font-awesome/5.10.2/css/solid.min.css")
+FONT_AWESOME_CSS = ('https://cdnjs.cloudflare.com/ajax/libs/'
+                    'font-awesome/5.10.2/css/fontawesome.min.css')
+FONT_AWESOME_SOLID_CSS = ('https://cdnjs.cloudflare.com/ajax/libs/'
+                          'font-awesome/5.10.2/css/solid.min.css')
 
-JQUERY_JS = "https://code.jquery.com/jquery-1.12.4.min.js"
-BOOTSTRAP_JS = ("https://stackpath.bootstrapcdn.com/bootstrap/"
-                "3.4.1/js/bootstrap.min.js")
-FANCYBOX_JS = ("https://cdnjs.cloudflare.com/ajax/libs/"
-               "fancybox/3.5.7/jquery.fancybox.min.js")
+JQUERY_JS = 'https://code.jquery.com/jquery-3.4.1.min.js'
+BOOTSTRAP_JS = ('https://stackpath.bootstrapcdn.com/bootstrap/'
+                '3.4.1/js/bootstrap.min.js')
+FANCYBOX_JS = ('https://cdnjs.cloudflare.com/ajax/libs/'
+               'fancybox/3.5.7/jquery.fancybox.min.js')
 
 GWBOOTSTRAP_CSS = resource_filename(
     'gwdetchar',

--- a/gwdetchar/io/tests/test_html.py
+++ b/gwdetchar/io/tests/test_html.py
@@ -60,7 +60,7 @@ NEW_BOOTSTRAP_PAGE = """<!DOCTYPE HTML>
 <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.10.2/css/fontawesome.min.css" rel="stylesheet" media="all" />
 <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.10.2/css/solid.min.css" rel="stylesheet" media="all" />
 <link href="static/gwbootstrap.min.css" rel="stylesheet" media="all" />
-<script src="https://code.jquery.com/jquery-1.12.4.min.js" type="text/javascript"></script>
+<script src="https://code.jquery.com/jquery-3.4.1.min.js" type="text/javascript"></script>
 <script src="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js" type="text/javascript"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/fancybox/3.5.7/jquery.fancybox.min.js" type="text/javascript"></script>
 <script src="static/gwbootstrap.min.js" type="text/javascript"></script>
@@ -237,7 +237,7 @@ def test_finalize_static_urls(tmpdir):
         'static/gwbootstrap.min.css',
     ]
     assert js == [
-        'https://code.jquery.com/jquery-1.12.4.min.js',
+        'https://code.jquery.com/jquery-3.4.1.min.js',
         'https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/js/'
             'bootstrap.min.js',  # noqa: E131
         'https://cdnjs.cloudflare.com/ajax/libs/fancybox/3.5.7/'


### PR DESCRIPTION
This PR upgrades the jQuery dependence to 3.4.1, as the jQuery 3.x series patches some (minor) security vulnerabilities.