### PR TITLE
Pin parse-conda-requirements.py to a specific version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
       env: PYTHON_VERSION="3.9"
 
 before_install:
-  - curl -LO https://raw.githubusercontent.com/gwpy/gwpy/master/ci/parse-conda-requirements.py
+  - curl -LO https://raw.githubusercontent.com/gwpy/gwpy/v2.0.3/ci/parse-conda-requirements.py
   - curl -o miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
   - bash miniconda.sh -b -p ${HOME}/miniconda
   - source "${HOME}/miniconda/etc/profile.d/conda.sh"


### PR DESCRIPTION
This PR pins the download reference for the `parse-conda-requirements.py` script, since the upstream gwpy is changing (see gwpy/gwpy#1320).