### PR TITLE
Exclude OAF-CAL_RANGE in addition to OAF-RANGE channels from LASSO

### DIFF
--- a/gwdetchar/lasso/__main__.py
+++ b/gwdetchar/lasso/__main__.py
@@ -543,7 +543,7 @@ def main(args=None):
     to_remove = ['.*\.n$', '.*.min$', '.*.max$', '.*.rms$']  # noqa: W605
     if range_is_primary:
         to_remove.extend([
-            'OAF-RANGE', 'SENSEMON', 'SENSMON',
+            'OAF*RANGE', 'SENSEMON', 'SENSMON',
             'CAL-CS_DARM', ':SUS-.*TM.*MODE[0-9]',
             'SQZ-DCPD_', 'CAL-CS_TDEP_*', 'PCAL*COHERENCE',
             'ASC-ADS*'])


### PR DESCRIPTION
This PR is a minor update to the channel exclusion list so that the recently added OAF-CAL_RANGE channels at L1 are excluded