### PR TITLE
Spacing enhancements for collapsed plots

### DIFF
--- a/bin/gwdetchar-lasso-correlation
+++ b/bin/gwdetchar-lasso-correlation
@@ -638,7 +638,7 @@ page.add(htmlio.get_command_line(about=False))
 
 if args.band_pass:
     page.h2('Primary channel spectra', class_='mt-4', id_='spectra')
-    page.div(class_='card card-%s card-body shadow-sm' % args.ifo.lower())
+    page.div(class_='card border-light card-body shadow-sm')
     page.div(class_='row')
     page.div(class_='col-md-6')
     spectra_img1 = htmlio.FancyPlot(spectrum_plot_zoomed_out)
@@ -649,7 +649,7 @@ if args.band_pass:
     page.add(htmlio.fancybox_img(spectra_img2))
     page.div.close()  # col-md-6
     page.div.close()  # row
-    page.div.close()  # card card-<ifo> card-body shadow-sm
+    page.div.close()  # card border-light card-body shadow-sm
 
 # -- model information
 page.h2('Model information', class_='mt-4', id_='model')
@@ -708,16 +708,16 @@ for i, (ch, lassocoef, plot4, plot5, plot6, ts) in enumerate(results):
         h = '%s [lasso coefficient = %.4f]' % (ch, lassocoef)
     if ((lassocoef is None) or (lassocoef == 0)
             or (abs(lassocoef) < args.threshold)):
-        card = 'card outline-light mb-1 shadow-sm'
+        card = 'card border-light mb-1 shadow-sm'
         card_header = 'card-header bg-light'
     elif abs(lassocoef) >= .5:
-        card = 'card outline-danger mb-1 shadow-sm'
+        card = 'card border-danger mb-1 shadow-sm'
         card_header = 'card-header text-white bg-danger'
     elif abs(lassocoef) >= .2:
-        card = 'card outline-warning mb-1 shadow-sm'
+        card = 'card border-warning mb-1 shadow-sm'
         card_header = 'card-header text-white bg-warning'
     else:
-        card = 'card outline-info mb-1 shadow-sm'
+        card = 'card border-info mb-1 shadow-sm'
         card_header = 'card-header text-white bg-info'
     page.div(class_=card)
 

--- a/bin/gwdetchar-scattering
+++ b/bin/gwdetchar-scattering
@@ -538,12 +538,18 @@ for i, channel in enumerate(sorted(osems)):
     page.div(id_='osem%s' % i, class_='collapse',
              **{'data-parent': '#osems-group'})
     page.div(class_='card-body')
+    page.div(class_='row')
     img = htmlio.FancyPlot(
         png, caption=scattering.SCATTER_CAPTION.format(CHANNEL=channel))
+    page.div(class_='col-md-10 offset-md-1')
     page.add(htmlio.fancybox_img(img))
+    page.div.close()  # col-md-10 offset-md-1
     himg = htmlio.FancyPlot(
         hpng, caption=scattering.HIST_CAPTION.format(CHANNEL=channel))
+    page.div(class_='col-md-10 offset-md-1')
     page.add(htmlio.fancybox_img(himg))
