### PR TITLE
Bump gwbootstrap to version 1.2.1

### DIFF
--- a/gwdetchar/io/html.py
+++ b/gwdetchar/io/html.py
@@ -124,9 +124,9 @@ BOOTSTRAP_JS = ('https://stackpath.bootstrapcdn.com/bootstrap/'
 FANCYBOX_JS = ('https://cdnjs.cloudflare.com/ajax/libs/'
                'fancybox/3.5.7/jquery.fancybox.min.js')
 
-GWBOOTSTRAP_CSS = ('https://cdn.jsdelivr.net/npm/gwbootstrap@1.2.0/'
+GWBOOTSTRAP_CSS = ('https://cdn.jsdelivr.net/npm/gwbootstrap@1.2.1/'
                    'lib/gwbootstrap.min.css')
-GWBOOTSTRAP_JS = ('https://cdn.jsdelivr.net/npm/gwbootstrap@1.2.0/'
+GWBOOTSTRAP_JS = ('https://cdn.jsdelivr.net/npm/gwbootstrap@1.2.1/'
                   'lib/gwbootstrap.min.js')
 
 CSS_FILES = [

--- a/gwdetchar/io/tests/test_html.py
+++ b/gwdetchar/io/tests/test_html.py
@@ -59,12 +59,12 @@ NEW_BOOTSTRAP_PAGE = """<!DOCTYPE HTML>
 <base href="{base}" />
 <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.11.2/css/fontawesome.min.css" rel="stylesheet" media="all" />
 <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.11.2/css/solid.min.css" rel="stylesheet" media="all" />
-<link href="https://cdn.jsdelivr.net/npm/gwbootstrap@1.2.0/lib/gwbootstrap.min.css" rel="stylesheet" media="all" />
+<link href="https://cdn.jsdelivr.net/npm/gwbootstrap@1.2.1/lib/gwbootstrap.min.css" rel="stylesheet" media="all" />
 <script src="https://code.jquery.com/jquery-3.4.1.min.js" type="text/javascript"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.lazy/1.7.10/jquery.lazy.min.js" type="text/javascript"></script>
 <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.bundle.min.js" type="text/javascript"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/fancybox/3.5.7/jquery.fancybox.min.js" type="text/javascript"></script>
-<script src="https://cdn.jsdelivr.net/npm/gwbootstrap@1.2.0/lib/gwbootstrap.min.js" type="text/javascript"></script>
+<script src="https://cdn.jsdelivr.net/npm/gwbootstrap@1.2.1/lib/gwbootstrap.min.js" type="text/javascript"></script>
 </head>
 <body>
 <div class="container">
@@ -237,7 +237,7 @@ def test_finalize_static_urls(tmpdir):
             'font-awesome/5.11.2/css/fontawesome.min.css',  # noqa: E131
         'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/'
             '5.11.2/css/solid.min.css',  # noqa: E131
-        'https://cdn.jsdelivr.net/npm/gwbootstrap@1.2.0/'
+        'https://cdn.jsdelivr.net/npm/gwbootstrap@1.2.1/'
             'lib/gwbootstrap.min.css',  # noqa E131
     ]
     assert js == [
@@ -248,7 +248,7 @@ def test_finalize_static_urls(tmpdir):
             'bootstrap.bundle.min.js',  # noqa: E131
         'https://cdnjs.cloudflare.com/ajax/libs/fancybox/3.5.7/'
             'jquery.fancybox.min.js',  # noqa E131
-        'https://cdn.jsdelivr.net/npm/gwbootstrap@1.2.0/'
+        'https://cdn.jsdelivr.net/npm/gwbootstrap@1.2.1/'
             'lib/gwbootstrap.min.js',  # noqa E131
     ]
     shutil.rmtree(str(tmpdir), ignore_errors=True)


### PR DESCRIPTION
This PR bumps the gwbootstrap version to 1.2.1.

cc @duncanmmacleod 