### PR TITLE
Bugfix to lasso table display

### DIFF
--- a/gwdetchar/lasso/__main__.py
+++ b/gwdetchar/lasso/__main__.py
@@ -640,7 +640,7 @@ def main(args=None):
     print('\n\n')
 
     # convert to pandas
-    set_option('max_colwidth', -1)
+    set_option('max_colwidth', None)
     df = results.to_pandas()
     df.index += 1
 


### PR DESCRIPTION
Pandas 2.0.1 doesn't allow nonnegative integers for col_width. This was causing lasso to fail. I think `None` is probably the equivalent option. I tested this with a short run which produced an output page.