### PR TITLE
Upgrade to gwbootstrap-1.2.0

### DIFF
--- a/bin/gwdetchar-omega
+++ b/bin/gwdetchar-omega
@@ -276,5 +276,5 @@ if analyzed:
     html.write_qscan_page(ifo, gps, analyzed, **htmlv)
 else:
     reason = 'No significant channels found during active analysis segments'
-    html.write_null_page(ifo, gps, reason)
+    html.write_null_page(ifo, gps, reason, context=ifo.lower())
 logger.info("-- index.html written, all done --")

--- a/bin/gwdetchar-overflow
+++ b/bin/gwdetchar-overflow
@@ -325,7 +325,7 @@ if args.html:
     msg += ("Consant overflow is shown as yellow, while transient overflow "
             "is shown as red. If a data-quality flag was loaded for this "
             "analysis, it will be displayed in green.")
-    page.add(htmlio.alert(msg))
+    page.add(htmlio.alert(msg), context=args.ifo.lower())
     # record state segments
     if args.state_flag:
         page.h3('State flag', class_='mt-3', id_='state-flag')
@@ -359,7 +359,7 @@ if args.html:
         page.div.close()
     else:
         page.add(htmlio.alert('No overflows were found in this analysis',
-                              dismiss=False))
+                              context=args.ifo.lower(), dismiss=False))
 
     # -- results table
     page.h2('Results summary', class_='mt-4', id_='results')

--- a/bin/gwdetchar-scattering
+++ b/bin/gwdetchar-scattering
@@ -294,7 +294,7 @@ if statea:  # contextual information
            "yellow panels denote weak evidence for scattering, while red "
            "panels denote strong evidence.").format(
                args.fmin, multiplier * args.frequency_threshold, str(paper))
-    page.add(htmlio.alert(msg))
+    page.add(htmlio.alert(msg), context=args.ifo.lower())
 else:  # null segments
     page.add(htmlio.alert('No active analysis segments were found',
                           context='warning', dismiss=False))
@@ -669,7 +669,7 @@ actives = actives.coalesce()  # merge contiguous segments
 if statea and not actives:
     page.add(htmlio.alert(
         'No evidence of scattering found in the channels analyzed',
-        dismiss=False))
+        context=args.ifo.lower(), dismiss=False))
 
 # identify triggers during active segments
 logger.debug('Writing a summary CSV record')
@@ -712,7 +712,7 @@ if nscans > 0:
            'To compare these against fringe frequency projections, please '
            'use the scattering module:',
            markup.oneliner.pre('$ python -m gwdetchar.scattering --help'))
-    page.add(htmlio.alert(msg, context='secondary'))
+    page.add(htmlio.alert(msg, context=args.ifo.lower()))
     page.add(htmlio.scaffold_omega_scans(
         omegatimes, args.main_channel, scandir=scandir))
 elif args.omega_scans:

--- a/bin/gwdetchar-software-saturations
+++ b/bin/gwdetchar-software-saturations
@@ -251,7 +251,7 @@ if args.html:
            "the LIMIT value set in software. Signals that achieve saturation "
            "are shown below, and saturation segments are available by "
            "expanding a given panel.").format(sum(map(len, channels)))
-    page.add(htmlio.alert(msg))
+    page.add(htmlio.alert(msg), context=ifo.lower())
     # record state segments
     if args.state_flag:
         page.h3('State flag', class_='mt-3', id_='state-flag')
@@ -276,11 +276,11 @@ if args.html:
         page.div.close()
     else:
         page.add(htmlio.alert('No software saturations were found in this '
-                              'analysis', dismiss=False))
+                              'analysis', context=ifo.lower(), dismiss=False))
     # -- results table
     page.h2('Results summary', class_='mt-4', id_='results')
     page.add(htmlio.alert("All channels for which the LIMIT setting was "
-                          "active are shown below."))
+                          "active are shown below.", context=ifo.lower()))
     page.table(class_='table table-striped table-hover')
     # write table header
     page.thead()

