### PR TITLE
Update rstcheck CI job configuration

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,6 +16,10 @@ on:
       - main
       - master
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   flake8:
     name: Flake8
@@ -46,7 +50,15 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install \
-            "rstcheck[sphinx,toml]>=6.0.0" \
+            "rstcheck[sphinx]>=6.0.0" \
         ;
+    - name: List packages
+      run: python -m pip list installed
     - name: Lint with rstcheck
-      run: rstcheck . --recursive
+      run: |
+        rstcheck . \
+            --config pyproject.toml \
+            --log-level DEBUG \
+            --recursive \
+            --report-level error \
+        ;


### PR DESCRIPTION
This PR updates the configuration of the `rstcheck` CI job to explicitly reference `pyproject.toml` as the config file.

Closes #435.