### PR TITLE
Take advantage of event listeners in gwbootstrap

### DIFF
--- a/gwdetchar/io/html.py
+++ b/gwdetchar/io/html.py
@@ -133,6 +133,8 @@ FONT_AWESOME_SOLID_CSS = ('https://cdnjs.cloudflare.com/ajax/libs/'
                           'font-awesome/5.10.2/css/solid.min.css')
 
 JQUERY_JS = 'https://code.jquery.com/jquery-3.4.1.min.js'
+JQUERY_LAZY_JS = ('https://cdnjs.cloudflare.com/ajax/libs/jquery.lazy/'
+                  '1.7.9/jquery.lazy.min.js')
 BOOTSTRAP_JS = ('https://stackpath.bootstrapcdn.com/bootstrap/'
                 '3.4.1/js/bootstrap.min.js')
 FANCYBOX_JS = ('https://cdnjs.cloudflare.com/ajax/libs/'
@@ -153,6 +155,7 @@ CSS_FILES = [
 
 JS_FILES = [
     JQUERY_JS,
+    JQUERY_LAZY_JS,
     BOOTSTRAP_JS,
     FANCYBOX_JS,
     GWBOOTSTRAP_JS,
@@ -315,8 +318,8 @@ def new_bootstrap_page(base=os.path.curdir, path=os.path.curdir, lang='en',
     page.body()
     if topbtn:
         glyph = markup.oneliner.i('', class_='fas fa-arrow-up')
-        page.button(glyph, title='Return to top', class_='btn-float',
-                    id_='top-btn', onclick='$("#top-btn").scrollView();')
+        page.button(glyph, title='Return to top',
+                    class_='btn-float', id_='top-btn')
     if navbar is not None:
         page.add(navbar)
     page.div(class_='container')
@@ -1004,8 +1007,7 @@ def table(headers, data, caption=None, separator='', id=None, **class_):
     if id:
         page.button(
             'Export to CSV', class_='btn btn-default btn-table',
-            onclick="exportTableToCSV('{name}.csv', '{name}')".format(
-                name=id))
+            **{'data-table-id': id, 'data-filename': '%s.csv' % id})
     return page()
 
 

--- a/gwdetchar/io/html.py
+++ b/gwdetchar/io/html.py
@@ -752,7 +752,7 @@ def fancybox_img(img, linkparams=dict(), **params):
     page.a(href=img, id_='a_%s_%s' % (channel, duration), **aparams)
     imgparams = {
         'alt': os.path.basename(img),
-        'class_': 'img-responsive',
+        'class_': 'img-responsive lazy',
     }
     if img.endswith('.svg') and os.path.isfile(img.replace('.svg', '.png')):
         imgparams['src'] = img.replace('.svg', '.png')

--- a/gwdetchar/io/tests/test_html.py
+++ b/gwdetchar/io/tests/test_html.py
@@ -61,6 +61,7 @@ NEW_BOOTSTRAP_PAGE = """<!DOCTYPE HTML>
 <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.10.2/css/solid.min.css" rel="stylesheet" media="all" />
 <link href="static/gwbootstrap.min.css" rel="stylesheet" media="all" />
 <script src="https://code.jquery.com/jquery-3.4.1.min.js" type="text/javascript"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.lazy/1.7.9/jquery.lazy.min.js" type="text/javascript"></script>
 <script src="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js" type="text/javascript"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/fancybox/3.5.7/jquery.fancybox.min.js" type="text/javascript"></script>
 <script src="static/gwbootstrap.min.js" type="text/javascript"></script>
@@ -87,7 +88,7 @@ ABOUT = """<div class="row">
 <span style="color: #7D9029">key</span> <span style="color: #666666">=</span> <span style="color: #BA2121">value</span>
 </pre></div>
 
-<h2>Environment</h2><table class="table table-hover table-condensed table-responsive" id="package-table"><caption>Table of packages installed in the production environment</caption><thead><tr><th scope="col">Name</th><th scope="col">Version</th></tr></thead><tbody><tr><td>gwdetchar</td><td>1.2.3</td></tr><tr><td>gwpy</td><td>1.0.0</td></tr></tbody></table><button class="btn btn-default btn-table" onclick="exportTableToCSV(&quot;package-table.csv&quot;, &quot;package-table&quot;)">Export to CSV</button>
+<h2>Environment</h2><table class="table table-hover table-condensed table-responsive" id="package-table"><caption>Table of packages installed in the production environment</caption><thead><tr><th scope="col">Name</th><th scope="col">Version</th></tr></thead><tbody><tr><td>gwdetchar</td><td>1.2.3</td></tr><tr><td>gwpy</td><td>1.0.0</td></tr></tbody></table><button class="btn btn-default btn-table" data-table-id="package-table" data-filename="package-table.csv">Export to CSV</button>
 </div>
 </div>""".format(sys.prefix)  # noqa: E501
 
@@ -118,7 +119,7 @@ ABOUT_WITH_CONFIG_LIST = """<div class="row">
 </div>
 </div>
 </div>
-<h2>Environment</h2><table class="table table-hover table-condensed table-responsive" id="package-table"><caption>Table of packages installed in the production environment</caption><thead><tr><th scope="col">Name</th><th scope="col">Version</th></tr></thead><tbody><tr><td>gwdetchar</td><td>1.2.3</td></tr><tr><td>gwpy</td><td>1.0.0</td></tr></tbody></table><button class="btn btn-default btn-table" onclick="exportTableToCSV(&quot;package-table.csv&quot;, &quot;package-table&quot;)">Export to CSV</button>
+<h2>Environment</h2><table class="table table-hover table-condensed table-responsive" id="package-table"><caption>Table of packages installed in the production environment</caption><thead><tr><th scope="col">Name</th><th scope="col">Version</th></tr></thead><tbody><tr><td>gwdetchar</td><td>1.2.3</td></tr><tr><td>gwpy</td><td>1.0.0</td></tr></tbody></table><button class="btn btn-default btn-table" data-table-id="package-table" data-filename="package-table.csv">Export to CSV</button>
 </div>
 </div>""".format(sys.prefix)  # noqa: E501
 
@@ -238,6 +239,8 @@ def test_finalize_static_urls(tmpdir):
     ]
     assert js == [
         'https://code.jquery.com/jquery-3.4.1.min.js',
+        'https://cdnjs.cloudflare.com/ajax/libs/jquery.lazy/1.7.9/'
+            'jquery.lazy.min.js',  # noqa: E131
         'https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/js/'
             'bootstrap.min.js',  # noqa: E131
         'https://cdnjs.cloudflare.com/ajax/libs/fancybox/3.5.7/'
@@ -471,8 +474,7 @@ def test_table():
         'id="test"><caption>This is a test table.</caption><thead><tr>'
         '<th scope="col">Test</th></tr></thead><tbody><tr><td>test</td></tr>'
         '</tbody></table><button class="btn btn-default btn-table" '
-        'onclick="exportTableToCSV(&quot;test.csv&quot;, &quot;test&quot;)">'
-        'Export to CSV</button>')
+        'data-table-id="test" data-filename="test.csv">Export to CSV</button>')
 
 
 def test_write_flag_html():
@@ -557,15 +559,11 @@ def test_package_table(package_list):
     assert parse_html(
         html.package_table(class_="test", caption="Test"),
     ) == parse_html(
-        "<h2>Environment</h2><table class=\"test\" id=\"package-table\">"
-        "<caption>Test</caption>"
-        "<thead>"
-        "<tr><th scope=\"col\">Name</th><th scope=\"col\">Version</th></tr>"
-        "</thead><tbody>"
-        "<tr><td>gwdetchar</td><td>1.2.3</td></tr>"
-        "<tr><td>gwpy</td><td>1.0.0</td></tr>"
-        "</tbody></table>"
-        "<button class=\"btn btn-default btn-table\" "
-        "onclick=\"exportTableToCSV(&quot;package-table.csv&quot;, "
-        "&quot;package-table&quot;)\">Export to CSV</button>",
+        '<h2>Environment</h2><table class="test" id="package-table">'
+        '<caption>Test</caption><thead><tr><th scope="col">Name</th><th '
+        'scope="col">Version</th></tr></thead><tbody><tr><td>gwdetchar</td>'
+        '<td>1.2.3</td></tr><tr><td>gwpy</td><td>1.0.0</td></tr></tbody>'
+        '</table><button class="btn btn-default btn-table" '
+        'data-table-id="package-table" data-filename="package-table.csv">'
+        'Export to CSV</button>'
     )

--- a/gwdetchar/io/tests/test_html.py
+++ b/gwdetchar/io/tests/test_html.py
@@ -166,7 +166,7 @@ FLAG_HTML_WITH_PLOTS = FLAG_CONTENT.format(
           'and active (large) analysis segments for X1:TEST_FLAG" '
           'class="fancybox" href="plots/X1-TEST_FLAG-0-66.png" '
           'data-fancybox-group="images">\n<img id="img_X1-TEST_FLAG_66" '
-          'alt="X1-TEST_FLAG-0-66.png" class="img-responsive" '
+          'alt="X1-TEST_FLAG-0-66.png" class="img-responsive lazy" '
           'src="plots/X1-TEST_FLAG-0-66.png" />\n</a>')
 
 FLAG_HTML_NO_SEGMENTS = FLAG_CONTENT.format(
@@ -190,17 +190,17 @@ OMEGA_SCAFFOLD = """<div class="panel well panel-default">
 <div class="row">
 <div class="col-sm-4">
 <a href="./1126259462/plots/X1-STRAIN-qscan_whitened-1.png" id="a_X1-STRAIN_1" title="X1-STRAIN-qscan_whitened-1.png" class="fancybox" target="_blank" data-fancybox-group="images">
-<img id="img_X1-STRAIN_1" alt="X1-STRAIN-qscan_whitened-1.png" class="img-responsive" src="./1126259462/plots/X1-STRAIN-qscan_whitened-1.png" />
+<img id="img_X1-STRAIN_1" alt="X1-STRAIN-qscan_whitened-1.png" class="img-responsive lazy" src="./1126259462/plots/X1-STRAIN-qscan_whitened-1.png" />
 </a>
 </div>
 <div class="col-sm-4">
 <a href="./1126259462/plots/X1-STRAIN-qscan_whitened-4.png" id="a_X1-STRAIN_4" title="X1-STRAIN-qscan_whitened-4.png" class="fancybox" target="_blank" data-fancybox-group="images">
-<img id="img_X1-STRAIN_4" alt="X1-STRAIN-qscan_whitened-4.png" class="img-responsive" src="./1126259462/plots/X1-STRAIN-qscan_whitened-4.png" />
+<img id="img_X1-STRAIN_4" alt="X1-STRAIN-qscan_whitened-4.png" class="img-responsive lazy" src="./1126259462/plots/X1-STRAIN-qscan_whitened-4.png" />
 </a>
 </div>
 <div class="col-sm-4">
 <a href="./1126259462/plots/X1-STRAIN-qscan_whitened-16.png" id="a_X1-STRAIN_16" title="X1-STRAIN-qscan_whitened-16.png" class="fancybox" target="_blank" data-fancybox-group="images">
-<img id="img_X1-STRAIN_16" alt="X1-STRAIN-qscan_whitened-16.png" class="img-responsive" src="./1126259462/plots/X1-STRAIN-qscan_whitened-16.png" />
+<img id="img_X1-STRAIN_16" alt="X1-STRAIN-qscan_whitened-16.png" class="img-responsive lazy" src="./1126259462/plots/X1-STRAIN-qscan_whitened-16.png" />
 </a>
 </div>
 </div>
@@ -401,7 +401,7 @@ def test_fancybox_img():
         '<a class="fancybox" href="X1-TEST_AUX-test-4.png" target="_blank" '
         'data-fancybox-group="images" id="a_X1-TEST_AUX_4" '
         'title="X1-TEST_AUX-test-4.png">\n'
-        '<img class="img-responsive" alt="X1-TEST_AUX-test-4.png" '
+        '<img class="img-responsive lazy" alt="X1-TEST_AUX-test-4.png" '
         'src="X1-TEST_AUX-test-4.png" id="img_X1-TEST_AUX_4"/>\n'
         '</a>')
 
@@ -416,13 +416,13 @@ def test_scaffold_plots():
         '<a class="fancybox" href="X1-TEST_AUX-test-4.png" target="_blank" '
         'id="a_X1-TEST_AUX_4" data-fancybox-group="images" '
         'title="X1-TEST_AUX-test-4.png">\n'
-        '<img class="img-responsive" alt="X1-TEST_AUX-test-4.png" '
+        '<img class="img-responsive lazy" alt="X1-TEST_AUX-test-4.png" '
         'id="img_X1-TEST_AUX_4" src="X1-TEST_AUX-test-4.png" />\n'
         '</a>\n</div>\n<div class="col-sm-6">\n'
         '<a class="fancybox" href="X1-TEST_AUX-test-16.png" target="_blank"'
         ' id="a_X1-TEST_AUX_16" data-fancybox-group="images" '
         'title="X1-TEST_AUX-test-16.png">\n'
-        '<img class="img-responsive" alt="X1-TEST_AUX-test-16.png" '
+        '<img class="img-responsive lazy" alt="X1-TEST_AUX-test-16.png" '
         'id="img_X1-TEST_AUX_16" src="X1-TEST_AUX-test-16.png" />\n'
         '</a>\n</div>\n</div>')
     assert h1 == h2

--- a/gwdetchar/omega/html.py
+++ b/gwdetchar/omega/html.py
@@ -186,11 +186,15 @@ def toggle_link(plottype, channel, pranges):
     text = plottype.split('_')[1]
     pstrings = ["'%s'" % p for p in pranges]
     chanstring = channel.name.replace('-', '_').replace(':', '-')
-    captions = [p.caption for p in channel.plots[plottype]]
+    captions = ["'%s'" % p.caption for p in channel.plots[plottype]]
     return markup.oneliner.a(
-        text, class_='dropdown-item',
-        onclick="showImage('{0}', [{1}], '{2}', {3});".format(
-            chanstring, ','.join(pstrings), plottype, captions))
+        text, class_='dropdown-item image-switch', **{
+            'data-captions': '[%s]' % ','.join(captions),
+            'data-channel-name': chanstring,
+            'data-image-dir': 'plots',
+            'data-image-type': plottype,
+            'data-t-ranges': '[%s]' % ','.join(pstrings),
+        })
 
 
 def write_summary_table(blocks, correlated, base=os.path.curdir):