+    page.div.close()  # col-md-10 offset-md-1
+    page.div.close()  # row
     segs = StringIO()
     if deadtime:
         page.p("%d segments were found predicting a scattering fringe above "

--- a/gwdetchar/io/html.py
+++ b/gwdetchar/io/html.py
@@ -753,7 +753,7 @@ def fancybox_img(img, linkparams=dict(), lazy=False, **params):
     src_attr = lazy and 'data-src' or 'src'
     imgparams = {
         'alt': os.path.basename(img),
-        'class_': lazy and 'img-fluid lazy' or 'img-fluid',
+        'class_': lazy and 'img-fluid w-100 lazy' or 'img-fluid w-100',
         src_attr: img.replace('.svg', '.png'),
     }
     imgparams.update(params)

--- a/gwdetchar/io/html.py
+++ b/gwdetchar/io/html.py
@@ -335,7 +335,7 @@ def navbar(links, class_='navbar navbar-expand-md fixed-top shadow-sm',
     class_ : `str`, optional
         navbar object class, default: `'navbar navbar-expand-md fixed-top'`
 
-    brand : `str` or `~MarkupPy.markup.page`, optional
+    brand : `str`, `~MarkupPy.markup.page`, or `list`, optional
         branding for the navigation bar, default: None
 
     collapse : `bool`, optional

--- a/gwdetchar/io/html.py
+++ b/gwdetchar/io/html.py
@@ -740,6 +740,7 @@ def fancybox_img(img, linkparams=dict(), lazy=False, **params):
         'title': img.caption,
         'class_': 'fancybox',
         'target': '_blank',
+        'data-caption': img.caption,
         'data-fancybox': 'gallery',
         'data-fancybox-group': 'images',
     }

--- a/gwdetchar/io/html.py
+++ b/gwdetchar/io/html.py
@@ -785,7 +785,7 @@ def scaffold_plots(plots, nperrow=3, lazy=True):
     # scaffold plots
     for i, p in enumerate(plots):
         if i % nperrow == 0:
-            page.div(class_='row')
+            page.div(class_='row scaffold')
         page.div(class_='col-sm-%d' % x)
         page.add(fancybox_img(p, lazy=lazy))
         page.div.close()  # col
@@ -1066,7 +1066,7 @@ def write_flag_html(flag, span=None, id=0, parent='accordion',
         img = FancyPlot(
             img=png, caption='Known (small) and active (large) analysis '
                              'segments for {}'.format(title))
-        page.add(fancybox_img(img))
+        page.add(scaffold_plots([img], nperrow=1, lazy=False))
     # write segments
     segs = StringIO()
     try:

--- a/gwdetchar/io/tests/test_html.py
+++ b/gwdetchar/io/tests/test_html.py
@@ -167,8 +167,8 @@ FLAG_HTML_WITH_PLOTS = FLAG_CONTENT.format(
           '"Known (small) and active (large) analysis segments for '
           'X1:TEST_FLAG" data-fancybox="gallery" data-fancybox-group="images"'
           '>\n<img id="img_X1-TEST_FLAG_66" alt="X1-TEST_FLAG-0-66.png" '
-          'class="img-fluid" src="plots/X1-TEST_FLAG-0-66.png" />\n</a>\n'
-          '</div>\n</div>')
+          'class="img-fluid w-100" src="plots/X1-TEST_FLAG-0-66.png" />\n</a>'
+          '\n</div>\n</div>')
 
 FLAG_HTML_NO_SEGMENTS = FLAG_CONTENT.format(
     content='<p>No segments were found.</p>', plots='')
@@ -191,17 +191,17 @@ OMEGA_SCAFFOLD = """<div class="card card-x1">
 <div class="row scaffold">
 <div class="col-sm-4">
 <a href="./1126259462/plots/X1-STRAIN-qscan_whitened-1.png" id="a_X1-STRAIN_1" title="X1-STRAIN-qscan_whitened-1.png" class="fancybox" target="_blank" data-caption="X1-STRAIN-qscan_whitened-1.png" data-fancybox="gallery" data-fancybox-group="images">
-<img id="img_X1-STRAIN_1" alt="X1-STRAIN-qscan_whitened-1.png" class="img-fluid lazy" data-src="./1126259462/plots/X1-STRAIN-qscan_whitened-1.png" />
+<img id="img_X1-STRAIN_1" alt="X1-STRAIN-qscan_whitened-1.png" class="img-fluid w-100 lazy" data-src="./1126259462/plots/X1-STRAIN-qscan_whitened-1.png" />
 </a>
 </div>
 <div class="col-sm-4">
 <a href="./1126259462/plots/X1-STRAIN-qscan_whitened-4.png" id="a_X1-STRAIN_4" title="X1-STRAIN-qscan_whitened-4.png" class="fancybox" target="_blank" data-caption="X1-STRAIN-qscan_whitened-4.png" data-fancybox="gallery" data-fancybox-group="images">
-<img id="img_X1-STRAIN_4" alt="X1-STRAIN-qscan_whitened-4.png" class="img-fluid lazy" data-src="./1126259462/plots/X1-STRAIN-qscan_whitened-4.png" />
+<img id="img_X1-STRAIN_4" alt="X1-STRAIN-qscan_whitened-4.png" class="img-fluid w-100 lazy" data-src="./1126259462/plots/X1-STRAIN-qscan_whitened-4.png" />
 </a>
 </div>
 <div class="col-sm-4">
 <a href="./1126259462/plots/X1-STRAIN-qscan_whitened-16.png" id="a_X1-STRAIN_16" title="X1-STRAIN-qscan_whitened-16.png" class="fancybox" target="_blank" data-caption="X1-STRAIN-qscan_whitened-16.png" data-fancybox="gallery" data-fancybox-group="images">
-<img id="img_X1-STRAIN_16" alt="X1-STRAIN-qscan_whitened-16.png" class="img-fluid lazy" data-src="./1126259462/plots/X1-STRAIN-qscan_whitened-16.png" />
+<img id="img_X1-STRAIN_16" alt="X1-STRAIN-qscan_whitened-16.png" class="img-fluid w-100 lazy" data-src="./1126259462/plots/X1-STRAIN-qscan_whitened-16.png" />
 </a>
 </div>
 </div>
@@ -408,7 +408,7 @@ def test_fancybox_img():
         'title="X1-TEST_AUX-test-4.png" class="fancybox" target="_blank" '
         'data-caption="X1-TEST_AUX-test-4.png" data-fancybox="gallery" '
         'data-fancybox-group="images">\n<img id="img_X1-TEST_AUX_4" '
-        'alt="X1-TEST_AUX-test-4.png" class="img-fluid" '
+        'alt="X1-TEST_AUX-test-4.png" class="img-fluid w-100" '
         'src="X1-TEST_AUX-test-4.png" />\n</a>')
 
 
@@ -423,14 +423,14 @@ def test_scaffold_plots():
         'data-caption="X1-TEST_AUX-test-4.png" data-fancybox="gallery" '
         'data-fancybox-group="images">\n'
         '<img id="img_X1-TEST_AUX_4" alt="X1-TEST_AUX-test-4.png" '
-        'class="img-fluid lazy" data-src="X1-TEST_AUX-test-4.png" />\n'
+        'class="img-fluid w-100 lazy" data-src="X1-TEST_AUX-test-4.png" />\n'
         '</a>\n</div>\n<div class="col-sm-6">\n'
         '<a href="X1-TEST_AUX-test-16.png" id="a_X1-TEST_AUX_16" '
         'title="X1-TEST_AUX-test-16.png" class="fancybox" target="_blank" '
         'data-caption="X1-TEST_AUX-test-16.png" data-fancybox="gallery" '
         'data-fancybox-group="images">\n'
         '<img id="img_X1-TEST_AUX_16" alt="X1-TEST_AUX-test-16.png" '
-        'class="img-fluid lazy" data-src="X1-TEST_AUX-test-16.png" />\n'
+        'class="img-fluid w-100 lazy" data-src="X1-TEST_AUX-test-16.png" />\n'
         '</a>\n</div>\n</div>')
 
 

--- a/gwdetchar/io/tests/test_html.py
+++ b/gwdetchar/io/tests/test_html.py
@@ -163,10 +163,12 @@ FLAG_HTML_WITH_PLOTS = FLAG_CONTENT.format(
     plots='\n<div class="row scaffold">\n<div class="col-sm-12">\n<a '
           'href="plots/X1-TEST_FLAG-0-66.png" id="a_X1-TEST_FLAG_66" '
           'title="Known (small) and active (large) analysis segments for '
-          'X1:TEST_FLAG" class="fancybox" target="_blank" data-fancybox='
-          '"gallery" data-fancybox-group="images">\n<img id="img_X1-TEST_FLAG'
-          '_66" alt="X1-TEST_FLAG-0-66.png" class="img-fluid" src="plots/X1-'
-          'TEST_FLAG-0-66.png" />\n</a>\n</div>\n</div>')
+          'X1:TEST_FLAG" class="fancybox" target="_blank" data-caption='
+          '"Known (small) and active (large) analysis segments for '
+          'X1:TEST_FLAG" data-fancybox="gallery" data-fancybox-group="images"'
+          '>\n<img id="img_X1-TEST_FLAG_66" alt="X1-TEST_FLAG-0-66.png" '
+          'class="img-fluid" src="plots/X1-TEST_FLAG-0-66.png" />\n</a>\n'
+          '</div>\n</div>')
 
 FLAG_HTML_NO_SEGMENTS = FLAG_CONTENT.format(
     content='<p>No segments were found.</p>', plots='')
@@ -188,17 +190,17 @@ OMEGA_SCAFFOLD = """<div class="card card-x1">
 </div>
 <div class="row scaffold">
 <div class="col-sm-4">
-<a href="./1126259462/plots/X1-STRAIN-qscan_whitened-1.png" id="a_X1-STRAIN_1" title="X1-STRAIN-qscan_whitened-1.png" class="fancybox" target="_blank" data-fancybox="gallery" data-fancybox-group="images">
+<a href="./1126259462/plots/X1-STRAIN-qscan_whitened-1.png" id="a_X1-STRAIN_1" title="X1-STRAIN-qscan_whitened-1.png" class="fancybox" target="_blank" data-caption="X1-STRAIN-qscan_whitened-1.png" data-fancybox="gallery" data-fancybox-group="images">
 <img id="img_X1-STRAIN_1" alt="X1-STRAIN-qscan_whitened-1.png" class="img-fluid lazy" data-src="./1126259462/plots/X1-STRAIN-qscan_whitened-1.png" />
 </a>
 </div>
 <div class="col-sm-4">
-<a href="./1126259462/plots/X1-STRAIN-qscan_whitened-4.png" id="a_X1-STRAIN_4" title="X1-STRAIN-qscan_whitened-4.png" class="fancybox" target="_blank" data-fancybox="gallery" data-fancybox-group="images">
+<a href="./1126259462/plots/X1-STRAIN-qscan_whitened-4.png" id="a_X1-STRAIN_4" title="X1-STRAIN-qscan_whitened-4.png" class="fancybox" target="_blank" data-caption="X1-STRAIN-qscan_whitened-4.png" data-fancybox="gallery" data-fancybox-group="images">
 <img id="img_X1-STRAIN_4" alt="X1-STRAIN-qscan_whitened-4.png" class="img-fluid lazy" data-src="./1126259462/plots/X1-STRAIN-qscan_whitened-4.png" />
 </a>
 </div>
 <div class="col-sm-4">
-<a href="./1126259462/plots/X1-STRAIN-qscan_whitened-16.png" id="a_X1-STRAIN_16" title="X1-STRAIN-qscan_whitened-16.png" class="fancybox" target="_blank" data-fancybox="gallery" data-fancybox-group="images">
+<a href="./1126259462/plots/X1-STRAIN-qscan_whitened-16.png" id="a_X1-STRAIN_16" title="X1-STRAIN-qscan_whitened-16.png" class="fancybox" target="_blank" data-caption="X1-STRAIN-qscan_whitened-16.png" data-fancybox="gallery" data-fancybox-group="images">
 <img id="img_X1-STRAIN_16" alt="X1-STRAIN-qscan_whitened-16.png" class="img-fluid lazy" data-src="./1126259462/plots/X1-STRAIN-qscan_whitened-16.png" />
 </a>
 </div>
@@ -404,9 +406,10 @@ def test_fancybox_img():
     assert parse_html(out) == parse_html(
         '<a href="X1-TEST_AUX-test-4.png" id="a_X1-TEST_AUX_4" '
         'title="X1-TEST_AUX-test-4.png" class="fancybox" target="_blank" '
-        'data-fancybox="gallery" data-fancybox-group="images">\n'
-        '<img id="img_X1-TEST_AUX_4" alt="X1-TEST_AUX-test-4.png" '
-        'class="img-fluid" src="X1-TEST_AUX-test-4.png" />\n</a>')
+        'data-caption="X1-TEST_AUX-test-4.png" data-fancybox="gallery" '
+        'data-fancybox-group="images">\n<img id="img_X1-TEST_AUX_4" '
+        'alt="X1-TEST_AUX-test-4.png" class="img-fluid" '
+        'src="X1-TEST_AUX-test-4.png" />\n</a>')
 
 
 def test_scaffold_plots():
