### PR TITLE
Fix omega.batch condor submission problems

### DIFF
--- a/gwdetchar/omega/batch.py
+++ b/gwdetchar/omega/batch.py
@@ -261,15 +261,17 @@ def generate_dag(
     dagman.build(fancyname=False)
     print("Workflow generated for {} times".format(len(times)))
     if submit:
-        dagman.submit_dag(submit_options="-force")
+        dagman.submit_dag(
+            submit_options=f"-force -include_env {getenv.replace(' ', '')}")
         print(
             "Submitted to condor, check status via:\n\n"
-            "$ condor_q {}".format(getuser())
+            f"$ condor_q {getuser()}"
         )
     else:
         print(
             "Submit to condor via:\n\n"
-            "$ condor_submit_dag {0.submit_file}".format(dagman),
+            f"$ condor_submit_dag -include_env {getenv.replace(' ', '')} "
+            f"{dagman.submit_file}"
         )
     return dagman
 


### PR DESCRIPTION
This PR fixes the problem that condor_submit_dag filters the environment variables unless they are specified to be passed, so even though the submit file for the jobs have been given `getenv = ...` they will not return anything other than empty unless the dag also has passed the variables.