### PR TITLE
Fix "top channels" blue ribbon dropdown

### DIFF
--- a/gwdetchar/lasso/__main__.py
+++ b/gwdetchar/lasso/__main__.py
@@ -1046,7 +1046,7 @@ def main(args=None):
             # heading
             page.div(class_=card_header)
             page.a(h, class_='collapsed card-link cis-link',
-                   href='#channel{i}', **{'data-toggle': 'collapse'})
+                   href=f'#channel{i}', **{'data-toggle': 'collapse'})
             page.div.close()  # card-header
             # body
             page.div(id_='channel%d' % i, class_='collapse',


### PR DESCRIPTION
This PR fixes an issue that the blue ribbon dropdown showing additional plots for the top channels was not working. It is fixed with this small typo fix