@@ -417,13 +420,15 @@ def test_scaffold_plots():
         '<div class="row scaffold">\n<div class="col-sm-6">\n'
         '<a href="X1-TEST_AUX-test-4.png" id="a_X1-TEST_AUX_4" '
         'title="X1-TEST_AUX-test-4.png" class="fancybox" target="_blank" '
-        'data-fancybox="gallery" data-fancybox-group="images">\n'
+        'data-caption="X1-TEST_AUX-test-4.png" data-fancybox="gallery" '
+        'data-fancybox-group="images">\n'
         '<img id="img_X1-TEST_AUX_4" alt="X1-TEST_AUX-test-4.png" '
         'class="img-fluid lazy" data-src="X1-TEST_AUX-test-4.png" />\n'
         '</a>\n</div>\n<div class="col-sm-6">\n'
         '<a href="X1-TEST_AUX-test-16.png" id="a_X1-TEST_AUX_16" '
         'title="X1-TEST_AUX-test-16.png" class="fancybox" target="_blank" '
-        'data-fancybox="gallery" data-fancybox-group="images">\n'
+        'data-caption="X1-TEST_AUX-test-16.png" data-fancybox="gallery" '
+        'data-fancybox-group="images">\n'
         '<img id="img_X1-TEST_AUX_16" alt="X1-TEST_AUX-test-16.png" '
         'class="img-fluid lazy" data-src="X1-TEST_AUX-test-16.png" />\n'
         '</a>\n</div>\n</div>')

