### PR TITLE
Fix lasso unit test find_alpha

### DIFF
--- a/gwdetchar/lasso/tests/test_core.py
+++ b/gwdetchar/lasso/tests/test_core.py
@@ -100,7 +100,7 @@ def test_fit():
 def test_find_alpha():
     # find the optimal alpha parameter
     alpha = core.find_alpha(DATA, TARGET)
-    assert alpha == 0.1
+    nptest.assert_almost_equal(alpha, 0.1)
 
 
 def test_remove_flat():


### PR DESCRIPTION
The Lasso CI had an exact floating point comparison `==`. This is too strict and is relaxed using `nptest.assert_almost_equal()`