### PR TITLE
Use text-justify class on bootstrap alert boxes

### DIFF
--- a/gwdetchar/io/html.py
+++ b/gwdetchar/io/html.py
@@ -941,8 +941,9 @@ def alert(text, context='info', dismiss=True):
         the rendered dialog box object
     """
     page = markup.page()
-    class_ = ('alert alert-%s alert-dismissible fade show shadow-sm' % context
-              if dismiss else 'alert alert-%s shadow-sm' % context)
+    class_ = ('alert alert-%s alert-dismissible fade show text-justify '
+              'shadow-sm' % context if dismiss else
+              'alert alert-%s text-justify shadow-sm' % context)
     page.div(class_=class_)
     if dismiss:  # add close button
         page.button(type_="button", class_="close",

--- a/gwdetchar/io/tests/test_html.py
+++ b/gwdetchar/io/tests/test_html.py
@@ -463,18 +463,18 @@ def test_parameter_table():
 def test_alert():
     page = html.alert('test')
     assert parse_html(page) == parse_html(
-        '<div class="alert alert-info alert-dismissible fade show shadow-sm">'
-        '\n<button type="button" class="close" data-dismiss="alert" '
-        'aria-label="Close">\n<span aria-hidden="true">&times;</span>\n'
-        '</button>\ntest\n</div>')
+        '<div class="alert alert-info alert-dismissible fade show text-justify'
+        ' shadow-sm">\n<button type="button" class="close" data-dismiss='
+        '"alert" aria-label="Close">\n<span aria-hidden="true">&times;</span>'
+        '\n</button>\ntest\n</div>')
 
 
 def test_alert_with_list():
     page = html.alert(['test'])
     assert parse_html(page) == parse_html(
-        '<div class="alert alert-info alert-dismissible fade show shadow-sm">'
-        '\n<button type="button" class="close" data-dismiss="alert" '
-        'aria-label="Close">\n<span aria-hidden="true">&times;</span>'
+        '<div class="alert alert-info alert-dismissible fade show text-justify'
+        ' shadow-sm">\n<button type="button" class="close" data-dismiss='
+        '"alert" aria-label="Close">\n<span aria-hidden="true">&times;</span>'
         '\n</button>\n<p>test</p>\n</div>')
 
 

--- a/gwdetchar/omega/tests/test_html.py
+++ b/gwdetchar/omega/tests/test_html.py
@@ -261,9 +261,9 @@ def test_write_summary():
         '"L1_0_summary.csv" class="dropdown-item">csv</a>'
         '\n<a href="data/summary.tex" download="L1_0_summary.tex" '
         'class="dropdown-item">tex</a>\n</div>\n</div>\n</div>\n</div>'
-        '\n<div class="alert alert-l1 alert-dismissible fade show '
-        'shadow-sm">\n<button type="button" class="close" data-dismiss="alert"'
-        'aria-label="Close">\n<span aria-hidden="true">&times;</span>\n'
+        '\n<div class="alert alert-l1 alert-dismissible fade show text-justify'
+        ' shadow-sm">\n<button type="button" class="close" data-dismiss='
+        '"alert"aria-label="Close">\n<span aria-hidden="true">&times;</span>\n'
         '</button>\n<strong>Note</strong>: This scan is in progress, and will '
         'auto-refresh every 60 seconds until completion.\n</div>')
 


### PR DESCRIPTION
This PR takes advantage of bootstrap-4's `text-justify` class to justify text inside of alert boxes.

cc @duncanmmacleod