--- a/gwdetchar/io/html.py
+++ b/gwdetchar/io/html.py
@@ -112,21 +112,21 @@ OBSERVATORY_MAP = {
 # -- HTML URLs
 
 FONT_AWESOME_CSS = ('https://cdnjs.cloudflare.com/ajax/libs/'
-                    'font-awesome/5.10.2/css/fontawesome.min.css')
+                    'font-awesome/5.11.2/css/fontawesome.min.css')
 FONT_AWESOME_SOLID_CSS = ('https://cdnjs.cloudflare.com/ajax/libs/'
-                          'font-awesome/5.10.2/css/solid.min.css')
+                          'font-awesome/5.11.2/css/solid.min.css')
 
 JQUERY_JS = 'https://code.jquery.com/jquery-3.4.1.min.js'
 JQUERY_LAZY_JS = ('https://cdnjs.cloudflare.com/ajax/libs/jquery.lazy/'
-                  '1.7.9/jquery.lazy.min.js')
+                  '1.7.10/jquery.lazy.min.js')
 BOOTSTRAP_JS = ('https://stackpath.bootstrapcdn.com/bootstrap/'
-                '4.3.1/js/bootstrap.bundle.min.js')
+                '4.4.1/js/bootstrap.bundle.min.js')
 FANCYBOX_JS = ('https://cdnjs.cloudflare.com/ajax/libs/'
                'fancybox/3.5.7/jquery.fancybox.min.js')
 
