### PR TITLE
Suppress runtime warnings by fixing various issues

### DIFF
--- a/gwdetchar/lasso/plot.py
+++ b/gwdetchar/lasso/plot.py
@@ -103,7 +103,7 @@ def make_spectrum_plots(start, end, flower, fupper, channel_name,
     x_label = 'Frequency [Hz]'
     if ':GDS-CALIB_STRAIN' in channel_name:
         y_label = ('GW amplitude spectral density '
-                   '[strain/$\sqrt{\mathrm{Hz}}]$')  # noqa: W605
+                   '[strain/$\\sqrt{\\mathrm{Hz}}]$')
     else:
         y_label = 'Primary channel units'
     y_min = 0.1 * filtered_spectrum.min().value

--- a/gwdetchar/lasso/tests/test_plot.py
+++ b/gwdetchar/lasso/tests/test_plot.py
@@ -20,6 +20,7 @@
 """
 
 import os
+import pytest
 import shutil
 
 import numpy
@@ -32,12 +33,6 @@ from gwpy.timeseries import TimeSeries
 from .. import plot
 
 __author__ = 'Alex Urban <alexander.urban@ligo.org>'
-
-
-# global test objects
-
-DATA = numpy.random.normal(loc=0, scale=1, size=24*60)
-SERIES = TimeSeries(DATA, sample_rate=60, unit='Mpc', name='X1:TEST')
 
 
 # -- make sure plots run end-to-end -------------------------------------------
@@ -53,9 +48,18 @@ def test_configure_mpl_tex():
 
 def test_save_figure(tmpdir):
     base = str(tmpdir)
-    fig = SERIES.plot()
+    series = TimeSeries(numpy.random.normal(loc=0, scale=1, size=24*60),
+                        sample_rate=60, unit='Mpc', name='X1:TEST')
+    fig = series.plot()
     tsplot = plot.save_figure(fig, os.path.join(base, 'test.png'))
     assert tsplot == os.path.join(base, 'test.png')
-    noneplot = plot.save_figure(fig, os.path.join('tgpflk', 'test.png'))
+
+    # no-directory should raise warning
+    with pytest.warns(UserWarning) as record:
+        noneplot = plot.save_figure(fig, os.path.join('tgpflk', 'test.png'))
     assert noneplot is None
+    assert len(record.list) == 1
+    assert 'Error saving' in str(record.list[0].message)
+
+    # remove base directory
     shutil.rmtree(base, ignore_errors=True)

--- a/gwdetchar/omega/html.py
+++ b/gwdetchar/omega/html.py
@@ -368,7 +368,7 @@ def write_ranking(toc, primary, thresh=6.5,
     pind = numpy.nonzero(entries['Channel'] == primary)
     # sort by matched-filter correlation
     ind_sorted = numpy.argsort(entries['Correlation'])[::-1]
-    if ind_sorted[0] != pind:
+    if not numpy.array_equiv(ind_sorted[0], pind):
         # prepend the primary channel
         dind = numpy.nonzero(ind_sorted == pind)
         ind_sorted = numpy.delete(ind_sorted, dind)

--- a/gwdetchar/tests/test_plot.py
+++ b/gwdetchar/tests/test_plot.py
@@ -21,11 +21,16 @@
 
 import os
 import shutil
+import warnings
 from unittest.mock import patch
 
 from gwpy.segments import DataQualityFlag
 
-from matplotlib import (use, rcParams)
+from matplotlib import (
+    use,
+    rcParams,
+    MatplotlibDeprecationWarning
+)
 use('agg')  # noqa
 
 from .. import plot
@@ -33,16 +38,13 @@ from .. import plot
 __author__ = 'Alex Urban <alexander.urban@ligo.org>'
 
 
-# global test objects
-
-FLAG = DataQualityFlag(known=[(0, 66)], active=[(16, 42)],
-                       name='X1:TEST-FLAG:1')
-
-
 # -- test utilities -----------------------------------------------------------
 
 def test_texify():
     name = 'X1:TEST-CHANNEL_NAME'
+
+    # ignore deprecation warnings for rcParams
+    warnings.simplefilter('ignore', MatplotlibDeprecationWarning)
 
     # test with LaTeX
     with patch.dict(rcParams, {'text.usetex': True}):
@@ -60,6 +62,11 @@ def test_texify():
 
 def test_plot_segments(tmpdir):
     base = str(tmpdir)
-    segplot = plot.plot_segments(FLAG, span=(0, 66))
+    flag = DataQualityFlag(
+        known=[(0, 66)],
+        active=[(16, 42)],
+        name='X1:TEST-FLAG:1',
+    )
+    segplot = plot.plot_segments(flag, span=(0, 66))
     segplot.savefig(os.path.join(base, 'test.png'))
     shutil.rmtree(base, ignore_errors=True)

--- a/gwdetchar/tests/test_plot.py
+++ b/gwdetchar/tests/test_plot.py
@@ -29,7 +29,7 @@ from gwpy.segments import DataQualityFlag
 from matplotlib import (
     use,
     rcParams,
-    MatplotlibDeprecationWarning
+    MatplotlibDeprecationWarning,
 )
 use('agg')  # noqa
 


### PR DESCRIPTION
This PR systematically addresses all but one runtime warning during travis-CI builds:

* In `gwdetchar.omega.html`, use `numpy.array_equiv` rather than a simple boolean, because the truth value of an empty array is ambiguous
* In `gwdetchar.lasso.plot`, use escaped backslashes to construct a LaTeX command string
* In `gwdetchar.lasso.tests.test_plot`, use pytest to check that a `UserWarning` is raised correctly
* De-scope a couple of global variables that only get used in one unit test
* In the unit test for `gwdetchar.plot.texify`, filter out `MatplotlibDeprecationWarning`s because they all stem from unrelated changes to the list of recognized `rcParams`

The one remaining warning originates from PyCondor and has been resolved on `master`, but has not yet made it into a release. Until it does, unfortunately, we will be unable to properly support python3.8.

cc @duncanmmacleod 