### PR TITLE
Allow generic file names when using FancyPlot

### DIFF
--- a/gwdetchar/io/html.py
+++ b/gwdetchar/io/html.py
@@ -768,7 +768,9 @@ def fancybox_img(img, linkparams=dict(), lazy=False, **params):
     substrings = os.path.basename(img).split('-')
     try:
         # If is the expected format, use channel and duration
-        if substrings[0] not in OBSERVATORY_MAP.keys():
+        ifo_str = substrings[0]
+        if not (len(ifo_str) == 2 and ifo_str[0].isalpha() and 
+                ifo_str[1].isdigit()):
             raise TypeError
         channel = f'{substrings[0]}-{substrings[1]}'
         duration = int(substrings[-1].split('.')[0])

--- a/gwdetchar/io/html.py
+++ b/gwdetchar/io/html.py
@@ -769,13 +769,15 @@ def fancybox_img(img, linkparams=dict(), lazy=False, **params):
     try:
         # If is the expected format, use channel and duration
         ifo_str = substrings[0]
-        if not (len(ifo_str) == 2 and ifo_str[0].isalpha() and 
+        if not (len(ifo_str) == 2 and ifo_str[0].isalpha() and
                 ifo_str[1].isdigit()):
             raise TypeError
+        duration = substrings[-1].split('.')[0]
+        if not duration.isdigit():
+            raise TypeError
         channel = f'{substrings[0]}-{substrings[1]}'
-        duration = int(substrings[-1].split('.')[0])
         img_str = f'{channel}_{duration}'
-    except:
+    except TypeError:
         # If unexpected format, use entire image name
         # This only changes the label of the image in the html code
         # and not the format of the page itself

--- a/gwdetchar/io/html.py
+++ b/gwdetchar/io/html.py
@@ -766,9 +766,15 @@ def fancybox_img(img, linkparams=dict(), lazy=False, **params):
     aparams.update(linkparams)
     img = str(img)
     substrings = os.path.basename(img).split('-')
-    channel = '%s-%s' % tuple(substrings[:2])
-    duration = substrings[-1].split('.')[0]
-    page.a(href=img, id_='a_%s_%s' % (channel, duration), **aparams)
+    if len(substrings) == 4:
+        # this is the expected format, use channel and duration
+        channel = '%s-%s' % tuple(substrings[:2])
+        duration = substrings[-1].split('.')[0]
+        img_str = '%s_%s' % (channel, duration)
+    else:
+        # unexpected format, use entire image name
+        img_str = os.path.basename(img).split('.')[0]
+    page.a(href=img, id_='a_%s' % img_str, **aparams)
     src_attr = lazy and 'data-src' or 'src'
     imgparams = {
         'alt': os.path.basename(img),
@@ -776,7 +782,7 @@ def fancybox_img(img, linkparams=dict(), lazy=False, **params):
         src_attr: img.replace('.svg', '.png'),
     }
     imgparams.update(params)
-    page.img(id_='img_%s_%s' % (channel, duration), **imgparams)
+    page.img(id_='img_%s' % img_str, **imgparams)
     page.a.close()
     return page()
 

--- a/gwdetchar/io/html.py
+++ b/gwdetchar/io/html.py
@@ -768,13 +768,13 @@ def fancybox_img(img, linkparams=dict(), lazy=False, **params):
     substrings = os.path.basename(img).split('-')
     if len(substrings) == 4:
         # this is the expected format, use channel and duration
-        channel = '%s-%s' % tuple(substrings[:2])
+        channel = f'{substrings[0]}-{substrings[1]}'
         duration = substrings[-1].split('.')[0]
-        img_str = '%s_%s' % (channel, duration)
+        img_str = f'{channel}_{duration}'
     else:
         # unexpected format, use entire image name
         img_str = os.path.basename(img).split('.')[0]
-    page.a(href=img, id_='a_%s' % img_str, **aparams)
+    page.a(href=img, id_=f'a_{img_str}', **aparams)
     src_attr = lazy and 'data-src' or 'src'
     imgparams = {
         'alt': os.path.basename(img),
@@ -782,7 +782,7 @@ def fancybox_img(img, linkparams=dict(), lazy=False, **params):
         src_attr: img.replace('.svg', '.png'),
     }
     imgparams.update(params)
-    page.img(id_='img_%s' % img_str, **imgparams)
+    page.img(id_=f'img_{img_str}', **imgparams)
     page.a.close()
     return page()
 

--- a/gwdetchar/io/html.py
+++ b/gwdetchar/io/html.py
@@ -770,7 +770,7 @@ def fancybox_img(img, linkparams=dict(), lazy=False, **params):
         # If is the expected format, use channel and duration
         ifo_str = substrings[0]
         if not (len(ifo_str) == 2 and ifo_str[0].isalpha() and
-                ifo_str[-1].isdigit()):
+                ifo_str[1].isdigit()):
             raise TypeError
         duration = substrings[-1].split('.')[0]
         if not duration.isdigit():

--- a/gwdetchar/io/html.py
+++ b/gwdetchar/io/html.py
@@ -766,13 +766,17 @@ def fancybox_img(img, linkparams=dict(), lazy=False, **params):
     aparams.update(linkparams)
     img = str(img)
     substrings = os.path.basename(img).split('-')
-    if len(substrings) == 4:
-        # this is the expected format, use channel and duration
+    try:
+        # If is the expected format, use channel and duration
+        if substrings[0] not in OBSERVATORY_MAP.keys():
+            raise TypeError
         channel = f'{substrings[0]}-{substrings[1]}'
-        duration = substrings[-1].split('.')[0]
+        duration = int(substrings[-1].split('.')[0])
         img_str = f'{channel}_{duration}'
-    else:
-        # unexpected format, use entire image name
+    except:
+        # If unexpected format, use entire image name
+        # This only changes the label of the image in the html code
+        # and not the format of the page itself
         img_str = os.path.basename(img).split('.')[0]
     page.a(href=img, id_=f'a_{img_str}', **aparams)
     src_attr = lazy and 'data-src' or 'src'

--- a/gwdetchar/io/html.py
+++ b/gwdetchar/io/html.py
@@ -770,7 +770,7 @@ def fancybox_img(img, linkparams=dict(), lazy=False, **params):
         # If is the expected format, use channel and duration
         ifo_str = substrings[0]
         if not (len(ifo_str) == 2 and ifo_str[0].isalpha() and
-                ifo_str[1].isdigit()):
+                ifo_str[-1].isdigit()):
             raise TypeError
         duration = substrings[-1].split('.')[0]
         if not duration.isdigit():


### PR DESCRIPTION
This MR allows users to use the `io.html.fancybox_img()` function with images that do not follow the "standard" naming convention. Although most tools follow this convention, requiring a naming convention has led to challenges with using `gwdetchar` in more generic applications (such as the IGWN DQR).

Closes #415 