### PR TITLE
Update condor workflow for batch omega scans

### DIFF
--- a/gwdetchar/io/html.py
+++ b/gwdetchar/io/html.py
@@ -1264,18 +1264,23 @@ def package_list():
     """
     prefix = sys.prefix
     if (Path(prefix) / "conda-meta").is_dir():
-        raw = subprocess.check_output(
-            ["conda", "list",
-             "--prefix", prefix,
-             "--json"],
-        )
+        raw = subprocess.check_output([
+            "conda",
+            "list",
+            "--prefix",
+            prefix,
+            "--json",
+        ])
     else:
-        raw = subprocess.check_output(
-            [sys.executable,
-             "-m", "pip",
-             "list", "installed",
-             "--format", "json"],
-        )
+        raw = subprocess.check_output([
+            sys.executable,
+            "-m",
+            "pip",
+            "list",
+            "installed",
+            "--format",
+            "json",
+        ])
     if isinstance(raw, bytes):
         raw = raw.decode('utf-8')
     return json.loads(raw)

--- a/gwdetchar/io/html.py
+++ b/gwdetchar/io/html.py
@@ -48,6 +48,8 @@ from .._version import __version__
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 __credit__ = 'Alex Urban <alexander.urban@ligo.org>'
 
+CONDA = os.getenv("CONDA_EXE", None) or "conda"
+
 # -- give context for ifo names
 
 OBSERVATORY_MAP = {
@@ -1265,7 +1267,7 @@ def package_list():
     prefix = sys.prefix
     if (Path(prefix) / "conda-meta").is_dir():
         raw = subprocess.check_output([
-            "conda",
+            CONDA,
             "list",
             "--prefix",
             prefix,

--- a/gwdetchar/io/tests/test_html.py
+++ b/gwdetchar/io/tests/test_html.py
@@ -545,6 +545,7 @@ def test_close_page(tmpdir):
     shutil.rmtree(target, ignore_errors=True)
 
 
+@mock.patch.object(html, "CONDA", "conda_exe")
 @mock.patch("{}.Path.is_dir".format(html.Path.__module__))
 @mock.patch("subprocess.check_output", return_value="{\"key\": 0}")
 @pytest.mark.parametrize("isdir, cmd", [
@@ -555,7 +556,7 @@ def test_close_page(tmpdir):
     ),
     pytest.param(
         True,
-        "conda list --prefix {} --json".format(sys.prefix),
+        "conda_exe list --prefix {} --json".format(sys.prefix),
         id="conda",
     ),
 ])


### PR DESCRIPTION
This PR updates the condor workflow generated and used in gwdetchar-omega-batch:

- use condor file transfer as much as possible, this should make the workflow more resilient
- specify `request_cpus`, `request_disk`, and `request_memory` explicitly
- replace `getenv = true` with specific minimum set of environment variables

This has been tested on the LDAS-LLO system via

```shell
python3 -m gwdetchar.omega.batch 1371255906.044922 -o test -s -j 1 -i L1 --config-file L-L1_R-selected.ini
```

and a few other variants.