### PR TITLE
Fix pad error that occurs when passing kwargs to find_urls

### DIFF
--- a/gwdetchar/io/datafind.py
+++ b/gwdetchar/io/datafind.py
@@ -187,6 +187,8 @@ def get_data(channel, start, end, frametype=None, source=None,
     else:
         series_class = TimeSeries
 
+    pad = kwargs.pop('pad', None)
+
     if frametype is not None:
         try:  # locate frame files
             ifo = re.search('[A-Z]1', frametype).group(0)
@@ -205,16 +207,16 @@ def get_data(channel, start, end, frametype=None, source=None,
     if source:  # read from frame files
         return series_class.read(
             source, channel, start=start, end=end, nproc=nproc,
-            verbose=verbose, **kwargs)
+            verbose=verbose, pad=pad, **kwargs)
 
     # read single channel from NDS
     if not isinstance(channel, (list, tuple)):
         return series_class.get(
-            channel, start, end, verbose=verbose, **kwargs)
+            channel, start, end, verbose=verbose, pad=pad, **kwargs)
 
     # if all else fails, process channels in groups of 60
     data = series_class()
     for group in [channel[i:i + 60] for i in range(0, len(channel), 60)]:
         data.append(series_class.get(
-            group, start, end, verbose=verbose, **kwargs))
+            group, start, end, verbose=verbose, pad=pad, **kwargs))
     return data


### PR DESCRIPTION
This PR fixes an issue that arises when passing a `pad` value to get_data. Since kwargs are passed to `find_urls()`, this results in an error if `pad` has been given as an optional argument

This bug was introduced in https://github.com/gwdetchar/gwdetchar/pull/420 and observed when running lasso (see https://git.ligo.org/detchar/ligo-monitors/-/issues/7)