### PR TITLE
Allow users to manually set the scaling of frequency axes

### DIFF
--- a/bin/gwdetchar-omega
+++ b/bin/gwdetchar-omega
@@ -69,6 +69,8 @@ parser.add_argument('-s', '--ignore-state-flags', action='store_true',
 parser.add_argument('-t', '--far-threshold', type=float, default=3.171e-8,
                     help='white noise false alarm rate threshold (Hz) for '
                          'processing channels, default: %(default)s')
+parser.add_argument('-y', '--yscale', default='log',
+                    help='scale of the frequency axis, default: %(default)s')
 parser.add_argument('-c', '--colormap', default='viridis',
                     help='name of colormap to use, default: %(default)s')
 cli.add_nproc_option(parser)
@@ -251,7 +253,9 @@ for block in blocks.values():
 
         logger.info(
             ' -- Plotting omega scan products for {}'.format(channel.name))
-        plot.write_qscan_plots(gps, channel, series, colormap=args.colormap)
+        plot.write_qscan_plots(gps, channel, series,
+                               yscale=args.yscale,
+                               colormap=args.colormap)
 
         if correlate is not None:
             logger.info(' -- Cross-correlating {}'.format(channel.name))

--- a/bin/gwdetchar-omega
+++ b/bin/gwdetchar-omega
@@ -69,8 +69,8 @@ parser.add_argument('-s', '--ignore-state-flags', action='store_true',
 parser.add_argument('-t', '--far-threshold', type=float, default=3.171e-8,
                     help='white noise false alarm rate threshold (Hz) for '
                          'processing channels, default: %(default)s')
-parser.add_argument('-y', '--yscale', default='log',
-                    help='scale of the frequency axis, default: %(default)s')
+parser.add_argument('-y', '--frequency-scale', default='log',
+                    help='scale of all frequency axes, default: %(default)s')
 parser.add_argument('-c', '--colormap', default='viridis',
                     help='name of colormap to use, default: %(default)s')
 cli.add_nproc_option(parser)
@@ -254,7 +254,7 @@ for block in blocks.values():
         logger.info(
             ' -- Plotting omega scan products for {}'.format(channel.name))
         plot.write_qscan_plots(gps, channel, series,
-                               yscale=args.yscale,
+                               yscale=args.frequency_scale,
                                colormap=args.colormap)
 
         if correlate is not None:

--- a/bin/gwdetchar-omega
+++ b/bin/gwdetchar-omega
@@ -69,8 +69,8 @@ parser.add_argument('-s', '--ignore-state-flags', action='store_true',
 parser.add_argument('-t', '--far-threshold', type=float, default=3.171e-8,
                     help='white noise false alarm rate threshold (Hz) for '
                          'processing channels, default: %(default)s')
-parser.add_argument('-y', '--frequency-scale', default='log',
-                    help='scale of all frequency axes, default: %(default)s')
+parser.add_argument('-y', '--frequency-scaling', default='log',
+                    help='scaling of all frequency axes, default: %(default)s')
 parser.add_argument('-c', '--colormap', default='viridis',
                     help='name of colormap to use, default: %(default)s')
 cli.add_nproc_option(parser)
@@ -239,7 +239,7 @@ for block in blocks.values():
             series = omega.scan(
                 gps, channel, data[channel.name].astype('float64'), fftlength,
                 resample=block.resample, fthresh=args.far_threshold,
-                search=block.search)
+                search=block.search, logf=(args.frequency_scaling == 'log'))
         except (ValueError, KeyError) as exc:
             warnings.warn("Skipping {}: [{}] {}".format(
                 channel.name, type(exc), str(exc)), UserWarning)
@@ -254,7 +254,7 @@ for block in blocks.values():
         logger.info(
             ' -- Plotting omega scan products for {}'.format(channel.name))
         plot.write_qscan_plots(gps, channel, series,
-                               fscale=args.frequency_scale,
+                               fscale=args.frequency_scaling,
                                colormap=args.colormap)
 
         if correlate is not None:

--- a/bin/gwdetchar-omega
+++ b/bin/gwdetchar-omega
@@ -254,7 +254,7 @@ for block in blocks.values():
         logger.info(
             ' -- Plotting omega scan products for {}'.format(channel.name))
         plot.write_qscan_plots(gps, channel, series,
-                               yscale=args.frequency_scale,
+                               fscale=args.frequency_scale,
                                colormap=args.colormap)
 
         if correlate is not None:

--- a/bin/gwdetchar-omega-batch
+++ b/bin/gwdetchar-omega-batch
@@ -53,7 +53,9 @@ parser.add_argument(
     '-f', '--config-file',
     help='path to configuration file to use, default: '
          'choose based on observatory, epoch, and pipeline')
-parser.add_argument('--colormap', default='viridis',
+parser.add_argument('-y', '--yscale', default='log',
+                    help='scale of the frequency axis, default: %(default)s')
+parser.add_argument('-c', '--colormap', default='viridis',
                     help='name of colormap to use, default: %(default)s')
 parser.add_argument('-d', '--disable-correlation', action='store_true',
                     default=False, help='disable cross-correlation of aux '

--- a/bin/gwdetchar-omega-batch
+++ b/bin/gwdetchar-omega-batch
@@ -53,8 +53,8 @@ parser.add_argument(
     '-f', '--config-file',
     help='path to configuration file to use, default: '
          'choose based on observatory, epoch, and pipeline')
-parser.add_argument('-y', '--yscale', default='log',
-                    help='scale of the frequency axis, default: %(default)s')
+parser.add_argument('-y', '--frequency-scale', default='log',
+                    help='scale of all frequency axes, default: %(default)s')
 parser.add_argument('-c', '--colormap', default='viridis',
                     help='name of colormap to use, default: %(default)s')
 parser.add_argument('-d', '--disable-correlation', action='store_true',
@@ -126,6 +126,7 @@ condorcmds = batch.get_condor_arguments(
 # get command-line flags
 flags = batch.get_command_line_flags(
     args.ifo,
+    fscale=args.frequency_scale,
     colormap=args.colormap,
     nproc=args.nproc,
     far=args.far_threshold,

--- a/bin/gwdetchar-omega-batch
+++ b/bin/gwdetchar-omega-batch
@@ -53,8 +53,8 @@ parser.add_argument(
     '-f', '--config-file',
     help='path to configuration file to use, default: '
          'choose based on observatory, epoch, and pipeline')
-parser.add_argument('-y', '--frequency-scale', default='log',
-                    help='scale of all frequency axes, default: %(default)s')
+parser.add_argument('-y', '--frequency-scaling', default='log',
+                    help='scaling of all frequency axes, default: %(default)s')
 parser.add_argument('-c', '--colormap', default='viridis',
                     help='name of colormap to use, default: %(default)s')
 parser.add_argument('-d', '--disable-correlation', action='store_true',
@@ -126,7 +126,7 @@ condorcmds = batch.get_condor_arguments(
 # get command-line flags
 flags = batch.get_command_line_flags(
     args.ifo,
-    fscale=args.frequency_scale,
+    fscale=args.frequency_scaling,
     colormap=args.colormap,
     nproc=args.nproc,
     far=args.far_threshold,

--- a/gwdetchar/omega/batch.py
+++ b/gwdetchar/omega/batch.py
@@ -39,13 +39,15 @@ ACCOUNTING_GROUP_USER = os.getenv(
 
 # -- utilities ----------------------------------------------------------------
 
-def get_command_line_flags(ifo, colormap='viridis', nproc=8, far=3.171e-8,
-                           config_file=None, disable_correlation=False,
-                           disable_checkpoint=False, ignore_state_flags=False):
+def get_command_line_flags(ifo, fscale='log', colormap='viridis', nproc=8,
+                           far=3.171e-8, config_file=None,
+                           disable_correlation=False, disable_checkpoint=False,
+                           ignore_state_flags=False):
     """Get a list of optional command-line arguments to `gwdetchar-omega`
     """
     flags = [
         "--ifo", ifo,
+        "--frequency-scale", fscale,
         "--colormap", colormap,
         "--nproc", str(nproc),
         "--far-threshold", str(far),

--- a/gwdetchar/omega/batch.py
+++ b/gwdetchar/omega/batch.py
@@ -47,7 +47,7 @@ def get_command_line_flags(ifo, fscale='log', colormap='viridis', nproc=8,
     """
     flags = [
         "--ifo", ifo,
-        "--frequency-scale", fscale,
+        "--frequency-scaling", fscale,
         "--colormap", colormap,
         "--nproc", str(nproc),
         "--far-threshold", str(far),

--- a/gwdetchar/omega/core.py
+++ b/gwdetchar/omega/core.py
@@ -236,7 +236,7 @@ def cross_correlate(xoft, hoft):
 
 
 def scan(gps, channel, xoft, fftlength, resample=None, fthresh=1e-10,
-         search=0.5, nt=1400, nf=700, **kwargs):
+         search=0.5, nt=1400, nf=700, logf=True, **kwargs):
     """Scan a channel for evidence of transients
 
     Parameters
@@ -270,8 +270,12 @@ def scan(gps, channel, xoft, fftlength, resample=None, fthresh=1e-10,
         default: 1400
 
     nf : `int`, optional
-        number of points on the (log-sampled) frequency axis of the
-        interpolated `Spectrogram`, default: 700
+        number of points on the frequency axis of the interpolated
+        `Spectrogram`, default: 700
+
+    logf : `bool`, optional
+        boolean switch to enable (`True`) or disable (`False`) use of
+        log-sampled frequencies in the output `Spectrogram`, default: `True`
 
     **kwargs : `dict`, optional
         additional arguments to `omega.conditioner`
@@ -302,10 +306,22 @@ def scan(gps, channel, xoft, fftlength, resample=None, fthresh=1e-10,
         frange=qgram.plane.frange, search=search)
     # compute interpolated spectrograms
     tres = min(channel.pranges) / nt
+    fres = nf if logf else (
+        channel.frange[1] - channel.frange[0]) / nf
     outseg = Segment(
-        gps - max(channel.pranges)/2, gps + max(channel.pranges)/2)
-    qspec = qgram.interpolate(tres=tres, fres=nf, logf=True,
-                              outseg=outseg)
-    rqspec = rqgram.interpolate(tres=tres, fres=nf, logf=True,
-                                outseg=outseg)
+        gps - max(channel.pranges)/2,
+        gps + max(channel.pranges)/2,
+    )
+    qspec = qgram.interpolate(
+        tres=tres,
+        fres=fres,
+        logf=logf,
+        outseg=outseg,
+    )
+    rqspec = rqgram.interpolate(
+        tres=tres,
+        fres=fres,
+        logf=logf,
+        outseg=outseg,
+    )
     return (xoft, hpxoft, wxoft, qgram, rqgram, qspec, rqspec)

--- a/gwdetchar/omega/plot.py
+++ b/gwdetchar/omega/plot.py
@@ -211,7 +211,7 @@ def spectral_plot(data, gps, span, channel, output, colormap='viridis',
     plot.close()
 
 
-def write_qscan_plots(gps, channel, series, yscale='log', colormap='viridis'):
+def write_qscan_plots(gps, channel, series, fscale='log', colormap='viridis'):
     """Custom plot utility for a full omega scan
 
     Parameters
@@ -225,7 +225,7 @@ def write_qscan_plots(gps, channel, series, yscale='log', colormap='viridis'):
     series : `tuple`
         a collection of `TimeSeries`, `Spectrogram`, and `QGram` objects
 
-    yscale : `str`
+    fscale : `str`
         scaling of the frequency axis, default: log
 
     colormap : `str`, optional
@@ -245,14 +245,14 @@ def write_qscan_plots(gps, channel, series, yscale='log', colormap='viridis'):
         # plot whitened qscan
         spectral_plot(
             qspec, gps, span, channel.name, str(png1), clim=(0, 25),
-            yscale=yscale, colormap=colormap)
+            yscale=fscale, colormap=colormap)
         # plot autoscaled, whitened qscan
         spectral_plot(qspec, gps, span, channel.name, str(png2),
-                      yscale=yscale, colormap=colormap)
+                      yscale=fscale, colormap=colormap)
         # plot raw qscan
         spectral_plot(
             rqspec, gps, span, channel.name, str(png3), clim=(0, 25),
-            yscale=yscale, colormap=colormap)
+            yscale=fscale, colormap=colormap)
         # plot raw timeseries
         timeseries_plot(xoft, gps, span, channel.name, str(png4),
                         ylabel='Amplitude')
@@ -266,13 +266,13 @@ def write_qscan_plots(gps, channel, series, yscale='log', colormap='viridis'):
         rtable = rqgram.table(snrthresh=channel.snrthresh)
         spectral_plot(
             rtable, gps, span, channel.name, str(png7), clim=(0, 25),
-            yscale=yscale, colormap=colormap)
+            yscale=fscale, colormap=colormap)
         # plot whitened eventgram
         table = qgram.table(snrthresh=channel.snrthresh)
         spectral_plot(
             table, gps, span, channel.name, str(png8), clim=(0, 25),
-            yscale=yscale, colormap=colormap)
+            yscale=fscale, colormap=colormap)
         # plot autoscaled whitened eventgram
         spectral_plot(table, gps, span, channel.name, str(png9),
-                      yscale=yscale, colormap=colormap)
+                      yscale=fscale, colormap=colormap)
     return

--- a/gwdetchar/omega/plot.py
+++ b/gwdetchar/omega/plot.py
@@ -55,7 +55,7 @@ def _format_time_axis(ax, gps, span):
     ax.grid(True, axis='x', which='major')
 
 
-def _format_frequency_axis(ax):
+def _format_frequency_axis(ax, yscale='log'):
     """Format the frequency axis of an omega scan plot
 
     Parameters
@@ -64,7 +64,7 @@ def _format_frequency_axis(ax):
         the `Axis` object to format
     """
     ax.grid(True, axis='y', which='both')
-    ax.set_yscale('log')
+    ax.set_yscale(yscale)
     ax.set_ylabel('Frequency [Hz]')
 
 
@@ -144,7 +144,8 @@ def timeseries_plot(data, gps, span, channel, output, ylabel=None,
 
 
 def spectral_plot(data, gps, span, channel, output, colormap='viridis',
-                  clim=None, nx=1400, norm='linear', figsize=(12, 6)):
+                  clim=None, nx=1400, yscale='log', norm='linear',
+                  figsize=(12, 6)):
     """Custom plot for a GWPy spectrogram or Q-gram
 
     Parameters
@@ -169,6 +170,9 @@ def spectral_plot(data, gps, span, channel, output, colormap='viridis',
 
     clim : `tuple` or `None`
         limits of the color axis, default: autoscale with log scaling
+
+    yscale : `str`
+        scaling of the frequency axis, default: log
 
     norm : `str`
         scaling of the color axis, only used if `clim` is given,
@@ -196,7 +200,7 @@ def spectral_plot(data, gps, span, channel, output, colormap='viridis',
     # set axis properties
     ax = plot.gca()
     _format_time_axis(ax, gps=gps, span=span)
-    _format_frequency_axis(ax)
+    _format_frequency_axis(ax, yscale=yscale)
     # set colorbar properties
     _format_color_axis(ax, colormap=colormap, clim=clim, norm=norm)
     # set title
@@ -207,7 +211,7 @@ def spectral_plot(data, gps, span, channel, output, colormap='viridis',
     plot.close()
 
 
-def write_qscan_plots(gps, channel, series, colormap='viridis'):
+def write_qscan_plots(gps, channel, series, yscale='log', colormap='viridis'):
     """Custom plot utility for a full omega scan
 
     Parameters
@@ -220,6 +224,9 @@ def write_qscan_plots(gps, channel, series, colormap='viridis'):
 
     series : `tuple`
         a collection of `TimeSeries`, `Spectrogram`, and `QGram` objects
+
+    yscale : `str`
+        scaling of the frequency axis, default: log
 
     colormap : `str`, optional
         matplotlib colormap to use, default: viridis
@@ -238,14 +245,14 @@ def write_qscan_plots(gps, channel, series, colormap='viridis'):
         # plot whitened qscan
         spectral_plot(
             qspec, gps, span, channel.name, str(png1), clim=(0, 25),
-            colormap=colormap)
+            yscale=yscale, colormap=colormap)
         # plot autoscaled, whitened qscan
         spectral_plot(qspec, gps, span, channel.name, str(png2),
-                      colormap=colormap)
+                      yscale=yscale, colormap=colormap)
         # plot raw qscan
         spectral_plot(
             rqspec, gps, span, channel.name, str(png3), clim=(0, 25),
-            colormap=colormap)
+            yscale=yscale, colormap=colormap)
         # plot raw timeseries
         timeseries_plot(xoft, gps, span, channel.name, str(png4),
                         ylabel='Amplitude')
@@ -259,13 +266,13 @@ def write_qscan_plots(gps, channel, series, colormap='viridis'):
         rtable = rqgram.table(snrthresh=channel.snrthresh)
         spectral_plot(
             rtable, gps, span, channel.name, str(png7), clim=(0, 25),
-            colormap=colormap)
+            yscale=yscale, colormap=colormap)
         # plot whitened eventgram
         table = qgram.table(snrthresh=channel.snrthresh)
         spectral_plot(
             table, gps, span, channel.name, str(png8), clim=(0, 25),
-            colormap=colormap)
+            yscale=yscale, colormap=colormap)
         # plot autoscaled whitened eventgram
         spectral_plot(table, gps, span, channel.name, str(png9),
-                      colormap=colormap)
+                      yscale=yscale, colormap=colormap)
     return

--- a/gwdetchar/omega/tests/test_batch.py
+++ b/gwdetchar/omega/tests/test_batch.py
@@ -36,6 +36,7 @@ __author__ = 'Alex Urban <alexander.urban@ligo.org>'
 
 FLAGS = [
     '--ifo', 'X1',
+    '--frequency-scale', 'log',
     '--colormap', 'viridis',
     '--nproc', '8',
     '--far-threshold', '3.171e-08',

--- a/gwdetchar/omega/tests/test_batch.py
+++ b/gwdetchar/omega/tests/test_batch.py
@@ -36,7 +36,7 @@ __author__ = 'Alex Urban <alexander.urban@ligo.org>'
 
 FLAGS = [
     '--ifo', 'X1',
-    '--frequency-scale', 'log',
+    '--frequency-scaling', 'log',
     '--colormap', 'viridis',
     '--nproc', '8',
     '--far-threshold', '3.171e-08',


### PR DESCRIPTION
This PR implements a way for omega scan users to manually set the scales of frequency axes by passing a command-line flag, `--frequency-scaling`. Note, there are two pieces to this:

* Allow users to manually switch between `'log'` (the default) and `'linear'` axis scaling, and propagate this from `gwdetchar-omega` to the final spectral plots
* If `'log'` is selected, sample frequency points logarithmically when interpolating the Q-transform, otherwise sample them linearly

This fixes #375.

cc @duncanmmacleod, @siddharth101 