### PR TITLE
swap to gwpy-based datafind

### DIFF
--- a/gwdetchar/io/datafind.py
+++ b/gwdetchar/io/datafind.py
@@ -24,8 +24,6 @@ import warnings
 from urllib.error import HTTPError
 from json.decoder import JSONDecodeError
 
-import gwdatafind
-
 from ..const import DEFAULT_SEGMENT_SERVER
 
 from gwpy.io import gwf as io_gwf

--- a/gwdetchar/io/datafind.py
+++ b/gwdetchar/io/datafind.py
@@ -29,6 +29,7 @@ import gwdatafind
 from ..const import DEFAULT_SEGMENT_SERVER
 
 from gwpy.io import gwf as io_gwf
+from gwpy.io import datafind as io_datafind
 from gwpy.segments import (Segment, DataQualityFlag)
 from gwpy.timeseries import (TimeSeries, TimeSeriesDict)
 
@@ -192,7 +193,7 @@ def get_data(channel, start, end, frametype=None, source=None,
         try:  # locate frame files
             ifo = re.search('[A-Z]1', frametype).group(0)
             obs = ifo[0]
-            source = gwdatafind.find_urls(obs, frametype, start, end)
+            source = io_datafind.find_urls(obs, frametype, start, end)
         except AttributeError:
             raise AttributeError(
                 'Could not determine observatory from frametype')

--- a/gwdetchar/io/tests/test_datafind.py
+++ b/gwdetchar/io/tests/test_datafind.py
@@ -93,7 +93,7 @@ def test_get_data_dict_from_NDS(tsdget):
     nptest.assert_array_equal(data['X1:TEST-STRAIN'].value, HOFT.value)
 
 
-@mock.patch('gwdatafind.find_urls')
+@mock.patch('gwpy.io.datafind.find_urls')
 @mock.patch('gwpy.timeseries.TimeSeries.read')
 def test_get_data_from_cache(tsget, find_data):
     # set return values
@@ -114,7 +114,7 @@ def test_get_data_from_cache(tsget, find_data):
     nptest.assert_array_equal(data.value, HOFT.crop(start, end).value)
 
 
-@mock.patch('gwdatafind.find_urls')
+@mock.patch('gwpy.io.datafind.find_urls')
 @mock.patch('gwdetchar.io.datafind.remove_missing_channels')
 @mock.patch('gwpy.timeseries.TimeSeriesDict.read')
 def test_get_data_dict_from_cache(tsdget, remove, find_data):


### PR DESCRIPTION
This pull request swaps out the datafind method in gwdetchar from `gwdatafind.find_urls()` to `gwpy.io.datafind.find_urls()`. The relevant gwpy function can be seen here: 

https://github.com/gwpy/gwpy/blob/223e6e5fc9223c5b08975c1c023286546fe5094f/gwpy/io/datafind.py#L698-L709

As linked above, in the LIGO case, the function `gwdatafind.find_urls()` is still used. However, this function also has support for finding Virgo FFL urls. Hence, this PR is necessary for Virgo support by gwdetchar tools and should still have the same result in the LIGO case. 