### PR TITLE
Fix CI build failures with latest pygments and rstcheck

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,10 +31,10 @@ jobs:
           - macOS
           - Ubuntu
         python-version:
-          - 3.6
           - 3.7
           - 3.8
           - 3.9
+          - '3.10'
     runs-on: ${{ matrix.os }}-latest
 
     # this is needed for conda environments to activate automatically

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -45,8 +45,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install \
-            "rstcheck" \
+        python -m pip install "sphinx"
+        python -m pip install "rstcheck"
         ;
     - name: Lint with rstcheck
       run: rstcheck . --recursive

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -47,6 +47,5 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install "sphinx"
         python -m pip install "rstcheck"
-        ;
     - name: Lint with rstcheck
       run: rstcheck . --recursive

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -46,6 +46,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install "sphinx"
-        python -m pip install "rstcheck"
+        python -m pip install "rstcheck>=6.0"
     - name: Lint with rstcheck
       run: rstcheck . --recursive

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -49,4 +49,4 @@ jobs:
             "rstcheck" \
         ;
     - name: Lint with rstcheck
-      run: python -m rstcheck . --recursive
+      run: rstcheck . --recursive

--- a/gwdetchar/io/tests/test_html.py
+++ b/gwdetchar/io/tests/test_html.py
@@ -27,9 +27,9 @@ import sys
 
 from getpass import getuser
 from MarkupPy import markup
+from pygments import __version__ as pygments_version
 from pytz import reference
 from unittest import mock
-from pygments import __version__ as pygments_version
 
 from gwpy.segments import (Segment, DataQualityFlag)
 

--- a/gwdetchar/io/tests/test_html.py
+++ b/gwdetchar/io/tests/test_html.py
@@ -29,6 +29,7 @@ from getpass import getuser
 from MarkupPy import markup
 from pytz import reference
 from unittest import mock
+from pygments import __version__ as pygments_version
 
 from gwpy.segments import (Segment, DataQualityFlag)
 
