### PR TITLE
Fix command line output for main lasso page

### DIFF
--- a/gwdetchar/lasso/__main__.py
+++ b/gwdetchar/lasso/__main__.py
@@ -1206,7 +1206,7 @@ def main(args=None):
         '(2018)</a>.'.format(
             lasso_link, primary_nickname, paper_link),
         ))
-    page.add(htmlio.get_command_line())
+    page.add(htmlio.get_command_line(prog=PROG))
     page.div.close()  # page-header
 
     img = htmlio.FancyPlot(


### PR DESCRIPTION
This PR updates the command line text printed to the summary page so that it shows
```
$ python -m gwdetchar.lasso
```
instead of
```
$ __main__.py
```