--- a/gwdetchar/io/tests/test_html.py
+++ b/gwdetchar/io/tests/test_html.py
@@ -160,13 +160,13 @@ FLAG_HTML = FLAG_CONTENT.format(content="""<pre># seg\tstart\tstop\tduration
 
 FLAG_HTML_WITH_PLOTS = FLAG_CONTENT.format(
     content='<pre># seg\tstart\tstop\tduration\n0\t0\t66\t66.0\n</pre>',
-    plots='\n<a href="plots/X1-TEST_FLAG-0-66.png" id="a_X1-TEST_FLAG_66" '
+    plots='\n<div class="row scaffold">\n<div class="col-sm-12">\n<a '
+          'href="plots/X1-TEST_FLAG-0-66.png" id="a_X1-TEST_FLAG_66" '
           'title="Known (small) and active (large) analysis segments for '
-          'X1:TEST_FLAG" class="fancybox" target="_blank" '
-          'data-fancybox="gallery" data-fancybox-group="images">\n'
-          '<img id="img_X1-TEST_FLAG_66" alt="X1-TEST_FLAG-0-66.png" '
-          'class="img-fluid" src="plots/X1-TEST_FLAG-0-66.png" '
-          '/>\n</a>')
+          'X1:TEST_FLAG" class="fancybox" target="_blank" data-fancybox='
+          '"gallery" data-fancybox-group="images">\n<img id="img_X1-TEST_FLAG'
+          '_66" alt="X1-TEST_FLAG-0-66.png" class="img-fluid" src="plots/X1-'
+          'TEST_FLAG-0-66.png" />\n</a>\n</div>\n</div>')
 
 FLAG_HTML_NO_SEGMENTS = FLAG_CONTENT.format(
     content='<p>No segments were found.</p>', plots='')
@@ -186,7 +186,7 @@ OMEGA_SCAFFOLD = """<div class="card card-x1">
 <a href="./1126259462" class="text-dark">1126259462</a>
 </h6>
 </div>
-<div class="row">
+<div class="row scaffold">
 <div class="col-sm-4">
 <a href="./1126259462/plots/X1-STRAIN-qscan_whitened-1.png" id="a_X1-STRAIN_1" title="X1-STRAIN-qscan_whitened-1.png" class="fancybox" target="_blank" data-fancybox="gallery" data-fancybox-group="images">
 <img id="img_X1-STRAIN_1" alt="X1-STRAIN-qscan_whitened-1.png" class="img-fluid lazy" data-src="./1126259462/plots/X1-STRAIN-qscan_whitened-1.png" />
@@ -414,7 +414,7 @@ def test_scaffold_plots():
         html.FancyPlot('X1-TEST_AUX-test-4.png'),
         html.FancyPlot('X1-TEST_AUX-test-16.png')], nperrow=2)
     assert parse_html(h1) == parse_html(
-        '<div class="row">\n<div class="col-sm-6">\n'
+        '<div class="row scaffold">\n<div class="col-sm-6">\n'
         '<a href="X1-TEST_AUX-test-4.png" id="a_X1-TEST_AUX_4" '
         'title="X1-TEST_AUX-test-4.png" class="fancybox" target="_blank" '
         'data-fancybox="gallery" data-fancybox-group="images">\n'

--- a/gwdetchar/omega/tests/test_html.py
+++ b/gwdetchar/omega/tests/test_html.py
@@ -191,9 +191,9 @@ BLOCK_HTML = """<div class="card card-x1 mb-5 shadow-sm">
 </div>
 </div>
 </div>
-<div class="row">
+<div class="row scaffold">
 <div class="col-sm-12">
-<a href="plots/X1-TEST_AUX-qscan_whitened-4.png" id="a_X1-TEST_AUX_4" title="X1-TEST_AUX-qscan_whitened-4.png" class="fancybox" target="_blank" data-fancybox="gallery" data-fancybox-group="images">
+<a href="plots/X1-TEST_AUX-qscan_whitened-4.png" id="a_X1-TEST_AUX_4" title="X1-TEST_AUX-qscan_whitened-4.png" class="fancybox" target="_blank" data-caption="X1-TEST_AUX-qscan_whitened-4.png" data-fancybox="gallery" data-fancybox-group="images">
 <img id="img_X1-TEST_AUX_4" alt="X1-TEST_AUX-qscan_whitened-4.png" class="img-fluid lazy" data-src="plots/X1-TEST_AUX-qscan_whitened-4.png" />
 </a>
 </div>

--- a/gwdetchar/omega/tests/test_html.py
+++ b/gwdetchar/omega/tests/test_html.py
@@ -194,7 +194,7 @@ BLOCK_HTML = """<div class="card card-x1 mb-5 shadow-sm">
 <div class="row scaffold">
 <div class="col-sm-12">
 <a href="plots/X1-TEST_AUX-qscan_whitened-4.png" id="a_X1-TEST_AUX_4" title="X1-TEST_AUX-qscan_whitened-4.png" class="fancybox" target="_blank" data-caption="X1-TEST_AUX-qscan_whitened-4.png" data-fancybox="gallery" data-fancybox-group="images">
-<img id="img_X1-TEST_AUX_4" alt="X1-TEST_AUX-qscan_whitened-4.png" class="img-fluid lazy" data-src="plots/X1-TEST_AUX-qscan_whitened-4.png" />
+<img id="img_X1-TEST_AUX_4" alt="X1-TEST_AUX-qscan_whitened-4.png" class="img-fluid w-100 lazy" data-src="plots/X1-TEST_AUX-qscan_whitened-4.png" />
 </a>
 </div>
 </div>


### PR DESCRIPTION
This PR re-centers plots as they appear in collapsed bootstrap cards, and replaces the `scaffold` class in a couple of places where it's relevant.