### PR TITLE
Add support for primary cache in lasso

### DIFF
--- a/bin/gwdetchar-lasso-correlation
+++ b/bin/gwdetchar-lasso-correlation
@@ -125,7 +125,7 @@ logger.info('{} Lasso correlations {}-{}'.format(args.ifo, start, end))
 # get primary channel frametype
 primary = args.primary_channel.format(ifo=args.ifo)
 range_is_primary = 'EFFECTIVE_RANGE_MPC' in args.primary_channel
-if args.primary_cache is not None: 
+if args.primary_cache is not None:
     logger.info("Using custom primary cache file")
 elif args.primary_frametype is None:
     try:

--- a/bin/gwdetchar-lasso-correlation
+++ b/bin/gwdetchar-lasso-correlation
@@ -83,7 +83,7 @@ parser.add_argument('-p', '--primary-channel',
 parser.add_argument('-P', '--primary-frametype', default=None,
                     help='frametype for --primary-channel, default: guess '
                          'by channel name')
-parser.add_argument( '--primary-cache', default=None,
+parser.add_argument('--primary-cache', default=None,
                     help='cache file for --primary-channel, default: None')
 parser.add_argument('-O', '--remove-outliers', type=float, default=None,
                     help='Std. dev. limit for removing outliers')

--- a/bin/gwdetchar-lasso-correlation
+++ b/bin/gwdetchar-lasso-correlation
@@ -83,6 +83,8 @@ parser.add_argument('-p', '--primary-channel',
 parser.add_argument('-P', '--primary-frametype', default=None,
                     help='frametype for --primary-channel, default: guess '
                          'by channel name')
+parser.add_argument( '--primary-cache', default=None,
+                    help='cache file for --primary-channel, default: None')
 parser.add_argument('-O', '--remove-outliers', type=float, default=None,
                     help='Std. dev. limit for removing outliers')
 parser.add_argument('-t', '--threshold', type=float, default=0.0001,
@@ -123,7 +125,9 @@ logger.info('{} Lasso correlations {}-{}'.format(args.ifo, start, end))
 # get primary channel frametype
 primary = args.primary_channel.format(ifo=args.ifo)
 range_is_primary = 'EFFECTIVE_RANGE_MPC' in args.primary_channel
-if args.primary_frametype is None:
+if args.primary_cache is not None: 
+    logger.info("Using custom primary cache file")
+elif args.primary_frametype is None:
     try:
         args.primary_frametype = DEFAULT_FRAMETYPE[
             args.primary_channel.split(':')[1]].format(ifo=args.ifo)
@@ -149,7 +153,8 @@ if args.band_pass:
     logger.info("-- Loading primary channel data")
     bandts = get_data(
         primary, start-pad, end+pad, verbose='Reading primary:'.rjust(30),
-        frametype=args.primary_frametype, nproc=args.nproc)
+        frametype=args.primary_frametype, source=args.primary_cache, 
+        nproc=args.nproc)
     if flower < 0 or fupper >= float((bandts.sample_rate/2.).value):
         raise ValueError("bandpass frequency is out of range for this "
                          "channel, band (Hz): {0}, sample rate: {1}".format(
@@ -191,7 +196,7 @@ else:
     # load primary channel data
     logger.info("-- Loading primary channel data")
     primaryts = get_data(primary, start, end, frametype=args.primary_frametype,
-                         verbose='Reading:'.rjust(30),
+                         source=args.primary_cache, verbose='Reading:'.rjust(30),
                          nproc=args.nproc).crop(start, end)
 
 if args.remove_outliers:
@@ -606,6 +611,7 @@ page.h1(title, class_='pb-2 mt-3 mb-2 border-bottom')
 content = [
     ('Primary channel', markup.oneliner.code(primary)),
     ('Primary frametype', markup.oneliner.code(args.primary_frametype) or '-'),
+    ('Primary cache file', markup.oneliner.code(args.primary_cache) or '-'),
     ('Outlier threshold', '%s sigma' % args.remove_outliers),
     ('Lasso coefficient threshold', str(args.threshold)),
     ('Cluster coefficient threshold', str(args.cluster_coefficient)),

--- a/bin/gwdetchar-lasso-correlation
+++ b/bin/gwdetchar-lasso-correlation
@@ -196,7 +196,8 @@ else:
     # load primary channel data
     logger.info("-- Loading primary channel data")
     primaryts = get_data(primary, start, end, frametype=args.primary_frametype,
-                         source=args.primary_cache, verbose='Reading:'.rjust(30),
+                         source=args.primary_cache,
+                         verbose='Reading:'.rjust(30),
                          nproc=args.nproc).crop(start, end)
 
 if args.remove_outliers:

--- a/bin/gwdetchar-lasso-correlation
+++ b/bin/gwdetchar-lasso-correlation
@@ -153,7 +153,7 @@ if args.band_pass:
     logger.info("-- Loading primary channel data")
     bandts = get_data(
         primary, start-pad, end+pad, verbose='Reading primary:'.rjust(30),
-        frametype=args.primary_frametype, source=args.primary_cache, 
+        frametype=args.primary_frametype, source=args.primary_cache,
         nproc=args.nproc)
     if flower < 0 or fupper >= float((bandts.sample_rate/2.).value):
         raise ValueError("bandpass frequency is out of range for this "


### PR DESCRIPTION
This merge request adds support to designate a primary cache file for reading primary channel data in `gwdetchar-lasso-correlations`. Additional support may be added in a similar fashion for auxiliary data, but this is not included in this merge request. 

If both a frametype and cache are specified in the command line, the data is read from the specified frametype, corresponding to the priority given in `gwdetchar.io.get_data()`.