### PR TITLE
Address race condition in logger

### DIFF
--- a/gwdetchar/cli.py
+++ b/gwdetchar/cli.py
@@ -73,6 +73,7 @@ def logger(name=__name__, level='DEBUG'):
     coloredlogs.install(
         level=level, logger=logger, stream=sys.stdout, fmt=FMT,
         datefmt=DATEFMT, level_styles=LEVEL_STYLES, field_styles=FIELD_STYLES)
+    logger.setLevel(level)
     return logger
 
 


### PR DESCRIPTION
Sometimes (I can't nail down _when_ this will happen) `coloredlogs.install()` will set the logging level on the parent logger _only_ and not the actual logger we gave it, so this PR adds a safety net to force the new logger to have the correct level.

cf https://git.ligo.org/computing/conda/-/jobs/1146040#L1527