### PR TITLE
Update gwdetchar for upcoming gwbootstrap upgrade

### DIFF
--- a/gwdetchar/io/html.py
+++ b/gwdetchar/io/html.py
@@ -108,21 +108,21 @@ OBSERVATORY_MAP = {
 # -- HTML URLs
 
 FONT_AWESOME_CSS = ('https://cdnjs.cloudflare.com/ajax/libs/'
-                    'font-awesome/5.15.1/css/fontawesome.min.css')
+                    'font-awesome/6.5.1/css/fontawesome.min.css')
 FONT_AWESOME_SOLID_CSS = ('https://cdnjs.cloudflare.com/ajax/libs/'
-                          'font-awesome/5.15.1/css/solid.min.css')
+                          'font-awesome/6.5.1/css/solid.min.css')
 
-JQUERY_JS = 'https://code.jquery.com/jquery-3.5.1.min.js'
+JQUERY_JS = 'https://code.jquery.com/jquery-3.7.1.min.js'
 JQUERY_LAZY_JS = ('https://cdnjs.cloudflare.com/ajax/libs/jquery.lazy/'
                   '1.7.11/jquery.lazy.min.js')
-BOOTSTRAP_JS = ('https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/'
+BOOTSTRAP_JS = ('https://cdn.jsdelivr.net/npm/bootstrap@5.5.3/'
                 'dist/js/bootstrap.bundle.min.js')
-FANCYBOX_JS = ('https://cdnjs.cloudflare.com/ajax/libs/'
-               'fancybox/3.5.7/jquery.fancybox.min.js')
+FANCYBOX_JS = ('https://cdn.jsdelivr.net/npm/@fancyapps/ui@5.0/'
+               'dist/fancybox/fancybox.umd.js')
 
-GWBOOTSTRAP_CSS = ('https://cdn.jsdelivr.net/npm/gwbootstrap@1.3.2/'
+GWBOOTSTRAP_CSS = ('https://cdn.jsdelivr.net/npm/gwbootstrap@1.3.3/'
                    'lib/gwbootstrap.min.css')
-GWBOOTSTRAP_JS = ('https://cdn.jsdelivr.net/npm/gwbootstrap@1.3.2/'
+GWBOOTSTRAP_JS = ('https://cdn.jsdelivr.net/npm/gwbootstrap@1.3.3/'
                   'lib/gwbootstrap.min.js')
 
 CSS_FILES = [
@@ -358,7 +358,9 @@ def navbar(links, class_='navbar navbar-expand-md fixed-top shadow-sm',
     if collapse:
         page.button(
             class_='navbar-toggler navbar-toggler-right', type_='button',
-            **{'data-toggle': 'collapse', 'data-target': '.navbar-collapse'})
+            **{'data-bs-toggle': 'collapse',
+               'data-target': '.navbar-collapse',
+               })
         page.span('', class_='navbar-toggler-icon')
         page.button.close()
         page.div(class_='collapse navbar-collapse justify-content-between')
@@ -440,7 +442,7 @@ def dropdown(text, links, active=None, class_='nav-link dropdown-toggle'):
 
     page = markup.page()
     page.a(text, href='#', class_=class_, role='button',
-           **{'data-toggle': 'dropdown'})
+           **{'data-bs-toggle': 'dropdown'})
 
     # work out columns
     ngroup = sum([has_columns(x) for x in links])
@@ -543,7 +545,7 @@ def get_brand(ifo, name, gps, about=None):
     page.ul(class_='nav navbar-nav')
     page.li(class_='nav-item dropdown')
     page.a('Links', class_='nav-link dropdown-toggle',
-           href='#', role='button', **{'data-toggle': 'dropdown'})
+           href='#', role='button', **{'data-bs-toggle': 'dropdown'})
     page.div(class_='dropdown-menu dropdown-menu-right shadow')
     if about is not None:
         page.h6('Internal', class_='dropdown-header')
@@ -608,7 +610,7 @@ def about_this_page(config, packagelist=True, prog=None):
                 os.path.basename(cpfile),
                 class_='collapsed card-link cis-link',
                 href='#file%d' % i,
-                **{'data-toggle': 'collapse'}
+                **{'data-bs-toggle': 'collapse'}
             )
             page.div.close()  # card-header
             page.div(id_='file%d' % i, class_='collapse',
@@ -862,7 +864,7 @@ def download_btn(content, label='Download summary',
     page = markup.page()
     page.div(class_=btndiv)
     page.button(label, type='button', class_=btnclass,
-                **{'data-toggle': 'dropdown',
+                **{'data-bs-toggle': 'dropdown',
                    'aria-expanded': 'false',
                    'aria-haspopup': 'true'})
     page.div(class_='dropdown-menu dropdown-menu-right shadow')
@@ -1086,7 +1088,7 @@ def write_flag_html(flag, span=None, id=0, parent='accordion',
     page.div(class_=_get_card_header(context))
     title = title or flag.name
     page.a(title, class_='collapsed card-link cis-link', href='#flag%s' % id,
-           **{'data-toggle': 'collapse'})
+           **{'data-bs-toggle': 'collapse'})
     page.div.close()  # card-header
     page.div(id_='flag%s' % id, class_='collapse',
              **{'data-parent': '#' + parent})

--- a/gwdetchar/io/tests/test_html.py
+++ b/gwdetchar/io/tests/test_html.py
@@ -131,7 +131,7 @@ ABOUT_WITH_CONFIG_LIST = f"""<div class="row">
 <div id="accordion">
 <div class="card mb-1 shadow-sm">
 <div class="card-header">
-<a class="collapsed card-link cis-link" href="#file0" data-toggle="collapse">test.ini</a>
+<a class="collapsed card-link cis-link" href="#file0" data-bs-toggle="collapse">test.ini</a>
 </div>
 <div id="file0" class="collapse" data-parent="#accordion">
 <div class="card-body">
@@ -170,7 +170,7 @@ HTML_CLOSE = """</div>
 
 FLAG_CONTENT = """<div class="card border-warning mb-1 shadow-sm">
 <div class="card-header text-white bg-warning">
-<a class="collapsed card-link cis-link" href="#flag0" data-toggle="collapse">X1:TEST_FLAG</a>
+<a class="collapsed card-link cis-link" href="#flag0" data-bs-toggle="collapse">X1:TEST_FLAG</a>
 </div>
 <div id="flag0" class="collapse" data-parent="#accordion">
 <div class="card-body">{plots}
@@ -289,25 +289,25 @@ def test_dropdown():
     menu = html.dropdown('test', [])
     assert parse_html(str(menu)) == parse_html(
         '<a href="#" class="nav-link dropdown-toggle" role="button" '
-        'data-toggle="dropdown">test</a>\n<div class="dropdown-menu '
+        'data-bs-toggle="dropdown">test</a>\n<div class="dropdown-menu '
         'dropdown-1-col shadow">\n</div>')
 
     menu = html.dropdown('test', ['test', '#'], active=0)
     assert parse_html(str(menu)) == parse_html(
         '<a href="#" class="nav-link dropdown-toggle" role="button" '
-        'data-toggle="dropdown">test</a>\n<div class="dropdown-menu '
+        'data-bs-toggle="dropdown">test</a>\n<div class="dropdown-menu '
         'dropdown-1-col shadow">\ntest\n#\n</div>')
 
     menu = html.dropdown('test', ['test', '#'], active=[0, 1])
     assert parse_html(str(menu)) == parse_html(
         '<a href="#" class="nav-link dropdown-toggle" role="button" '
-        'data-toggle="dropdown">test</a>\n<div class="dropdown-menu '
+        'data-bs-toggle="dropdown">test</a>\n<div class="dropdown-menu '
         'dropdown-1-col shadow">\ntest\n#\n</div>')
 
     menu = html.dropdown('<test />', ['test', '#'], active=[0, 1])
     assert parse_html(str(menu)) == parse_html(
         '<a href="#" class="nav-link dropdown-toggle" role="button" '
-        'data-toggle="dropdown"><test /></a>\n<div class="dropdown-menu '
+        'data-bs-toggle="dropdown"><test /></a>\n<div class="dropdown-menu '
         'dropdown-1-col shadow">\ntest\n#\n</div>')
 
 
@@ -334,7 +334,7 @@ def test_get_brand():
     assert parse_html(help_) == parse_html(
         '<ul class="nav navbar-nav">\n<li class="nav-item dropdown">\n'
         '<a class="nav-link dropdown-toggle" href="#" role="button" '
-        'data-toggle="dropdown">Links</a>\n<div class="dropdown-menu '
+        'data-bs-toggle="dropdown">Links</a>\n<div class="dropdown-menu '
         'dropdown-menu-right shadow">\n<h6 class="dropdown-header">Internal'
         '</h6>\n<a href="about" class="dropdown-item">About this page</a>\n'
         '<div class="dropdown-divider"></div>\n<h6 class="dropdown-header">'
@@ -444,7 +444,7 @@ def test_download_btn():
     assert parse_html(page) == parse_html(
         '<div class="dropdown float-right d-none d-lg-block">\n'
         '<button type="button" class="btn btn-outline-secondary '
-        'dropdown-toggle" data-toggle="dropdown" aria-expanded="false" '
+        'dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false" '
         'aria-haspopup="true">Download summary</button>\n<div '
         'class="dropdown-menu dropdown-menu-right shadow">\n<a href="test" '
         'download="test" class="dropdown-item">test</a>\n</div>\n</div>')

--- a/gwdetchar/lasso/__main__.py
+++ b/gwdetchar/lasso/__main__.py
@@ -1086,7 +1086,7 @@ def main(args=None):
             # heading
             page.div(class_=card_header)
             page.a(h, class_='collapsed card-link cis-link',
-                   href=f'#channel{i}', **{'data-toggle': 'collapse'})
+                   href=f'#channel{i}', **{'data-bs-toggle': 'collapse'})
             page.div.close()  # card-header
             # body
             page.div(id_='channel%d' % i, class_='collapse',

--- a/gwdetchar/omega/html.py
+++ b/gwdetchar/omega/html.py
@@ -501,7 +501,7 @@ def write_block(blockkey, block, context,
             page.div(class_='btn-group', role='group')
             page.button(ptitle, id_=_id, type='button',
                         class_='btn btn-%s dropdown-toggle' % context,
-                        **{'data-toggle': 'dropdown'})
+                        **{'data-bs-toggle': 'dropdown'})
             page.div(class_='dropdown-menu shadow', **{'aria-labelledby': _id})
             for ptype in ptypes:
                 page.add(toggle_link('{0}_{1}'.format(pclass, ptype),

--- a/gwdetchar/omega/tests/test_html.py
+++ b/gwdetchar/omega/tests/test_html.py
@@ -35,7 +35,7 @@ __credits__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 HTML_HEADER = """<nav class="navbar fixed-top navbar-expand-md navbar-{ifo} shadow-sm">
 <div class="container-fluid">
 <div class="navbar-brand border border-white rounded">{IFO} &Omega;-scan</div>
-<button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-target=".navbar-collapse">
+<button class="navbar-toggler navbar-toggler-right" type="button" data-bs-toggle="collapse" data-target=".navbar-collapse">
 <span class="navbar-toggler-icon"></span>
 </button>
 <div class="collapse navbar-collapse justify-content-between">
@@ -47,7 +47,7 @@ HTML_HEADER = """<nav class="navbar fixed-top navbar-expand-md navbar-{ifo} shad
 <a href="#" class="nav-link">Summary</a>
 </li>
 <li class="nav-item dropdown">
-<a href="#" class="nav-link dropdown-toggle" role="button" data-toggle="dropdown">GW</a>
+<a href="#" class="nav-link dropdown-toggle" role="button" data-bs-toggle="dropdown">GW</a>
 <div class="dropdown-menu dropdown-1-col shadow">
 <div class="row">
 <div class="col-sm-12 col-md-12">
@@ -60,7 +60,7 @@ HTML_HEADER = """<nav class="navbar fixed-top navbar-expand-md navbar-{ifo} shad
 </ul>
 <ul class="nav navbar-nav">
 <li class="nav-item dropdown">
-<a class="nav-link dropdown-toggle" href="#" role="button" data-toggle="dropdown">Links</a>
+<a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown">Links</a>
 <div class="dropdown-menu dropdown-menu-right shadow">
 <h6 class="dropdown-header">Internal</h6>
 <a href="about" class="dropdown-item">About this page</a>
@@ -163,7 +163,7 @@ BLOCK_HTML = """<div class="card card-x1 mb-5 shadow-sm">
 <div class="col-sm-12 col-md-5">
 <div class="btn-group flex-wrap" role="group">
 <div class="btn-group" role="group">
-<button id="btnGroupTimeseries0" type="button" class="btn btn-x1 dropdown-toggle" data-toggle="dropdown">Timeseries</button>
+<button id="btnGroupTimeseries0" type="button" class="btn btn-x1 dropdown-toggle" data-bs-toggle="dropdown">Timeseries</button>
 <div class="dropdown-menu shadow" aria-labelledby="btnGroupTimeseries0">
 <a class="dropdown-item image-switch" data-captions="[&quot;X1-TEST_AUX-timeseries_raw-4.png&quot;]" data-channel-name="X1-TEST_AUX" data-image-dir="plots" data-image-type="timeseries_raw" data-t-ranges="[&quot;4&quot;]">raw</a>
 <a class="dropdown-item image-switch" data-captions="[&quot;X1-TEST_AUX-timeseries_highpassed-4.png&quot;]" data-channel-name="X1-TEST_AUX" data-image-dir="plots" data-image-type="timeseries_highpassed" data-t-ranges="[&quot;4&quot;]">highpassed</a>
@@ -171,7 +171,7 @@ BLOCK_HTML = """<div class="card card-x1 mb-5 shadow-sm">
 </div>
 </div>
 <div class="btn-group" role="group">
-<button id="btnGroupQscan0" type="button" class="btn btn-x1 dropdown-toggle" data-toggle="dropdown">Spectrogram</button>
+<button id="btnGroupQscan0" type="button" class="btn btn-x1 dropdown-toggle" data-bs-toggle="dropdown">Spectrogram</button>
 <div class="dropdown-menu shadow" aria-labelledby="btnGroupQscan0">
 <a class="dropdown-item image-switch" data-captions="[&quot;X1-TEST_AUX-qscan_highpassed-4.png&quot;]" data-channel-name="X1-TEST_AUX" data-image-dir="plots" data-image-type="qscan_highpassed" data-t-ranges="[&quot;4&quot;]">highpassed</a>
 <a class="dropdown-item image-switch" data-captions="[&quot;X1-TEST_AUX-qscan_whitened-4.png&quot;]" data-channel-name="X1-TEST_AUX" data-image-dir="plots" data-image-type="qscan_whitened" data-t-ranges="[&quot;4&quot;]">whitened</a>
@@ -179,7 +179,7 @@ BLOCK_HTML = """<div class="card card-x1 mb-5 shadow-sm">
 </div>
 </div>
 <div class="btn-group" role="group">
-<button id="btnGroupEventgram0" type="button" class="btn btn-x1 dropdown-toggle" data-toggle="dropdown">Eventgram</button>
+<button id="btnGroupEventgram0" type="button" class="btn btn-x1 dropdown-toggle" data-bs-toggle="dropdown">Eventgram</button>
 <div class="dropdown-menu shadow" aria-labelledby="btnGroupEventgram0">
 <a class="dropdown-item image-switch" data-captions="[&quot;X1-TEST_AUX-eventgram_highpassed-4.png&quot;]" data-channel-name="X1-TEST_AUX" data-image-dir="plots" data-image-type="eventgram_highpassed" data-t-ranges="[&quot;4&quot;]">highpassed</a>
 <a class="dropdown-item image-switch" data-captions="[&quot;X1-TEST_AUX-eventgram_whitened-4.png&quot;]" data-channel-name="X1-TEST_AUX" data-image-dir="plots" data-image-type="eventgram_whitened" data-t-ranges="[&quot;4&quot;]">whitened</a>
@@ -250,7 +250,7 @@ def test_write_summary():
         '\n</tr>\n</tbody>\n</table>\n</div>\n<div class="col-sm-12 col-md-7">'
         '\n<div class="dropdown float-right d-none d-lg-block">'
         '\n<button type="button" class="btn btn-l1 dropdown-toggle" '
-        'data-toggle="dropdown" aria-expanded="false" aria-haspopup="true">'
+        'data-bs-toggle="dropdown" aria-expanded="false" aria-haspopup="true">'
         'Download summary</button>\n<div class="dropdown-menu dropdown-menu-'
         'right shadow">\n<a href="data/summary.txt" download="L1_0_summary.txt'
         '" class="dropdown-item">txt</a>\n<a href="data/summary.csv" download='

--- a/gwdetchar/scattering/__main__.py
+++ b/gwdetchar/scattering/__main__.py
@@ -669,7 +669,7 @@ def main(args=None):
         page.div(class_='card border-%s mb-1 shadow-sm' % context)
         page.div(class_='card-header text-white bg-%s' % context)
         page.a(channel, class_='collapsed card-link cis-link',
-               href='#osem%s' % i, **{'data-toggle': 'collapse'})
+               href='#osem%s' % i, **{'data-bs-toggle': 'collapse'})
         page.div.close()  # card-header
         page.div(id_='osem%s' % i, class_='collapse',
                  **{'data-parent': '#osems-group'})


### PR DESCRIPTION
The packages for gwdetchar are being updated, see https://github.com/gwdetchar/gwbootstrap/pull/49. There are some slight modifications needed for the html dropdown menus and JS/CSS package pins needed for gwdetchar to be compatible.

See working example: https://ldas-jobs.ligo-wa.caltech.edu/~detchar/summary/