-GWBOOTSTRAP_CSS = ('https://cdn.jsdelivr.net/npm/gwbootstrap@1.1.0/'
+GWBOOTSTRAP_CSS = ('https://cdn.jsdelivr.net/npm/gwbootstrap@1.2.0/'
                    'lib/gwbootstrap.min.css')
-GWBOOTSTRAP_JS = ('https://cdn.jsdelivr.net/npm/gwbootstrap@1.1.0/'
+GWBOOTSTRAP_JS = ('https://cdn.jsdelivr.net/npm/gwbootstrap@1.2.0/'
                   'lib/gwbootstrap.min.js')
 
 CSS_FILES = [

--- a/gwdetchar/io/tests/test_html.py
+++ b/gwdetchar/io/tests/test_html.py
@@ -57,14 +57,14 @@ NEW_BOOTSTRAP_PAGE = """<!DOCTYPE HTML>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <meta content="width=device-width, initial-scale=1.0" name="viewport" />
 <base href="{base}" />
-<link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.10.2/css/fontawesome.min.css" rel="stylesheet" media="all" />
-<link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.10.2/css/solid.min.css" rel="stylesheet" media="all" />
-<link href="https://cdn.jsdelivr.net/npm/gwbootstrap@1.1.0/lib/gwbootstrap.min.css" rel="stylesheet" media="all" />
+<link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.11.2/css/fontawesome.min.css" rel="stylesheet" media="all" />
+<link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.11.2/css/solid.min.css" rel="stylesheet" media="all" />
+<link href="https://cdn.jsdelivr.net/npm/gwbootstrap@1.2.0/lib/gwbootstrap.min.css" rel="stylesheet" media="all" />
 <script src="https://code.jquery.com/jquery-3.4.1.min.js" type="text/javascript"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.lazy/1.7.9/jquery.lazy.min.js" type="text/javascript"></script>
-<script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.bundle.min.js" type="text/javascript"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.lazy/1.7.10/jquery.lazy.min.js" type="text/javascript"></script>
+<script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.bundle.min.js" type="text/javascript"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/fancybox/3.5.7/jquery.fancybox.min.js" type="text/javascript"></script>
-<script src="https://cdn.jsdelivr.net/npm/gwbootstrap@1.1.0/lib/gwbootstrap.min.js" type="text/javascript"></script>
+<script src="https://cdn.jsdelivr.net/npm/gwbootstrap@1.2.0/lib/gwbootstrap.min.js" type="text/javascript"></script>
 </head>
 <body>
 <div class="container">
@@ -234,21 +234,21 @@ def test_finalize_static_urls(tmpdir):
         static, base, html.CSS_FILES, html.JS_FILES)
     assert css == [
         'https://cdnjs.cloudflare.com/ajax/libs/'
-            'font-awesome/5.10.2/css/fontawesome.min.css',  # noqa: E131
+            'font-awesome/5.11.2/css/fontawesome.min.css',  # noqa: E131
         'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/'
-            '5.10.2/css/solid.min.css',  # noqa: E131
-        'https://cdn.jsdelivr.net/npm/gwbootstrap@1.1.0/'
+            '5.11.2/css/solid.min.css',  # noqa: E131
+        'https://cdn.jsdelivr.net/npm/gwbootstrap@1.2.0/'
             'lib/gwbootstrap.min.css',  # noqa E131
     ]
     assert js == [
         'https://code.jquery.com/jquery-3.4.1.min.js',
-        'https://cdnjs.cloudflare.com/ajax/libs/jquery.lazy/1.7.9/'
+        'https://cdnjs.cloudflare.com/ajax/libs/jquery.lazy/1.7.10/'
             'jquery.lazy.min.js',  # noqa: E131
-        'https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/'
+        'https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/'
             'bootstrap.bundle.min.js',  # noqa: E131
         'https://cdnjs.cloudflare.com/ajax/libs/fancybox/3.5.7/'
             'jquery.fancybox.min.js',  # noqa E131
-        'https://cdn.jsdelivr.net/npm/gwbootstrap@1.1.0/'
+        'https://cdn.jsdelivr.net/npm/gwbootstrap@1.2.0/'
             'lib/gwbootstrap.min.js',  # noqa E131
     ]
     shutil.rmtree(str(tmpdir), ignore_errors=True)

--- a/gwdetchar/omega/html.py
+++ b/gwdetchar/omega/html.py
@@ -315,7 +315,7 @@ def write_summary(
         page.add(htmlio.alert(
             ('<strong>Note</strong>: This scan is in progress, and will '
              'auto-refresh every 60 seconds until completion.'),
-            context='warning'))
+            context=ifo.lower()))
     return page()
 
 
@@ -564,7 +564,7 @@ def write_qscan_page(blocks, context):
 
 
 @wrap_html
-def write_null_page(reason):
+def write_null_page(reason, context='info'):
     """Write the Qscan results to HTML
 
     Parameters
@@ -578,13 +578,16 @@ def write_null_page(reason):
     reason : `str`
         the explanation for this null result
 
+    context : `str`
+        type of bootstrap alert box to use, default: ``info``
+
     Returns
     -------
     index : `str`
         the path of the HTML written for this analysis
     """
     page = markup.page()
-    page.add(htmlio.alert(reason, 'info', dismiss=False))
+    page.add(htmlio.alert(reason, context=context, dismiss=False))
     return page
 
 

--- a/gwdetchar/omega/tests/test_html.py
+++ b/gwdetchar/omega/tests/test_html.py
@@ -261,7 +261,7 @@ def test_write_summary():
         '"L1_0_summary.csv" class="dropdown-item">csv</a>'
         '\n<a href="data/summary.tex" download="L1_0_summary.tex" '
         'class="dropdown-item">tex</a>\n</div>\n</div>\n</div>\n</div>'
-        '\n<div class="alert alert-warning alert-dismissible fade show '
+        '\n<div class="alert alert-l1 alert-dismissible fade show '
         'shadow-sm">\n<button type="button" class="close" data-dismiss="alert"'
         'aria-label="Close">\n<span aria-hidden="true">&times;</span>\n'
         '</button>\n<strong>Note</strong>: This scan is in progress, and will '

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ lscsoft-glue >= 2.0.0
 lxml
 matplotlib >= 2.0.0
 MarkupPy >=1.14
-numpy >= 1.10
+numpy >= 1.16
 pandas
 pycondor
 pytz

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ install_requires = [
     'gwtrigfind',
     'MarkupPy>=1.14',
     'matplotlib>=2.0.0',
-    'numpy>=1.10',
+    'numpy>=1.16',
     'pandas',
     'pycondor',
     'pytz',


### PR DESCRIPTION
This PR upgrades HTML output pages to use gwbootstrap-1.2.0, as well as updated version pins for bootstrap, jquery-lazy, and font-awesome, and taking advantage of the new `alert-<ifo>` classes available from gwbootstrap.

Also included is a bump of the minimum version requirement for numpy to 1.16, for the sake of astropy.

cc @duncanmmacleod 