### PR TITLE
Pin matplotlib to prevent error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
   "ligo-segments",
   "lxml",
   "MarkupPy >=1.14",
-  "matplotlib >=3.1.0",
+  "matplotlib >=3.1.0,<=3.7.1",
   "numpy >=1.16",
   "pandas",
   "pycondor",


### PR DESCRIPTION
This PR pins matplotlib to be less than 3.7.2 because there is a problem with 3.7.2 passing the CI tests