### PR TITLE
Swap out broken link

### DIFF
--- a/gwdetchar/io/html.py
+++ b/gwdetchar/io/html.py
@@ -1210,7 +1210,7 @@ def write_footer(about=None, link=None, issues=None, external=None):
         page.a(markup.oneliner.i('', class_='fas fa-external-link-alt'),
                href=external, title="View this page's external source")
     page.a(markup.oneliner.i('', class_='fas fa-heartbeat'),
-           href='https://attackofthecute.com/random.php',
+           href='https://apod.nasa.gov/apod/astropix.html',
            title='Take a break from science', target='_blank')
     page.div.close()  # col-sm-3 icon-bar
     # print timestamp

--- a/gwdetchar/io/tests/test_html.py
+++ b/gwdetchar/io/tests/test_html.py
@@ -127,7 +127,7 @@ HTML_FOOTER = """<footer class="footer">
 <a href="https://github.com/gwdetchar/gwdetchar/issues" title="Open an issue ticket" target="_blank"><i class="fas fa-ticket-alt"></i></a>
 <a href="about" title="How was this page generated?"><i class="fas fa-info-circle"></i></a>
 <a href="external" title="View this page&quot;s external source"><i class="fas fa-external-link-alt"></i></a>
-<a href="https://attackofthecute.com/random.php" title="Take a break from science" target="_blank"><i class="fas fa-heartbeat"></i></a>
+<a href="https://apod.nasa.gov/apod/astropix.html" title="Take a break from science" target="_blank"><i class="fas fa-heartbeat"></i></a>
 </div>
 <div class="col-sm-6">
 <p>Created by {user} at {date}</p>


### PR DESCRIPTION
This pull request swaps out a broken link that is hard-coded in the `gwdetchar` codebase. 

In the long term, if this feature is intended to be kept, this link should be a configurable option. In the short term, I suggest swapping to a link that we believe will be stable (e.g. my suggestion in the PR for astro pic of the day). If this is also a concern, then I suggest we simply remove the feature (and the link) until this code can be re-added. 