--- a/gwdetchar/omega/tests/test_html.py
+++ b/gwdetchar/omega/tests/test_html.py
@@ -186,9 +186,9 @@ BLOCK_HTML = """<div class="panel well panel-info">
 Timeseries view <span class="caret"></span>
 </button>
 <ul class="dropdown-menu" role="menu" aria-labelledby="btnGroupTimeseries0">
-<li><a class="dropdown-item" onclick="showImage(&quot;X1-TEST_AUX&quot;, [&quot;4&quot;], &quot;timeseries_raw&quot;, [&quot;X1-TEST_AUX-timeseries_raw-4.png&quot;]);">raw</a></li>
-<li><a class="dropdown-item" onclick="showImage(&quot;X1-TEST_AUX&quot;, [&quot;4&quot;], &quot;timeseries_highpassed&quot;, [&quot;X1-TEST_AUX-timeseries_highpassed-4.png&quot;]);">highpassed</a></li>
-<li><a class="dropdown-item" onclick="showImage(&quot;X1-TEST_AUX&quot;, [&quot;4&quot;], &quot;timeseries_whitened&quot;, [&quot;X1-TEST_AUX-timeseries_whitened-4.png&quot;]);">whitened</a></li>
+<li><a class="dropdown-item image-switch" data-captions="[&quot;X1-TEST_AUX-timeseries_raw-4.png&quot;]" data-channel-name="X1-TEST_AUX" data-image-dir="plots" data-image-type="timeseries_raw" data-t-ranges="[&quot;4&quot;]">raw</a></li>
+<li><a class="dropdown-item image-switch" data-captions="[&quot;X1-TEST_AUX-timeseries_highpassed-4.png&quot;]" data-channel-name="X1-TEST_AUX" data-image-dir="plots" data-image-type="timeseries_highpassed" data-t-ranges="[&quot;4&quot;]">highpassed</a></li>
+<li><a class="dropdown-item image-switch" data-captions="[&quot;X1-TEST_AUX-timeseries_whitened-4.png&quot;]" data-channel-name="X1-TEST_AUX" data-image-dir="plots" data-image-type="timeseries_whitened" data-t-ranges="[&quot;4&quot;]">whitened</a></li>
 </ul>
 </div>
 <div class="btn-group" role="group">
@@ -196,9 +196,9 @@ Timeseries view <span class="caret"></span>
 Spectrogram view <span class="caret"></span>
 </button>
 <ul class="dropdown-menu" role="menu" aria-labelledby="btnGroupQscan0">
-<li><a class="dropdown-item" onclick="showImage(&quot;X1-TEST_AUX&quot;, [&quot;4&quot;], &quot;qscan_highpassed&quot;, [&quot;X1-TEST_AUX-qscan_highpassed-4.png&quot;]);">highpassed</a></li>
-<li><a class="dropdown-item" onclick="showImage(&quot;X1-TEST_AUX&quot;, [&quot;4&quot;], &quot;qscan_whitened&quot;, [&quot;X1-TEST_AUX-qscan_whitened-4.png&quot;]);">whitened</a></li>
-<li><a class="dropdown-item" onclick="showImage(&quot;X1-TEST_AUX&quot;, [&quot;4&quot;], &quot;qscan_autoscaled&quot;, [&quot;X1-TEST_AUX-qscan_autoscaled-4.png&quot;]);">autoscaled</a></li>
+<li><a class="dropdown-item image-switch" data-captions="[&quot;X1-TEST_AUX-qscan_highpassed-4.png&quot;]" data-channel-name="X1-TEST_AUX" data-image-dir="plots" data-image-type="qscan_highpassed" data-t-ranges="[&quot;4&quot;]">highpassed</a></li>
+<li><a class="dropdown-item image-switch" data-captions="[&quot;X1-TEST_AUX-qscan_whitened-4.png&quot;]" data-channel-name="X1-TEST_AUX" data-image-dir="plots" data-image-type="qscan_whitened" data-t-ranges="[&quot;4&quot;]">whitened</a></li>
+<li><a class="dropdown-item image-switch" data-captions="[&quot;X1-TEST_AUX-qscan_autoscaled-4.png&quot;]" data-channel-name="X1-TEST_AUX" data-image-dir="plots" data-image-type="qscan_autoscaled" data-t-ranges="[&quot;4&quot;]">autoscaled</a></li>
 </ul>
 </div>
 <div class="btn-group" role="group">
@@ -206,9 +206,9 @@ Spectrogram view <span class="caret"></span>
 Eventgram view <span class="caret"></span>
 </button>
 <ul class="dropdown-menu" role="menu" aria-labelledby="btnGroupEventgram0">
-<li><a class="dropdown-item" onclick="showImage(&quot;X1-TEST_AUX&quot;, [&quot;4&quot;], &quot;eventgram_highpassed&quot;, [&quot;X1-TEST_AUX-eventgram_highpassed-4.png&quot;]);">highpassed</a></li>
-<li><a class="dropdown-item" onclick="showImage(&quot;X1-TEST_AUX&quot;, [&quot;4&quot;], &quot;eventgram_whitened&quot;, [&quot;X1-TEST_AUX-eventgram_whitened-4.png&quot;]);">whitened</a></li>
-<li><a class="dropdown-item" onclick="showImage(&quot;X1-TEST_AUX&quot;, [&quot;4&quot;], &quot;eventgram_autoscaled&quot;, [&quot;X1-TEST_AUX-eventgram_autoscaled-4.png&quot;]);">autoscaled</a></li>
+<li><a class="dropdown-item image-switch" data-captions="[&quot;X1-TEST_AUX-eventgram_highpassed-4.png&quot;]" data-channel-name="X1-TEST_AUX" data-image-dir="plots" data-image-type="eventgram_highpassed" data-t-ranges="[&quot;4&quot;]">highpassed</a></li>
+<li><a class="dropdown-item image-switch" data-captions="[&quot;X1-TEST_AUX-eventgram_whitened-4.png&quot;]" data-channel-name="X1-TEST_AUX" data-image-dir="plots" data-image-type="eventgram_whitened" data-t-ranges="[&quot;4&quot;]">whitened</a></li>
+<li><a class="dropdown-item image-switch" data-captions="[&quot;X1-TEST_AUX-eventgram_autoscaled-4.png&quot;]" data-channel-name="X1-TEST_AUX" data-image-dir="plots" data-image-type="eventgram_autoscaled" data-t-ranges="[&quot;4&quot;]">autoscaled</a></li>
 </ul>
 </div>
 </div>
@@ -247,10 +247,11 @@ def test_navbar():
 def test_toggle_link():
     h1 = parse_html(html.toggle_link('timeseries_raw', GW.channels[0], [4]))
     h2 = parse_html(
-        '<a class="dropdown-item" '
-        'onclick="showImage(&quot;X1-TEST_AUX&quot;, [&quot;4&quot;], '
-        '&quot;timeseries_raw&quot;, '
-        '[&quot;X1-TEST_AUX-timeseries_raw-4.png&quot;]);">raw</a>'
+        '<a class="dropdown-item image-switch" data-captions='
+        '"[&quot;X1-TEST_AUX-timeseries_raw-4.png&quot;]" '
+        'data-channel-name="X1-TEST_AUX" data-image-dir="plots" '
+        'data-image-type="timeseries_raw" data-t-ranges="[&quot;4&quot;]">'
+        'raw</a>'
     )
     assert h1 == h2
 

--- a/gwdetchar/omega/tests/test_html.py
+++ b/gwdetchar/omega/tests/test_html.py
@@ -217,7 +217,7 @@ Eventgram view <span class="caret"></span>
 <div class="row">
 <div class="col-sm-12">
 <a href="plots/X1-TEST_AUX-qscan_whitened-4.png" id="a_X1-TEST_AUX_4" title="X1-TEST_AUX-qscan_whitened-4.png" class="fancybox" target="_blank" data-fancybox-group="images">
-<img id="img_X1-TEST_AUX_4" alt="X1-TEST_AUX-qscan_whitened-4.png" class="img-responsive" src="plots/X1-TEST_AUX-qscan_whitened-4.png" />
+<img id="img_X1-TEST_AUX_4" alt="X1-TEST_AUX-qscan_whitened-4.png" class="img-responsive lazy" src="plots/X1-TEST_AUX-qscan_whitened-4.png" />
 </a>
 </div>
 </div>


### PR DESCRIPTION
This PR takes advantage of a couple new additions to gwbootstrap:

* Use event listeners for button click actions, including for omega scans, table-to-CSV conversion, and return-to-top button
* Use [`jQuery.Lazy`](http://jquery.eisbehr.de/lazy/) to lazy-load omega scan output pages, since they have lots and lots of images

Example output is available [**here**](https://ldas-jobs.ligo.caltech.edu/~alexander.urban/wdq/L1_1238582513.88/) (requires `LIGO.ORG` credentials). See also gwdetchar/gwbootstrap#9.

cc @duncanmmacleod 