### PR TITLE
Clean up jQuery.Lazy calls

### DIFF
--- a/_setup_utils.py
+++ b/_setup_utils.py
@@ -23,6 +23,7 @@
 import glob
 import os.path
 from distutils import log
+from shutil import copyfile
 
 from setuptools import Command
 from setuptools.command.egg_info import egg_info

--- a/gwdetchar/io/html.py
+++ b/gwdetchar/io/html.py
@@ -753,11 +753,9 @@ def fancybox_img(img, linkparams=dict(), **params):
     imgparams = {
         'alt': os.path.basename(img),
         'class_': 'img-responsive lazy',
+        'src': img.replace('.svg', '.png'),
+        'data-src': img.replace('.svg', '.png'),
     }
-    if img.endswith('.svg') and os.path.isfile(img.replace('.svg', '.png')):
-        imgparams['src'] = img.replace('.svg', '.png')
-    else:
-        imgparams['src'] = img
     imgparams.update(params)
     page.img(id_='img_%s_%s' % (channel, duration), **imgparams)
     page.a.close()

--- a/gwdetchar/io/html.py
+++ b/gwdetchar/io/html.py
@@ -742,6 +742,7 @@ def fancybox_img(img, linkparams=dict(), **params):
         'title': img.caption,
         'class_': 'fancybox',
         'target': '_blank',
+        'data-fancybox': 'gallery',
         'data-fancybox-group': 'images',
     }
     aparams.update(linkparams)
@@ -753,7 +754,6 @@ def fancybox_img(img, linkparams=dict(), **params):
     imgparams = {
         'alt': os.path.basename(img),
         'class_': 'img-responsive lazy',
-        'src': img.replace('.svg', '.png'),
         'data-src': img.replace('.svg', '.png'),
     }
     imgparams.update(params)

