### PR TITLE
Style fix for multi-column navbar dropdowns

### DIFF
--- a/gwdetchar/io/html.py
+++ b/gwdetchar/io/html.py
@@ -441,21 +441,28 @@ def dropdown(text, links, active=None, class_='nav-link dropdown-toggle'):
     # work out columns
     ngroup = sum([isinstance(x, (tuple, list)) and len(x) and
                   isinstance(x[1], (tuple, list)) for x in links])
-    ncol = 1 or min(ngroup, 4)
-    column = 'col-sm-12 col-md-%d' % (12 // ncol)
+    ncol = min(ngroup, 4) or 1
+    page.div(class_='dropdown-menu dropdown-%d-col shadow' % ncol)
 
     # dropdown elements
-    page.div(class_='dropdown-menu dropdown-%d-col shadow' % ncol)
-    page.div(class_='row')
     for i, link in enumerate(links):
+        # handle active links
         if isinstance(active, int) and i == active:
             active_ = True
         elif isinstance(active, (list, tuple)) and i == active[0]:
             active_ = active[1]
         else:
             active_ = False
-        dropdown_link(page, link, active=active_, class_=column)
-    page.div.close()  # row
+        # handle multi-column
+        if isinstance(link, (tuple, list)):
+            page.div(class_='row')
+            dropdown_link(page, link, active=active_,
+                          class_='col-sm-12 col-md-%d' % (12 // ncol))
+            page.div.close()  # row
+        else:
+            dropdown_link(page, link, active=active_)
+
+    # close and return
     page.div.close()  # dropdown-menu
     return page()
 

--- a/gwdetchar/io/html.py
+++ b/gwdetchar/io/html.py
@@ -441,7 +441,7 @@ def dropdown(text, links, active=None, class_='nav-link dropdown-toggle'):
     # work out columns
     ngroup = sum([isinstance(x, (tuple, list)) and len(x) and
                  isinstance(x[1], (tuple, list)) for x in links])
-    if ngroup < 2:
+    if ngroup < 1:
         column = ''
     else:
         ncol = min(ngroup, 4)

--- a/gwdetchar/io/html.py
+++ b/gwdetchar/io/html.py
@@ -1017,7 +1017,7 @@ def table(headers, data, caption=None, separator='', id=None, **class_):
     # add export button
     if id:
         page.button(
-            'Export to CSV', class_='btn btn-outline-secondary btn-table',
+            'Export to CSV', class_='btn btn-outline-secondary btn-table mt-2',
             **{'data-table-id': id, 'data-filename': '%s.csv' % id})
     return page()
 

--- a/gwdetchar/io/html.py
+++ b/gwdetchar/io/html.py
@@ -450,7 +450,6 @@ def dropdown(text, links, active=None, class_='nav-link dropdown-toggle'):
     # dropdown elements
     if column:
         page.div(class_='dropdown-menu dropdown-%d-col shadow' % ncol)
-        page.div(class_='container')
         page.div(class_='row')
     else:
         page.div(class_='dropdown-menu shadow')
@@ -464,7 +463,6 @@ def dropdown(text, links, active=None, class_='nav-link dropdown-toggle'):
         dropdown_link(page, link, active=active_, class_=column)
     if column:
         page.div.close()  # row
-        page.div.close()  # container
     page.div.close()
     return page()
 
@@ -595,7 +593,7 @@ def about_this_page(config, packagelist=True):
     elif isinstance(config, list):
         page.div(id_='accordion')
         for i, cpfile in enumerate(config):
-            page.div(class_='card bg-light mb-1 shadow-sm')
+            page.div(class_='card mb-1 shadow-sm')
             page.div(class_='card-header')
             page.a(
                 os.path.basename(cpfile), class_='collapsed card-link',
@@ -1298,7 +1296,7 @@ def package_table(
     # create page and write <table>
     page = markup.page(separator="")
     if h2 is not None:
-        page.h2(h2)
+        page.h2(h2, class_='mt-4')
     headers = [head.title() for head in cols]
     data = [[pkg[col.lower()] for col in cols]
             for pkg in sorted(pkgs, key=itemgetter("name"))]

--- a/gwdetchar/io/html.py
+++ b/gwdetchar/io/html.py
@@ -445,13 +445,15 @@ def dropdown(text, links, active=None, class_='nav-link dropdown-toggle'):
         column = ''
     else:
         ncol = min(ngroup, 4)
-        column = 'col-12 col-md-%d' % (12 // ncol)
+        column = 'col-sm-12 col-md-%d' % (12 // ncol)
 
     # dropdown elements
     if column:
-        page.ul(class_='dropdown-menu dropdown-%d-col row shadow' % ncol)
+        page.div(class_='dropdown-menu dropdown-%d-col shadow' % ncol)
+        page.div(class_='container')
+        page.div(class_='row')
     else:
-        page.ul(class_='dropdown-menu shadow')
+        page.div(class_='dropdown-menu shadow')
     for i, link in enumerate(links):
         if isinstance(active, int) and i == active:
             active_ = True
@@ -460,7 +462,10 @@ def dropdown(text, links, active=None, class_='nav-link dropdown-toggle'):
         else:
             active_ = False
         dropdown_link(page, link, active=active_, class_=column)
-    page.ul.close()
+    if column:
+        page.div.close()  # row
+        page.div.close()  # container
+    page.div.close()
     return page()
 
 
@@ -482,25 +487,22 @@ def dropdown_link(page, link, active=False, class_=''):
     class_ : `str`, optional
         object class of the link, default: `''`
     """
-    if link is None:
-        page.li(class_='dropdown-divider')
-    elif active is True:
-        page.li(class_='active')
-    else:
-        page.li()
-    if isinstance(link, (tuple, list)):
+    if link in [None, '']:
+        page.div('', class_='dropdown-divider')
+    elif isinstance(link, (tuple, list)):
         if isinstance(link[1], (tuple, list)):
-            page.ul(class_=class_ + ' list-unstyled')
-            page.li(link[0], class_='dropdown-header')
+            page.div(class_=class_)
+            page.h6(link[0], class_='dropdown-header')
             for j, link2 in enumerate(link[1]):
                 dropdown_link(page, link2,
                               active=(type(active) is int and active == j))
-            page.ul.close()
+            page.div.close()
         else:
-            page.a(link[0], href=link[1], class_='dropdown-item')
+            page.a(link[0], href=link[1],
+                   class_=('dropdown-item active' if active is True
+                           else 'dropdown-item'))
     elif link is not None:
         page.add(str(link))
-    page.li.close()
 
 
 def get_brand(ifo, name, gps, about=None):

--- a/gwdetchar/io/html.py
+++ b/gwdetchar/io/html.py
@@ -449,9 +449,9 @@ def dropdown(text, links, active=None, class_='nav-link dropdown-toggle'):
 
     # dropdown elements
     if column:
-        page.div(class_='dropdown-menu dropdown-%d-col row' % ncol)
+        page.ul(class_='dropdown-menu dropdown-%d-col row shadow' % ncol)
     else:
-        page.div(class_='dropdown-menu')
+        page.ul(class_='dropdown-menu shadow')
     for i, link in enumerate(links):
         if isinstance(active, int) and i == active:
             active_ = True
@@ -460,7 +460,7 @@ def dropdown(text, links, active=None, class_='nav-link dropdown-toggle'):
         else:
             active_ = False
         dropdown_link(page, link, active=active_, class_=column)
-    page.div.close()
+    page.ul.close()
     return page()
 
 
@@ -482,22 +482,25 @@ def dropdown_link(page, link, active=False, class_=''):
     class_ : `str`, optional
         object class of the link, default: `''`
     """
-    if link in [None, '']:
-        page.div('', class_='dropdown-divider')
-    elif isinstance(link, (tuple, list)):
+    if link is None:
+        page.li(class_='dropdown-divider')
+    elif active is True:
+        page.li(class_='active')
+    else:
+        page.li()
+    if isinstance(link, (tuple, list)):
         if isinstance(link[1], (tuple, list)):
-            page.div(class_=class_)
-            page.h6(link[0], class_='dropdown-header')
+            page.ul(class_=class_ + ' list-unstyled')
+            page.li(link[0], class_='dropdown-header')
             for j, link2 in enumerate(link[1]):
                 dropdown_link(page, link2,
                               active=(type(active) is int and active == j))
-            page.div.close()
+            page.ul.close()
         else:
-            page.a(link[0], href=link[1],
-                   class_=('dropdown-item active' if active is True
-                           else 'dropdown-item'))
+            page.a(link[0], href=link[1], class_='dropdown-item')
     elif link is not None:
         page.add(str(link))
+    page.li.close()
 
 
 def get_brand(ifo, name, gps, about=None):
@@ -536,7 +539,7 @@ def get_brand(ifo, name, gps, about=None):
     page.li(class_='nav-item dropdown')
     page.a('Links', class_='nav-link dropdown-toggle',
            href='#', role='button', **{'data-toggle': 'dropdown'})
-    page.div(class_='dropdown-menu dropdown-menu-right')
+    page.div(class_='dropdown-menu dropdown-menu-right shadow')
     if about is not None:
         page.h6('Internal', class_='dropdown-header')
         page.a('About this page', href=about, class_='dropdown-item')
@@ -832,7 +835,7 @@ def download_btn(content, label='Download summary',
                 **{'data-toggle': 'dropdown',
                    'aria-expanded': 'false',
                    'aria-haspopup': 'true'})
-    page.div(class_='dropdown-menu dropdown-menu-right')
+    page.div(class_='dropdown-menu dropdown-menu-right shadow')
     for item in content:
         if len(item) == 2:
             text, href = item

--- a/gwdetchar/io/html.py
+++ b/gwdetchar/io/html.py
@@ -596,8 +596,11 @@ def about_this_page(config, packagelist=True):
             page.div(class_='card mb-1 shadow-sm')
             page.div(class_='card-header')
             page.a(
-                os.path.basename(cpfile), class_='collapsed card-link',
-                href='#file%d' % i, **{'data-toggle': 'collapse'})
+                os.path.basename(cpfile),
+                class_='collapsed card-link cis-link',
+                href='#file%d' % i,
+                **{'data-toggle': 'collapse'}
+            )
             page.div.close()  # card-header
             page.div(id_='file%d' % i, class_='collapse',
                      **{'data-parent': '#accordion'})

--- a/gwdetchar/io/html.py
+++ b/gwdetchar/io/html.py
@@ -440,19 +440,13 @@ def dropdown(text, links, active=None, class_='nav-link dropdown-toggle'):
 
     # work out columns
     ngroup = sum([isinstance(x, (tuple, list)) and len(x) and
-                 isinstance(x[1], (tuple, list)) for x in links])
-    if ngroup < 1:
-        column = ''
-    else:
-        ncol = min(ngroup, 4)
-        column = 'col-sm-12 col-md-%d' % (12 // ncol)
+                  isinstance(x[1], (tuple, list)) for x in links])
+    ncol = 1 or min(ngroup, 4)
+    column = 'col-sm-12 col-md-%d' % (12 // ncol)
 
     # dropdown elements
-    if column:
-        page.div(class_='dropdown-menu dropdown-%d-col shadow' % ncol)
-        page.div(class_='row')
-    else:
-        page.div(class_='dropdown-menu shadow')
+    page.div(class_='dropdown-menu dropdown-%d-col shadow' % ncol)
+    page.div(class_='row')
     for i, link in enumerate(links):
         if isinstance(active, int) and i == active:
             active_ = True
@@ -461,9 +455,8 @@ def dropdown(text, links, active=None, class_='nav-link dropdown-toggle'):
         else:
             active_ = False
         dropdown_link(page, link, active=active_, class_=column)
-    if column:
-        page.div.close()  # row
-    page.div.close()
+    page.div.close()  # row
+    page.div.close()  # dropdown-menu
     return page()
 
 

--- a/gwdetchar/io/html.py
+++ b/gwdetchar/io/html.py
@@ -944,7 +944,6 @@ def alert(text, context='info', dismiss=True):
         the rendered dialog box object
     """
     page = markup.page()
-    text = (text,) if isinstance(text, str) else text
     class_ = ('alert alert-%s alert-dismissible fade show shadow-sm' % context
               if dismiss else 'alert alert-%s shadow-sm' % context)
     page.div(class_=class_)
@@ -953,8 +952,11 @@ def alert(text, context='info', dismiss=True):
                     **{'data-dismiss': 'alert', 'aria-label': 'Close'})
         page.span('&times;', **{'aria-hidden': "true"})
         page.button.close()
-    for msg in text:
-        page.add(str(msg))
+    if isinstance(text, (list, tuple)):
+        for msg in text:
+            page.p(str(msg))
+    else:
+        page.add(str(text))
     page.div.close()
     return page()
 

--- a/gwdetchar/io/tests/test_html.py
+++ b/gwdetchar/io/tests/test_html.py
@@ -467,6 +467,15 @@ def test_alert():
         '</button>\ntest\n</div>')
 
 
+def test_alert_with_list():
+    page = html.alert(['test'])
+    assert parse_html(page) == parse_html(
+        '<div class="alert alert-info alert-dismissible fade show shadow-sm">'
+        '\n<button type="button" class="close" data-dismiss="alert" '
+        'aria-label="Close">\n<span aria-hidden="true">&times;</span>'
+        '\n</button>\n<p>test</p>\n</div>')
+
+
 def test_table():
     headers = ['Test']
     data = [['test']]

--- a/gwdetchar/io/tests/test_html.py
+++ b/gwdetchar/io/tests/test_html.py
@@ -88,7 +88,7 @@ ABOUT = """<div class="row">
 <span style="color: #7D9029">key</span> <span style="color: #666666">=</span> <span style="color: #BA2121">value</span>
 </pre></div>
 
-<h2>Environment</h2><table class="table table-sm table-hover table-responsive" id="package-table"><caption>Table of packages installed in the production environment</caption><thead><tr><th scope="col">Name</th><th scope="col">Version</th></tr></thead><tbody><tr><td>gwdetchar</td><td>1.2.3</td></tr><tr><td>gwpy</td><td>1.0.0</td></tr></tbody></table><button class="btn btn-outline-secondary btn-table" data-table-id="package-table" data-filename="package-table.csv">Export to CSV</button>
+<h2 class="mt-4">Environment</h2><table class="table table-sm table-hover table-responsive" id="package-table"><caption>Table of packages installed in the production environment</caption><thead><tr><th scope="col">Name</th><th scope="col">Version</th></tr></thead><tbody><tr><td>gwdetchar</td><td>1.2.3</td></tr><tr><td>gwpy</td><td>1.0.0</td></tr></tbody></table><button class="btn btn-outline-secondary btn-table" data-table-id="package-table" data-filename="package-table.csv">Export to CSV</button>
 </div>
 </div>""".format(sys.prefix)  # noqa: E501
 
@@ -103,7 +103,7 @@ ABOUT_WITH_CONFIG_LIST = """<div class="row">
 <h2>Configuration files</h2>
 <p>The following INI-format configuration file(s) were passed on the comand-line and are reproduced here in full:</p>
 <div id="accordion">
-<div class="card bg-light mb-1 shadow-sm">
+<div class="card mb-1 shadow-sm">
 <div class="card-header">
 <a class="collapsed card-link" href="#file0" data-toggle="collapse">test.ini</a>
 </div>
@@ -117,7 +117,7 @@ ABOUT_WITH_CONFIG_LIST = """<div class="row">
 </div>
 </div>
 </div>
-<h2>Environment</h2><table class="table table-sm table-hover table-responsive" id="package-table"><caption>Table of packages installed in the production environment</caption><thead><tr><th scope="col">Name</th><th scope="col">Version</th></tr></thead><tbody><tr><td>gwdetchar</td><td>1.2.3</td></tr><tr><td>gwpy</td><td>1.0.0</td></tr></tbody></table><button class="btn btn-outline-secondary btn-table" data-table-id="package-table" data-filename="package-table.csv">Export to CSV</button>
+<h2 class="mt-4">Environment</h2><table class="table table-sm table-hover table-responsive" id="package-table"><caption>Table of packages installed in the production environment</caption><thead><tr><th scope="col">Name</th><th scope="col">Version</th></tr></thead><tbody><tr><td>gwdetchar</td><td>1.2.3</td></tr><tr><td>gwpy</td><td>1.0.0</td></tr></tbody></table><button class="btn btn-outline-secondary btn-table" data-table-id="package-table" data-filename="package-table.csv">Export to CSV</button>
 </div>
 </div>""".format(sys.prefix)  # noqa: E501
 
@@ -562,7 +562,8 @@ def test_package_table(package_list):
     assert parse_html(
         html.package_table(class_="test", caption="Test"),
     ) == parse_html(
-        '<h2>Environment</h2><table class="test" id="package-table"><caption>'
+        '<h2 class="mt-4">Environment</h2>'
+        '<table class="test" id="package-table"><caption>'
         'Test</caption><thead><tr><th scope="col">Name</th><th scope="col">'
         'Version</th></tr></thead><tbody><tr><td>gwdetchar</td><td>1.2.3</td>'
         '</tr><tr><td>gwpy</td><td>1.0.0</td></tr></tbody></table><button '

--- a/gwdetchar/io/tests/test_html.py
+++ b/gwdetchar/io/tests/test_html.py
@@ -105,7 +105,7 @@ ABOUT_WITH_CONFIG_LIST = """<div class="row">
 <div id="accordion">
 <div class="card mb-1 shadow-sm">
 <div class="card-header">
-<a class="collapsed card-link" href="#file0" data-toggle="collapse">test.ini</a>
+<a class="collapsed card-link cis-link" href="#file0" data-toggle="collapse">test.ini</a>
 </div>
 <div id="file0" class="collapse" data-parent="#accordion">
 <div class="card-body">

--- a/gwdetchar/io/tests/test_html.py
+++ b/gwdetchar/io/tests/test_html.py
@@ -273,26 +273,26 @@ def test_dropdown():
     menu = html.dropdown('test', [])
     assert parse_html(str(menu)) == parse_html(
         '<a href="#" class="nav-link dropdown-toggle" role="button" '
-        'data-toggle="dropdown">test</a>\n<div class="dropdown-menu">'
+        'data-toggle="dropdown">test</a>\n<div class="dropdown-menu shadow">'
         '\n</div>')
 
     menu = html.dropdown('test', ['test', '#'], active=0)
     assert parse_html(str(menu)) == parse_html(
         '<a href="#" class="nav-link dropdown-toggle" role="button" '
-        'data-toggle="dropdown">test</a>\n<div class="dropdown-menu">'
+        'data-toggle="dropdown">test</a>\n<div class="dropdown-menu shadow">'
         '\ntest\n#\n</div>')
 
     menu = html.dropdown('test', ['test', '#'], active=[0, 1])
     assert parse_html(str(menu)) == parse_html(
         '<a href="#" class="nav-link dropdown-toggle" role="button" '
-        'data-toggle="dropdown">test</a>\n<div class="dropdown-menu">\n'
+        'data-toggle="dropdown">test</a>\n<div class="dropdown-menu shadow">\n'
         'test\n#\n</div>')
 
     menu = html.dropdown('<test />', ['test', '#'], active=[0, 1])
     assert parse_html(str(menu)) == parse_html(
         '<a href="#" class="nav-link dropdown-toggle" role="button" '
-        'data-toggle="dropdown"><test /></a>\n<div class="dropdown-menu">\n'
-        'test\n#\n</div>')
+        'data-toggle="dropdown"><test /></a>\n<div class="dropdown-menu '
+        'shadow">\ntest\n#\n</div>')
 
 
 def test_dropdown_link():
@@ -319,8 +319,8 @@ def test_get_brand():
         '<ul class="nav navbar-nav">\n<li class="nav-item dropdown">\n'
         '<a class="nav-link dropdown-toggle" href="#" role="button" '
         'data-toggle="dropdown">Links</a>\n<div class="dropdown-menu '
-        'dropdown-menu-right">\n<h6 class="dropdown-header">Internal</h6>\n'
-        '<a href="about" class="dropdown-item">About this page</a>\n'
+        'dropdown-menu-right shadow">\n<h6 class="dropdown-header">Internal'
+        '</h6>\n<a href="about" class="dropdown-item">About this page</a>\n'
         '<div class="dropdown-divider"></div>\n<h6 class="dropdown-header">'
         'External</h6>\n<a href="https://ldas-jobs.ligo-wa.caltech.edu/'
         '~detchar/summary/day/19800106" class="dropdown-item" target="_blank">'
@@ -441,7 +441,7 @@ def test_download_btn():
         '<button type="button" class="btn btn-outline-secondary '
         'dropdown-toggle" data-toggle="dropdown" aria-expanded="false" '
         'aria-haspopup="true">Download summary</button>\n<div '
-        'class="dropdown-menu dropdown-menu-right">\n<a href="test" '
+        'class="dropdown-menu dropdown-menu-right shadow">\n<a href="test" '
         'download="test" class="dropdown-item">test</a>\n</div>\n</div>')
 
 

--- a/gwdetchar/io/tests/test_html.py
+++ b/gwdetchar/io/tests/test_html.py
@@ -273,26 +273,26 @@ def test_dropdown():
     menu = html.dropdown('test', [])
     assert parse_html(str(menu)) == parse_html(
         '<a href="#" class="nav-link dropdown-toggle" role="button" '
-        'data-toggle="dropdown">test</a>\n<div class="dropdown-menu shadow">'
-        '\n</div>')
+        'data-toggle="dropdown">test</a>\n<div class="dropdown-menu '
+        'dropdown-1-col shadow">\n</div>')
 
     menu = html.dropdown('test', ['test', '#'], active=0)
     assert parse_html(str(menu)) == parse_html(
         '<a href="#" class="nav-link dropdown-toggle" role="button" '
-        'data-toggle="dropdown">test</a>\n<div class="dropdown-menu shadow">'
-        '\ntest\n#\n</div>')
+        'data-toggle="dropdown">test</a>\n<div class="dropdown-menu '
+        'dropdown-1-col shadow">\ntest\n#\n</div>')
 
     menu = html.dropdown('test', ['test', '#'], active=[0, 1])
     assert parse_html(str(menu)) == parse_html(
         '<a href="#" class="nav-link dropdown-toggle" role="button" '
-        'data-toggle="dropdown">test</a>\n<div class="dropdown-menu shadow">\n'
-        'test\n#\n</div>')
+        'data-toggle="dropdown">test</a>\n<div class="dropdown-menu '
+        'dropdown-1-col shadow">\ntest\n#\n</div>')
 
     menu = html.dropdown('<test />', ['test', '#'], active=[0, 1])
     assert parse_html(str(menu)) == parse_html(
         '<a href="#" class="nav-link dropdown-toggle" role="button" '
         'data-toggle="dropdown"><test /></a>\n<div class="dropdown-menu '
-        'shadow">\ntest\n#\n</div>')
+        'dropdown-1-col shadow">\ntest\n#\n</div>')
 
 
 def test_dropdown_link():

--- a/gwdetchar/io/tests/test_html.py
+++ b/gwdetchar/io/tests/test_html.py
@@ -88,7 +88,7 @@ ABOUT = """<div class="row">
 <span style="color: #7D9029">key</span> <span style="color: #666666">=</span> <span style="color: #BA2121">value</span>
 </pre></div>
 
-<h2 class="mt-4">Environment</h2><table class="table table-sm table-hover table-responsive" id="package-table"><caption>Table of packages installed in the production environment</caption><thead><tr><th scope="col">Name</th><th scope="col">Version</th></tr></thead><tbody><tr><td>gwdetchar</td><td>1.2.3</td></tr><tr><td>gwpy</td><td>1.0.0</td></tr></tbody></table><button class="btn btn-outline-secondary btn-table" data-table-id="package-table" data-filename="package-table.csv">Export to CSV</button>
+<h2 class="mt-4">Environment</h2><table class="table table-sm table-hover table-responsive" id="package-table"><caption>Table of packages installed in the production environment</caption><thead><tr><th scope="col">Name</th><th scope="col">Version</th></tr></thead><tbody><tr><td>gwdetchar</td><td>1.2.3</td></tr><tr><td>gwpy</td><td>1.0.0</td></tr></tbody></table><button class="btn btn-outline-secondary btn-table mt-2" data-table-id="package-table" data-filename="package-table.csv">Export to CSV</button>
 </div>
 </div>""".format(sys.prefix)  # noqa: E501
 
@@ -117,7 +117,7 @@ ABOUT_WITH_CONFIG_LIST = """<div class="row">
 </div>
 </div>
 </div>
-<h2 class="mt-4">Environment</h2><table class="table table-sm table-hover table-responsive" id="package-table"><caption>Table of packages installed in the production environment</caption><thead><tr><th scope="col">Name</th><th scope="col">Version</th></tr></thead><tbody><tr><td>gwdetchar</td><td>1.2.3</td></tr><tr><td>gwpy</td><td>1.0.0</td></tr></tbody></table><button class="btn btn-outline-secondary btn-table" data-table-id="package-table" data-filename="package-table.csv">Export to CSV</button>
+<h2 class="mt-4">Environment</h2><table class="table table-sm table-hover table-responsive" id="package-table"><caption>Table of packages installed in the production environment</caption><thead><tr><th scope="col">Name</th><th scope="col">Version</th></tr></thead><tbody><tr><td>gwdetchar</td><td>1.2.3</td></tr><tr><td>gwpy</td><td>1.0.0</td></tr></tbody></table><button class="btn btn-outline-secondary btn-table mt-2" data-table-id="package-table" data-filename="package-table.csv">Export to CSV</button>
 </div>
 </div>""".format(sys.prefix)  # noqa: E501
 
@@ -473,10 +473,10 @@ def test_table():
     caption = 'This is a test table.'
     page = html.table(headers=headers, data=data, caption=caption, id='test')
     assert parse_html(page) == parse_html(
-        '<table class="table table-sm table-hover" id="test">'
-        '<caption>This is a test table.</caption><thead><tr>'
-        '<th scope="col">Test</th></tr></thead><tbody><tr><td>test</td></tr>'
-        '</tbody></table><button class="btn btn-outline-secondary btn-table" '
+        '<table class="table table-sm table-hover" id="test"><caption>'
+        'This is a test table.</caption><thead><tr><th scope="col">Test'
+        '</th></tr></thead><tbody><tr><td>test</td></tr></tbody></table>'
+        '<button class="btn btn-outline-secondary btn-table mt-2" '
         'data-table-id="test" data-filename="test.csv">Export to CSV</button>')
 
 
@@ -567,7 +567,7 @@ def test_package_table(package_list):
         'Test</caption><thead><tr><th scope="col">Name</th><th scope="col">'
         'Version</th></tr></thead><tbody><tr><td>gwdetchar</td><td>1.2.3</td>'
         '</tr><tr><td>gwpy</td><td>1.0.0</td></tr></tbody></table><button '
-        'class="btn btn-outline-secondary btn-table" data-table-id='
+        'class="btn btn-outline-secondary btn-table mt-2" data-table-id='
         '"package-table" data-filename="package-table.csv">Export to CSV'
         '</button>'
     )

--- a/gwdetchar/omega/html.py
+++ b/gwdetchar/omega/html.py
@@ -501,7 +501,7 @@ def write_block(blockkey, block, context,
             page.button(ptitle, id_=_id, type='button',
                         class_='btn btn-%s dropdown-toggle' % context,
                         **{'data-toggle': 'dropdown'})
-            page.div(class_='dropdown-menu', **{'aria-labelledby': _id})
+            page.div(class_='dropdown-menu shadow', **{'aria-labelledby': _id})
             for ptype in ptypes:
                 page.add(toggle_link('{0}_{1}'.format(pclass, ptype),
                                      channel, channel.pranges))

--- a/gwdetchar/omega/tests/test_html.py
+++ b/gwdetchar/omega/tests/test_html.py
@@ -52,10 +52,12 @@ HTML_HEADER = """<nav class="navbar fixed-top navbar-expand-md navbar-{ifo} shad
 </li>
 <li class="nav-item dropdown">
 <a href="#" class="nav-link dropdown-toggle" role="button" data-toggle="dropdown">GW</a>
-<div class="dropdown-menu shadow">
-<div class="">
+<div class="dropdown-menu dropdown-1-col shadow">
+<div class="row">
+<div class="col-sm-12 col-md-12">
 <h6 class="dropdown-header">Gravitational-Wave Strain</h6>
 <a href="#x1-test-aux" class="dropdown-item">X1:TEST-AUX</a>
+</div>
 </div>
 </div>
 </li>

--- a/gwdetchar/omega/tests/test_html.py
+++ b/gwdetchar/omega/tests/test_html.py
@@ -52,7 +52,7 @@ HTML_HEADER = """<nav class="navbar fixed-top navbar-expand-md navbar-{ifo} shad
 </li>
 <li class="nav-item dropdown">
 <a href="#" class="nav-link dropdown-toggle" role="button" data-toggle="dropdown">GW</a>
-<div class="dropdown-menu">
+<div class="dropdown-menu shadow">
 <div class="">
 <h6 class="dropdown-header">Gravitational-Wave Strain</h6>
 <a href="#x1-test-aux" class="dropdown-item">X1:TEST-AUX</a>
@@ -63,7 +63,7 @@ HTML_HEADER = """<nav class="navbar fixed-top navbar-expand-md navbar-{ifo} shad
 <ul class="nav navbar-nav">
 <li class="nav-item dropdown">
 <a class="nav-link dropdown-toggle" href="#" role="button" data-toggle="dropdown">Links</a>
-<div class="dropdown-menu dropdown-menu-right">
+<div class="dropdown-menu dropdown-menu-right shadow">
 <h6 class="dropdown-header">Internal</h6>
 <a href="about" class="dropdown-item">About this page</a>
 <div class="dropdown-divider"></div>
@@ -166,7 +166,7 @@ BLOCK_HTML = """<div class="card card-x1 mb-5 shadow-sm">
 <div class="btn-group flex-wrap" role="group">
 <div class="btn-group" role="group">
 <button id="btnGroupTimeseries0" type="button" class="btn btn-x1 dropdown-toggle" data-toggle="dropdown">Timeseries</button>
-<div class="dropdown-menu" aria-labelledby="btnGroupTimeseries0">
+<div class="dropdown-menu shadow" aria-labelledby="btnGroupTimeseries0">
 <a class="dropdown-item image-switch" data-captions="[&quot;X1-TEST_AUX-timeseries_raw-4.png&quot;]" data-channel-name="X1-TEST_AUX" data-image-dir="plots" data-image-type="timeseries_raw" data-t-ranges="[&quot;4&quot;]">raw</a>
 <a class="dropdown-item image-switch" data-captions="[&quot;X1-TEST_AUX-timeseries_highpassed-4.png&quot;]" data-channel-name="X1-TEST_AUX" data-image-dir="plots" data-image-type="timeseries_highpassed" data-t-ranges="[&quot;4&quot;]">highpassed</a>
 <a class="dropdown-item image-switch" data-captions="[&quot;X1-TEST_AUX-timeseries_whitened-4.png&quot;]" data-channel-name="X1-TEST_AUX" data-image-dir="plots" data-image-type="timeseries_whitened" data-t-ranges="[&quot;4&quot;]">whitened</a>
@@ -174,7 +174,7 @@ BLOCK_HTML = """<div class="card card-x1 mb-5 shadow-sm">
 </div>
 <div class="btn-group" role="group">
 <button id="btnGroupQscan0" type="button" class="btn btn-x1 dropdown-toggle" data-toggle="dropdown">Spectrogram</button>
-<div class="dropdown-menu" aria-labelledby="btnGroupQscan0">
+<div class="dropdown-menu shadow" aria-labelledby="btnGroupQscan0">
 <a class="dropdown-item image-switch" data-captions="[&quot;X1-TEST_AUX-qscan_highpassed-4.png&quot;]" data-channel-name="X1-TEST_AUX" data-image-dir="plots" data-image-type="qscan_highpassed" data-t-ranges="[&quot;4&quot;]">highpassed</a>
 <a class="dropdown-item image-switch" data-captions="[&quot;X1-TEST_AUX-qscan_whitened-4.png&quot;]" data-channel-name="X1-TEST_AUX" data-image-dir="plots" data-image-type="qscan_whitened" data-t-ranges="[&quot;4&quot;]">whitened</a>
 <a class="dropdown-item image-switch" data-captions="[&quot;X1-TEST_AUX-qscan_autoscaled-4.png&quot;]" data-channel-name="X1-TEST_AUX" data-image-dir="plots" data-image-type="qscan_autoscaled" data-t-ranges="[&quot;4&quot;]">autoscaled</a>
@@ -182,7 +182,7 @@ BLOCK_HTML = """<div class="card card-x1 mb-5 shadow-sm">
 </div>
 <div class="btn-group" role="group">
 <button id="btnGroupEventgram0" type="button" class="btn btn-x1 dropdown-toggle" data-toggle="dropdown">Eventgram</button>
-<div class="dropdown-menu" aria-labelledby="btnGroupEventgram0">
+<div class="dropdown-menu shadow" aria-labelledby="btnGroupEventgram0">
 <a class="dropdown-item image-switch" data-captions="[&quot;X1-TEST_AUX-eventgram_highpassed-4.png&quot;]" data-channel-name="X1-TEST_AUX" data-image-dir="plots" data-image-type="eventgram_highpassed" data-t-ranges="[&quot;4&quot;]">highpassed</a>
 <a class="dropdown-item image-switch" data-captions="[&quot;X1-TEST_AUX-eventgram_whitened-4.png&quot;]" data-channel-name="X1-TEST_AUX" data-image-dir="plots" data-image-type="eventgram_whitened" data-t-ranges="[&quot;4&quot;]">whitened</a>
 <a class="dropdown-item image-switch" data-captions="[&quot;X1-TEST_AUX-eventgram_autoscaled-4.png&quot;]" data-channel-name="X1-TEST_AUX" data-image-dir="plots" data-image-type="eventgram_autoscaled" data-t-ranges="[&quot;4&quot;]">autoscaled</a>
@@ -254,8 +254,8 @@ def test_write_summary():
         '\n<button type="button" class="btn btn-l1 dropdown-toggle" '
         'data-toggle="dropdown" aria-expanded="false" aria-haspopup="true">'
         'Download summary</button>\n<div class="dropdown-menu dropdown-menu-'
-        'right">\n<a href="data/summary.txt" download="L1_0_summary.txt" '
-        'class="dropdown-item">txt</a>\n<a href="data/summary.csv" download='
+        'right shadow">\n<a href="data/summary.txt" download="L1_0_summary.txt'
+        '" class="dropdown-item">txt</a>\n<a href="data/summary.csv" download='
         '"L1_0_summary.csv" class="dropdown-item">csv</a>'
         '\n<a href="data/summary.tex" download="L1_0_summary.tex" '
         'class="dropdown-item">tex</a>\n</div>\n</div>\n</div>\n</div>'


### PR DESCRIPTION
This PR reverts to using unsettled lists for navbar dropdown menus, in the hopes of restoring multi-column menu formatting.

Other misc. items included:

* Gracefully choose whether to wrap alert box text within `<p>` tags
* Add a `margin-top` of 2 px to table download-to-CSV buttons