### PR TITLE
Remove unused lalsuite requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ beautifulsoup4
 gwdatafind
 gwpy >= 2.0.0
 gwtrigfind
-lalsuite
 lscsoft-glue >= 2.0.0
 lxml
 MarkupPy >=1.14

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,7 +53,6 @@ install_requires =
 	gwdatafind
 	gwpy >=2.0.0
 	gwtrigfind
-	lalsuite
 	lscsoft-glue >=2.0.0
 	lxml
 	MarkupPy >=1.14


### PR DESCRIPTION
This PR removes the (apparently) unused `lalsuite` `install_requires` entry. I think the last need for this was removed in fa60c53bb939b92d16f2104bac576f597c3f775b.