### PR TITLE
Skip processing of missing channels

### DIFF
--- a/gwdetchar/omega/__main__.py
+++ b/gwdetchar/omega/__main__.py
@@ -386,8 +386,7 @@ def main(args=None):
                 continue
 
             if channel.name not in data:
-                LOGGER.warning(
-                    ' -- No data found for {}, skipping channel'.format(channel.name))
+                # Channel must not have been found by get_data()
                 continue
 
             analyzed = _scan_channel(

--- a/gwdetchar/omega/__main__.py
+++ b/gwdetchar/omega/__main__.py
@@ -385,6 +385,11 @@ def main(args=None):
                 html.write_qscan_page(ifo, gps, analyzed, **htmlv)
                 continue
 
+            if channel.name not in data:
+                LOGGER.warning(
+                    ' -- No data found for {}, skipping channel'.format(channel.name))
+                continue
+
             analyzed = _scan_channel(
                 channel, data[channel.name], analyzed, gps, block,
                 args.far_threshold, (args.frequency_scaling == 'log'),


### PR DESCRIPTION
This PR updates `gwdetchar-omega` so that when data from channels is not found, the channel is simply skipped rather than returning an error. 

An example omegascan with this new update is here: https://ldas-jobs.ligo.caltech.edu/~derek.davis/detchar/O4/gwdetchar_tests/omega_missing_chans/

The output (with a message showing some channels were skipped) is saved here: https://ldas-jobs.ligo.caltech.edu/~derek.davis/detchar/O4/gwdetchar_tests/omega_missing_chans/omega_output.txt

The above links are being populated when this PR is created, I'll add a comment once these are complete. 