--- a/gwdetchar/io/tests/test_html.py
+++ b/gwdetchar/io/tests/test_html.py
@@ -162,13 +162,13 @@ FLAG_HTML = FLAG_CONTENT.format(content="""<pre># seg\tstart\tstop\tduration
 
 FLAG_HTML_WITH_PLOTS = FLAG_CONTENT.format(
     content='<pre># seg\tstart\tstop\tduration\n0\t0\t66\t66.0\n</pre>',
-    plots='\n<a id="a_X1-TEST_FLAG_66" target="_blank" title="Known (small) '
-          'and active (large) analysis segments for X1:TEST_FLAG" '
-          'class="fancybox" href="plots/X1-TEST_FLAG-0-66.png" '
-          'data-fancybox-group="images">\n<img id="img_X1-TEST_FLAG_66" '
-          'alt="X1-TEST_FLAG-0-66.png" class="img-responsive lazy" '
-          'src="plots/X1-TEST_FLAG-0-66.png" '
-          'data-src="plots/X1-TEST_FLAG-0-66.png"/>\n</a>')
+    plots='\n<a href="plots/X1-TEST_FLAG-0-66.png" id="a_X1-TEST_FLAG_66" '
+          'title="Known (small) and active (large) analysis segments for '
+          'X1:TEST_FLAG" class="fancybox" target="_blank" '
+          'data-fancybox="gallery" data-fancybox-group="images">\n'
+          '<img id="img_X1-TEST_FLAG_66" alt="X1-TEST_FLAG-0-66.png" '
+          'class="img-responsive lazy" data-src="plots/X1-TEST_FLAG-0-66.png" '
+          '/>\n</a>')
 
 FLAG_HTML_NO_SEGMENTS = FLAG_CONTENT.format(
     content='<p>No segments were found.</p>', plots='')
@@ -190,18 +190,18 @@ OMEGA_SCAFFOLD = """<div class="panel well panel-default">
 </div>
 <div class="row">
 <div class="col-sm-4">
-<a href="./1126259462/plots/X1-STRAIN-qscan_whitened-1.png" id="a_X1-STRAIN_1" title="X1-STRAIN-qscan_whitened-1.png" class="fancybox" target="_blank" data-fancybox-group="images">
-<img id="img_X1-STRAIN_1" alt="X1-STRAIN-qscan_whitened-1.png" class="img-responsive lazy" src="./1126259462/plots/X1-STRAIN-qscan_whitened-1.png" data-src="./1126259462/plots/X1-STRAIN-qscan_whitened-1.png" />
+<a href="./1126259462/plots/X1-STRAIN-qscan_whitened-1.png" id="a_X1-STRAIN_1" title="X1-STRAIN-qscan_whitened-1.png" class="fancybox" target="_blank" data-fancybox="gallery" data-fancybox-group="images">
+<img id="img_X1-STRAIN_1" alt="X1-STRAIN-qscan_whitened-1.png" class="img-responsive lazy" data-src="./1126259462/plots/X1-STRAIN-qscan_whitened-1.png" />
 </a>
 </div>
 <div class="col-sm-4">
-<a href="./1126259462/plots/X1-STRAIN-qscan_whitened-4.png" id="a_X1-STRAIN_4" title="X1-STRAIN-qscan_whitened-4.png" class="fancybox" target="_blank" data-fancybox-group="images">
-<img id="img_X1-STRAIN_4" alt="X1-STRAIN-qscan_whitened-4.png" class="img-responsive lazy" src="./1126259462/plots/X1-STRAIN-qscan_whitened-4.png" data-src="./1126259462/plots/X1-STRAIN-qscan_whitened-4.png" />
+<a href="./1126259462/plots/X1-STRAIN-qscan_whitened-4.png" id="a_X1-STRAIN_4" title="X1-STRAIN-qscan_whitened-4.png" class="fancybox" target="_blank" data-fancybox="gallery" data-fancybox-group="images">
+<img id="img_X1-STRAIN_4" alt="X1-STRAIN-qscan_whitened-4.png" class="img-responsive lazy" data-src="./1126259462/plots/X1-STRAIN-qscan_whitened-4.png" />
 </a>
 </div>
 <div class="col-sm-4">
-<a href="./1126259462/plots/X1-STRAIN-qscan_whitened-16.png" id="a_X1-STRAIN_16" title="X1-STRAIN-qscan_whitened-16.png" class="fancybox" target="_blank" data-fancybox-group="images">
-<img id="img_X1-STRAIN_16" alt="X1-STRAIN-qscan_whitened-16.png" class="img-responsive lazy" src="./1126259462/plots/X1-STRAIN-qscan_whitened-16.png" data-src="./1126259462/plots/X1-STRAIN-qscan_whitened-16.png" />
+<a href="./1126259462/plots/X1-STRAIN-qscan_whitened-16.png" id="a_X1-STRAIN_16" title="X1-STRAIN-qscan_whitened-16.png" class="fancybox" target="_blank" data-fancybox="gallery" data-fancybox-group="images">
+<img id="img_X1-STRAIN_16" alt="X1-STRAIN-qscan_whitened-16.png" class="img-responsive lazy" data-src="./1126259462/plots/X1-STRAIN-qscan_whitened-16.png" />
 </a>
 </div>
 </div>
@@ -399,35 +399,32 @@ def test_fancybox_img():
     img = html.FancyPlot('X1-TEST_AUX-test-4.png')
     out = html.fancybox_img(img)
     assert parse_html(out) == parse_html(
-        '<a class="fancybox" href="X1-TEST_AUX-test-4.png" target="_blank" '
-        'data-fancybox-group="images" id="a_X1-TEST_AUX_4" '
-        'title="X1-TEST_AUX-test-4.png">\n'
-        '<img class="img-responsive lazy" alt="X1-TEST_AUX-test-4.png" '
-        'src="X1-TEST_AUX-test-4.png" data-src="X1-TEST_AUX-test-4.png" '
-        'id="img_X1-TEST_AUX_4"/>\n</a>')
+        '<a href="X1-TEST_AUX-test-4.png" id="a_X1-TEST_AUX_4" '
+        'title="X1-TEST_AUX-test-4.png" class="fancybox" target="_blank" '
+        'data-fancybox="gallery" data-fancybox-group="images">\n'
+        '<img id="img_X1-TEST_AUX_4" alt="X1-TEST_AUX-test-4.png" '
+        'class="img-responsive lazy" data-src="X1-TEST_AUX-test-4.png" />\n'
+        '</a>')
 
 
 def test_scaffold_plots():