@@ -72,79 +73,49 @@ NEW_BOOTSTRAP_PAGE = """<!DOCTYPE HTML>
 TEST_CONFIGURATION = """[section]
 key = value"""
 
-ABOUT = """<div class="row">
+if pygments_version >= "2.11.0":
+    pygments_output = (
+        '<span style="color: #bbbbbb"></span>\n'
+        '<span style="color: #687822">key</span>'
+        '<span style="color: #bbbbbb"> </span>'
+        '<span style="color: #666666">=</span>'
+        '<span style="color: #bbbbbb"> </span>'
+        '<span style="color: #BA2121">value</span>'
+        '<span style="color: #bbbbbb"></span>'
+    )
+else:
+    pygments_output = (
+        '\n'
+        '<span style="color: #7D9029">key</span> '
+        '<span style="color: #666666">=</span> '
+        '<span style="color: #BA2121">value</span>'
+    )
+
+ABOUT = f"""<div class="row">
 <div class="col-md-12">
 <h2>On the command-line</h2>
 <p>This page was generated with the following command-line call:</p>
 <div class="highlight" style="background: #f8f8f8"><pre style="line-height: 125%;"><span></span>$ gwdetchar-scattering -i X1
 </pre></div>
 
-<p>The install path used was <code>{}</code>.</p>
+<p>The install path used was <code>{sys.prefix}</code>.</p>
 <h2>Configuration files</h2>
 <p>The following INI-format configuration file(s) were passed on the comand-line and are reproduced here in full:</p>
-<div class="highlight" style="background: #f8f8f8"><pre style="line-height: 125%;"><span></span><span style="color: #008000; font-weight: bold">[section]</span>
-<span style="color: #7D9029">key</span> <span style="color: #666666">=</span> <span style="color: #BA2121">value</span>
+<div class="highlight" style="background: #f8f8f8"><pre style="line-height: 125%;"><span></span><span style="color: #008000; font-weight: bold">[section]</span>{pygments_output}
 </pre></div>
 
 <h2 class="mt-4">Environment</h2><table class="table table-sm table-hover table-responsive" id="package-table"><caption>Table of packages installed in the production environment</caption><thead><tr><th scope="col">Name</th><th scope="col">Version</th></tr></thead><tbody><tr><td>gwdetchar</td><td>1.2.3</td></tr><tr><td>gwpy</td><td>1.0.0</td></tr></tbody></table><button class="btn btn-outline-secondary btn-table mt-2" data-table-id="package-table" data-filename="package-table.csv">Export to CSV</button>
 </div>
-</div>""".format(sys.prefix)  # noqa: E501
+</div>"""  # noqa: E501
 
-ABOUT2 = """<div class="row">
+ABOUT_WITH_CONFIG_LIST = f"""<div class="row">
 <div class="col-md-12">
 <h2>On the command-line</h2>
 <p>This page was generated with the following command-line call:</p>
 <div class="highlight" style="background: #f8f8f8"><pre style="line-height: 125%;"><span></span>$ gwdetchar-scattering -i X1
 </pre></div>
 
-<p>The install path used was <code>{}</code>.</p>
-<h2>Configuration files</h2>
-<p>The following INI-format configuration file(s) were passed on the comand-line and are reproduced here in full:</p>
-<div class="highlight" style="background: #f8f8f8"><pre style="line-height: 125%;"><span></span><span style="color: #008000; font-weight: bold">[section]</span><span style="color: #bbbbbb"></span>
-<span style="color: #687822">key</span><span style="color: #bbbbbb"> </span><span style="color: #666666">=</span><span style="color: #bbbbbb"> </span><span style="color: #BA2121">value</span><span style="color: #bbbbbb"></span>
-</pre></div>
-
-<h2 class="mt-4">Environment</h2><table class="table table-sm table-hover table-responsive" id="package-table"><caption>Table of packages installed in the production environment</caption><thead><tr><th scope="col">Name</th><th scope="col">Version</th></tr></thead><tbody><tr><td>gwdetchar</td><td>1.2.3</td></tr><tr><td>gwpy</td><td>1.0.0</td></tr></tbody></table><button class="btn btn-outline-secondary btn-table mt-2" data-table-id="package-table" data-filename="package-table.csv">Export to CSV</button>
-</div>
-</div>""".format(sys.prefix)  # noqa: E501
-
-ABOUT_WITH_CONFIG_LIST = """<div class="row">
-<div class="col-md-12">
-<h2>On the command-line</h2>
-<p>This page was generated with the following command-line call:</p>
-<div class="highlight" style="background: #f8f8f8"><pre style="line-height: 125%;"><span></span>$ gwdetchar-scattering -i X1
-</pre></div>
-
-<p>The install path used was <code>{}</code>.</p>
-<h2>Configuration files</h2>
-<p>The following INI-format configuration file(s) were passed on the comand-line and are reproduced here in full:</p>
-<div id="accordion">
-<div class="card mb-1 shadow-sm">
-<div class="card-header">
-<a class="collapsed card-link cis-link" href="#file0" data-toggle="collapse">test.ini</a>
-</div>
-<div id="file0" class="collapse" data-parent="#accordion">
-<div class="card-body">
-<div class="highlight" style="background: #f8f8f8"><pre style="line-height: 125%;"><span></span><span style="color: #008000; font-weight: bold">[section]</span>
-<span style="color: #7D9029">key</span> <span style="color: #666666">=</span> <span style="color: #BA2121">value</span>
-</pre></div>
-
-</div>
-</div>
-</div>
-</div>
-<h2 class="mt-4">Environment</h2><table class="table table-sm table-hover table-responsive" id="package-table"><caption>Table of packages installed in the production environment</caption><thead><tr><th scope="col">Name</th><th scope="col">Version</th></tr></thead><tbody><tr><td>gwdetchar</td><td>1.2.3</td></tr><tr><td>gwpy</td><td>1.0.0</td></tr></tbody></table><button class="btn btn-outline-secondary btn-table mt-2" data-table-id="package-table" data-filename="package-table.csv">Export to CSV</button>
-</div>
-</div>""".format(sys.prefix)  # noqa: E501
-
-ABOUT_WITH_CONFIG_LIST2 = """<div class="row">
-<div class="col-md-12">
-<h2>On the command-line</h2>
-<p>This page was generated with the following command-line call:</p>
-<div class="highlight" style="background: #f8f8f8"><pre style="line-height: 125%;"><span></span>$ gwdetchar-scattering -i X1
-</pre></div>
-
-<p>The install path used was <code>{}</code>.</p>
+<p>The install path used was <code>{sys.prefix}</code>.</p>
 <h2>Configuration files</h2>
 <p>The following INI-format configuration file(s) were passed on the comand-line and are reproduced here in full:</p>
 <div id="accordion">
@@ -154,8 +125,7 @@ ABOUT_WITH_CONFIG_LIST2 = """<div class="row">
 </div>
 <div id="file0" class="collapse" data-parent="#accordion">
 <div class="card-body">