-    h1 = parse_html(html.scaffold_plots([
+    h1 = html.scaffold_plots([
         html.FancyPlot('X1-TEST_AUX-test-4.png'),
-        html.FancyPlot('X1-TEST_AUX-test-16.png')], nperrow=2))
-    h2 = parse_html(
-        '<div class="row">\n'
-        '<div class="col-sm-6">\n'
-        '<a class="fancybox" href="X1-TEST_AUX-test-4.png" target="_blank" '
-        'id="a_X1-TEST_AUX_4" data-fancybox-group="images" '
-        'title="X1-TEST_AUX-test-4.png">\n'
-        '<img class="img-responsive lazy" alt="X1-TEST_AUX-test-4.png" '
-        'id="img_X1-TEST_AUX_4" src="X1-TEST_AUX-test-4.png" '
-        'data-src="X1-TEST_AUX-test-4.png"/>\n'
+        html.FancyPlot('X1-TEST_AUX-test-16.png')], nperrow=2)
+    assert parse_html(h1) == parse_html(
+        '<div class="row">\n<div class="col-sm-6">\n'
+        '<a href="X1-TEST_AUX-test-4.png" id="a_X1-TEST_AUX_4" '
+        'title="X1-TEST_AUX-test-4.png" class="fancybox" target="_blank" '
+        'data-fancybox="gallery" data-fancybox-group="images">\n'
+        '<img id="img_X1-TEST_AUX_4" alt="X1-TEST_AUX-test-4.png" '
+        'class="img-responsive lazy" data-src="X1-TEST_AUX-test-4.png" />\n'
         '</a>\n</div>\n<div class="col-sm-6">\n'
-        '<a class="fancybox" href="X1-TEST_AUX-test-16.png" target="_blank"'
-        ' id="a_X1-TEST_AUX_16" data-fancybox-group="images" '
-        'title="X1-TEST_AUX-test-16.png">\n'
-        '<img class="img-responsive lazy" alt="X1-TEST_AUX-test-16.png" '
-        'id="img_X1-TEST_AUX_16" src="X1-TEST_AUX-test-16.png" '
-        'data-src="X1-TEST_AUX-test-16.png"/>\n</a>\n</div>\n</div>')
-    assert h1 == h2
+        '<a href="X1-TEST_AUX-test-16.png" id="a_X1-TEST_AUX_16" '
+        'title="X1-TEST_AUX-test-16.png" class="fancybox" target="_blank" '
+        'data-fancybox="gallery" data-fancybox-group="images">\n'
+        '<img id="img_X1-TEST_AUX_16" alt="X1-TEST_AUX-test-16.png" '
+        'class="img-responsive lazy" data-src="X1-TEST_AUX-test-16.png" />\n'
+        '</a>\n</div>\n</div>')
 
 
 def test_download_btn():

--- a/gwdetchar/io/tests/test_html.py
+++ b/gwdetchar/io/tests/test_html.py
@@ -167,7 +167,8 @@ FLAG_HTML_WITH_PLOTS = FLAG_CONTENT.format(
           'class="fancybox" href="plots/X1-TEST_FLAG-0-66.png" '
           'data-fancybox-group="images">\n<img id="img_X1-TEST_FLAG_66" '
           'alt="X1-TEST_FLAG-0-66.png" class="img-responsive lazy" '
-          'src="plots/X1-TEST_FLAG-0-66.png" />\n</a>')
+          'src="plots/X1-TEST_FLAG-0-66.png" '
+          'data-src="plots/X1-TEST_FLAG-0-66.png"/>\n</a>')
 
 FLAG_HTML_NO_SEGMENTS = FLAG_CONTENT.format(
     content='<p>No segments were found.</p>', plots='')
@@ -190,17 +191,17 @@ OMEGA_SCAFFOLD = """<div class="panel well panel-default">
 <div class="row">
 <div class="col-sm-4">
 <a href="./1126259462/plots/X1-STRAIN-qscan_whitened-1.png" id="a_X1-STRAIN_1" title="X1-STRAIN-qscan_whitened-1.png" class="fancybox" target="_blank" data-fancybox-group="images">
-<img id="img_X1-STRAIN_1" alt="X1-STRAIN-qscan_whitened-1.png" class="img-responsive lazy" src="./1126259462/plots/X1-STRAIN-qscan_whitened-1.png" />
+<img id="img_X1-STRAIN_1" alt="X1-STRAIN-qscan_whitened-1.png" class="img-responsive lazy" src="./1126259462/plots/X1-STRAIN-qscan_whitened-1.png" data-src="./1126259462/plots/X1-STRAIN-qscan_whitened-1.png" />
 </a>
 </div>
 <div class="col-sm-4">
 <a href="./1126259462/plots/X1-STRAIN-qscan_whitened-4.png" id="a_X1-STRAIN_4" title="X1-STRAIN-qscan_whitened-4.png" class="fancybox" target="_blank" data-fancybox-group="images">
-<img id="img_X1-STRAIN_4" alt="X1-STRAIN-qscan_whitened-4.png" class="img-responsive lazy" src="./1126259462/plots/X1-STRAIN-qscan_whitened-4.png" />
+<img id="img_X1-STRAIN_4" alt="X1-STRAIN-qscan_whitened-4.png" class="img-responsive lazy" src="./1126259462/plots/X1-STRAIN-qscan_whitened-4.png" data-src="./1126259462/plots/X1-STRAIN-qscan_whitened-4.png" />
 </a>
 </div>
 <div class="col-sm-4">
 <a href="./1126259462/plots/X1-STRAIN-qscan_whitened-16.png" id="a_X1-STRAIN_16" title="X1-STRAIN-qscan_whitened-16.png" class="fancybox" target="_blank" data-fancybox-group="images">
-<img id="img_X1-STRAIN_16" alt="X1-STRAIN-qscan_whitened-16.png" class="img-responsive lazy" src="./1126259462/plots/X1-STRAIN-qscan_whitened-16.png" />
+<img id="img_X1-STRAIN_16" alt="X1-STRAIN-qscan_whitened-16.png" class="img-responsive lazy" src="./1126259462/plots/X1-STRAIN-qscan_whitened-16.png" data-src="./1126259462/plots/X1-STRAIN-qscan_whitened-16.png" />
 </a>
 </div>
 </div>
@@ -402,8 +403,8 @@ def test_fancybox_img():
         'data-fancybox-group="images" id="a_X1-TEST_AUX_4" '
         'title="X1-TEST_AUX-test-4.png">\n'
         '<img class="img-responsive lazy" alt="X1-TEST_AUX-test-4.png" '
-        'src="X1-TEST_AUX-test-4.png" id="img_X1-TEST_AUX_4"/>\n'
-        '</a>')
+        'src="X1-TEST_AUX-test-4.png" data-src="X1-TEST_AUX-test-4.png" '
+        'id="img_X1-TEST_AUX_4"/>\n</a>')
 
 
 def test_scaffold_plots():
@@ -417,14 +418,15 @@ def test_scaffold_plots():
         'id="a_X1-TEST_AUX_4" data-fancybox-group="images" '
         'title="X1-TEST_AUX-test-4.png">\n'
         '<img class="img-responsive lazy" alt="X1-TEST_AUX-test-4.png" '
-        'id="img_X1-TEST_AUX_4" src="X1-TEST_AUX-test-4.png" />\n'
+        'id="img_X1-TEST_AUX_4" src="X1-TEST_AUX-test-4.png" '
+        'data-src="X1-TEST_AUX-test-4.png"/>\n'
         '</a>\n</div>\n<div class="col-sm-6">\n'
         '<a class="fancybox" href="X1-TEST_AUX-test-16.png" target="_blank"'
         ' id="a_X1-TEST_AUX_16" data-fancybox-group="images" '
         'title="X1-TEST_AUX-test-16.png">\n'
         '<img class="img-responsive lazy" alt="X1-TEST_AUX-test-16.png" '
-        'id="img_X1-TEST_AUX_16" src="X1-TEST_AUX-test-16.png" />\n'
-        '</a>\n</div>\n</div>')
+        'id="img_X1-TEST_AUX_16" src="X1-TEST_AUX-test-16.png" '
+        'data-src="X1-TEST_AUX-test-16.png"/>\n</a>\n</div>\n</div>')
     assert h1 == h2
 
 

--- a/gwdetchar/omega/tests/test_html.py
+++ b/gwdetchar/omega/tests/test_html.py
@@ -217,7 +217,7 @@ Eventgram view <span class="caret"></span>
 <div class="row">
 <div class="col-sm-12">
 <a href="plots/X1-TEST_AUX-qscan_whitened-4.png" id="a_X1-TEST_AUX_4" title="X1-TEST_AUX-qscan_whitened-4.png" class="fancybox" target="_blank" data-fancybox-group="images">
-<img id="img_X1-TEST_AUX_4" alt="X1-TEST_AUX-qscan_whitened-4.png" class="img-responsive lazy" src="plots/X1-TEST_AUX-qscan_whitened-4.png" />
+<img id="img_X1-TEST_AUX_4" alt="X1-TEST_AUX-qscan_whitened-4.png" class="img-responsive lazy" src="plots/X1-TEST_AUX-qscan_whitened-4.png" data-src="plots/X1-TEST_AUX-qscan_whitened-4.png" />
 </a>
 </div>
 </div>

--- a/gwdetchar/omega/tests/test_html.py
+++ b/gwdetchar/omega/tests/test_html.py
@@ -216,8 +216,8 @@ Eventgram view <span class="caret"></span>
 </div>
 <div class="row">
 <div class="col-sm-12">
-<a href="plots/X1-TEST_AUX-qscan_whitened-4.png" id="a_X1-TEST_AUX_4" title="X1-TEST_AUX-qscan_whitened-4.png" class="fancybox" target="_blank" data-fancybox-group="images">
-<img id="img_X1-TEST_AUX_4" alt="X1-TEST_AUX-qscan_whitened-4.png" class="img-responsive lazy" src="plots/X1-TEST_AUX-qscan_whitened-4.png" data-src="plots/X1-TEST_AUX-qscan_whitened-4.png" />
+<a href="plots/X1-TEST_AUX-qscan_whitened-4.png" id="a_X1-TEST_AUX_4" title="X1-TEST_AUX-qscan_whitened-4.png" class="fancybox" target="_blank" data-fancybox="gallery" data-fancybox-group="images">
+<img id="img_X1-TEST_AUX_4" alt="X1-TEST_AUX-qscan_whitened-4.png" class="img-responsive lazy" data-src="plots/X1-TEST_AUX-qscan_whitened-4.png" />
 </a>
 </div>
 </div>


### PR DESCRIPTION
This PR cleans up calls to `jQuery.Lazy()` by updating the `gwbootstrap` version pin (see gwdetchar/gwbootstrap#10), and by adding `data-src` attributes to HTML `omg` objects.