-<div class="highlight" style="background: #f8f8f8"><pre style="line-height: 125%;"><span></span><span style="color: #008000; font-weight: bold">[section]</span><span style="color: #bbbbbb"></span>
-<span style="color: #687822">key</span><span style="color: #bbbbbb"> </span><span style="color: #666666">=</span><span style="color: #bbbbbb"> </span><span style="color: #BA2121">value</span><span style="color: #bbbbbb"></span>
+<div class="highlight" style="background: #f8f8f8"><pre style="line-height: 125%;"><span></span><span style="color: #008000; font-weight: bold">[section]</span>{pygments_output}
 </pre></div>
 
 </div>
@@ -164,7 +134,7 @@ ABOUT_WITH_CONFIG_LIST2 = """<div class="row">
 </div>
 <h2 class="mt-4">Environment</h2><table class="table table-sm table-hover table-responsive" id="package-table"><caption>Table of packages installed in the production environment</caption><thead><tr><th scope="col">Name</th><th scope="col">Version</th></tr></thead><tbody><tr><td>gwdetchar</td><td>1.2.3</td></tr><tr><td>gwpy</td><td>1.0.0</td></tr></tbody></table><button class="btn btn-outline-secondary btn-table mt-2" data-table-id="package-table" data-filename="package-table.csv">Export to CSV</button>
 </div>
-</div>""".format(sys.prefix)  # noqa: E501
+</div>"""  # noqa: E501
 
 HTML_FOOTER = """<footer class="footer">
 <div class="container">
@@ -376,12 +346,10 @@ def test_about_this_page(package_list, tmpdir):
     with mock.patch.object(sys, 'argv', testargs):
         # test with a single config file
         about = html.about_this_page(config_file)
-        assert (parse_html(about) == parse_html(ABOUT) or
-                parse_html(about) == parse_html(ABOUT2))
+        assert parse_html(about) == parse_html(ABOUT)
         # test with a list of config files
         about = html.about_this_page([config_file])
-        assert (parse_html(about) == parse_html(ABOUT_WITH_CONFIG_LIST) or
-                parse_html(about) == parse_html(ABOUT_WITH_CONFIG_LIST2))
+        assert parse_html(about) == parse_html(ABOUT_WITH_CONFIG_LIST)
     # clean up
     shutil.rmtree(outdir, ignore_errors=True)
 

--- a/gwdetchar/io/tests/test_html.py
+++ b/gwdetchar/io/tests/test_html.py
@@ -90,6 +90,24 @@ ABOUT = """<div class="row">
 </div>
 </div>""".format(sys.prefix)  # noqa: E501
 
+ABOUT2 = """<div class="row">
+<div class="col-md-12">
+<h2>On the command-line</h2>
+<p>This page was generated with the following command-line call:</p>
+<div class="highlight" style="background: #f8f8f8"><pre style="line-height: 125%;"><span></span>$ gwdetchar-scattering -i X1
+</pre></div>
+
+<p>The install path used was <code>{}</code>.</p>
+<h2>Configuration files</h2>
+<p>The following INI-format configuration file(s) were passed on the comand-line and are reproduced here in full:</p>
+<div class="highlight" style="background: #f8f8f8"><pre style="line-height: 125%;"><span></span><span style="color: #008000; font-weight: bold">[section]</span><span style="color: #bbbbbb"></span>
+<span style="color: #687822">key</span><span style="color: #bbbbbb"> </span><span style="color: #666666">=</span><span style="color: #bbbbbb"> </span><span style="color: #BA2121">value</span><span style="color: #bbbbbb"></span>
+</pre></div>
+
+<h2 class="mt-4">Environment</h2><table class="table table-sm table-hover table-responsive" id="package-table"><caption>Table of packages installed in the production environment</caption><thead><tr><th scope="col">Name</th><th scope="col">Version</th></tr></thead><tbody><tr><td>gwdetchar</td><td>1.2.3</td></tr><tr><td>gwpy</td><td>1.0.0</td></tr></tbody></table><button class="btn btn-outline-secondary btn-table mt-2" data-table-id="package-table" data-filename="package-table.csv">Export to CSV</button>
+</div>
+</div>""".format(sys.prefix)  # noqa: E501
+
 ABOUT_WITH_CONFIG_LIST = """<div class="row">
 <div class="col-md-12">
 <h2>On the command-line</h2>
@@ -109,6 +127,35 @@ ABOUT_WITH_CONFIG_LIST = """<div class="row">
 <div class="card-body">
 <div class="highlight" style="background: #f8f8f8"><pre style="line-height: 125%;"><span></span><span style="color: #008000; font-weight: bold">[section]</span>
 <span style="color: #7D9029">key</span> <span style="color: #666666">=</span> <span style="color: #BA2121">value</span>
+</pre></div>
+
+</div>
+</div>
+</div>
+</div>
+<h2 class="mt-4">Environment</h2><table class="table table-sm table-hover table-responsive" id="package-table"><caption>Table of packages installed in the production environment</caption><thead><tr><th scope="col">Name</th><th scope="col">Version</th></tr></thead><tbody><tr><td>gwdetchar</td><td>1.2.3</td></tr><tr><td>gwpy</td><td>1.0.0</td></tr></tbody></table><button class="btn btn-outline-secondary btn-table mt-2" data-table-id="package-table" data-filename="package-table.csv">Export to CSV</button>
+</div>
+</div>""".format(sys.prefix)  # noqa: E501
+
+ABOUT_WITH_CONFIG_LIST2 = """<div class="row">
+<div class="col-md-12">
+<h2>On the command-line</h2>
+<p>This page was generated with the following command-line call:</p>
+<div class="highlight" style="background: #f8f8f8"><pre style="line-height: 125%;"><span></span>$ gwdetchar-scattering -i X1
+</pre></div>
+
+<p>The install path used was <code>{}</code>.</p>
+<h2>Configuration files</h2>
+<p>The following INI-format configuration file(s) were passed on the comand-line and are reproduced here in full:</p>
+<div id="accordion">
+<div class="card mb-1 shadow-sm">
+<div class="card-header">
+<a class="collapsed card-link cis-link" href="#file0" data-toggle="collapse">test.ini</a>
+</div>
+<div id="file0" class="collapse" data-parent="#accordion">
+<div class="card-body">
+<div class="highlight" style="background: #f8f8f8"><pre style="line-height: 125%;"><span></span><span style="color: #008000; font-weight: bold">[section]</span><span style="color: #bbbbbb"></span>
+<span style="color: #687822">key</span><span style="color: #bbbbbb"> </span><span style="color: #666666">=</span><span style="color: #bbbbbb"> </span><span style="color: #BA2121">value</span><span style="color: #bbbbbb"></span>
 </pre></div>
 
 </div>
@@ -329,10 +376,12 @@ def test_about_this_page(package_list, tmpdir):
     with mock.patch.object(sys, 'argv', testargs):
         # test with a single config file
         about = html.about_this_page(config_file)
-        assert parse_html(about) == parse_html(ABOUT)
+        assert (parse_html(about) == parse_html(ABOUT) or
+                parse_html(about) == parse_html(ABOUT2))
         # test with a list of config files
         about = html.about_this_page([config_file])
-        assert parse_html(about) == parse_html(ABOUT_WITH_CONFIG_LIST)
+        assert (parse_html(about) == parse_html(ABOUT_WITH_CONFIG_LIST) or
+                parse_html(about) == parse_html(ABOUT_WITH_CONFIG_LIST2))
     # clean up
     shutil.rmtree(outdir, ignore_errors=True)
 

--- a/gwdetchar/lasso/old.py
+++ b/gwdetchar/lasso/old.py
@@ -290,7 +290,7 @@ def main(args=None):
                 corr2 = 0.0
                 corr2s = 0.0
             # if all corralations are below threshold it does not plot
-            if((abs(corr1) < args.threshold)
+            if ((abs(corr1) < args.threshold)
                and (abs(corr1s) < args.threshold)
                and (abs(corr2) < args.threshold)
                and (abs(corr2s) < args.threshold)):
@@ -522,13 +522,13 @@ def main(args=None):
             h = '%s [%s = %.2f]' % (ch, r_blrms, corr1)
         if (corr1 is None) or (corr1 == 0) or (plot1 is None):
             context = 'bg-light'
-        elif((numpy.absolute(corr1) >= .6) or (numpy.absolute(corr1s) >= .6)
-             or (numpy.absolute(corr2) >= .6)
-             or (numpy.absolute(corr2s) >= .6)):
+        elif ((numpy.absolute(corr1) >= .6) or (numpy.absolute(corr1s) >= .6)
+              or (numpy.absolute(corr2) >= .6)
+              or (numpy.absolute(corr2s) >= .6)):
             context = 'text-white bg-danger'
-        elif((numpy.absolute(corr1) >= .4) or (numpy.absolute(corr1s) >= .4)
-             or (numpy.absolute(corr2) >= .4)
-             or (numpy.absolute(corr2s) >= .4)):
+        elif ((numpy.absolute(corr1) >= .4) or (numpy.absolute(corr1s) >= .4)
+              or (numpy.absolute(corr2) >= .4)
+              or (numpy.absolute(corr2s) >= .4)):
             context = 'text-white bg-warning'
         else:
             context = 'text-white bg-info'

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,10 +33,10 @@ classifiers =
 	Operating System :: MacOS
 	Programming Language :: Python
 	Programming Language :: Python :: 3
-	Programming Language :: Python :: 3.6
 	Programming Language :: Python :: 3.7
 	Programming Language :: Python :: 3.8
 	Programming Language :: Python :: 3.9
+	Programming Language :: Python :: 3.10
 	Topic :: Scientific/Engineering
 	Topic :: Scientific/Engineering :: Astronomy
 	Topic :: Scientific/Engineering :: Physics
@@ -44,7 +44,7 @@ classifiers =
 [options]
 zip_safe = False
 packages = find:
-python_requires = >=3.6
+python_requires = >=3.7
 setup_requires =
 	setuptools >=30.3.0
 install_requires =

--- a/setup.cfg
+++ b/setup.cfg
@@ -126,4 +126,5 @@ per-file-ignores =
 
 [rstcheck]
 report = severe
-ignore_language = bash
+ignore_languages = bash
+ignore_directives = autosummary,command-output

--- a/setup.cfg
+++ b/setup.cfg
@@ -125,6 +125,6 @@ per-file-ignores =
 	__init__.py:F401,
 
 [rstcheck]
-report = severe
+report_level = SEVERE
 ignore_languages = bash
 ignore_directives = autosummary,command-output


### PR DESCRIPTION
This PR does several things
- Drops testing of python3.6
- Adds testing of python3.10
- Handles CI build failures from versions of `pygments-2.11` and higher
- Fixes `rstcheck` tests since version 6 has some API changes
- Fixes some flake8 failures in Lasso

Closes #409