### PR TITLE
Fix dropdown alignment for menus that are right aligned

### DIFF
--- a/gwdetchar/io/html.py
+++ b/gwdetchar/io/html.py
@@ -120,9 +120,9 @@ BOOTSTRAP_JS = ('https://cdn.jsdelivr.net/npm/bootstrap@5.5.3/'
 FANCYBOX_JS = ('https://cdn.jsdelivr.net/npm/@fancyapps/ui@5.0/'
                'dist/fancybox/fancybox.umd.js')
 
-GWBOOTSTRAP_CSS = ('https://cdn.jsdelivr.net/npm/gwbootstrap@1.3.4/'
+GWBOOTSTRAP_CSS = ('https://cdn.jsdelivr.net/npm/gwbootstrap@1.3.5/'
                    'lib/gwbootstrap.min.css')
-GWBOOTSTRAP_JS = ('https://cdn.jsdelivr.net/npm/gwbootstrap@1.3.4/'
+GWBOOTSTRAP_JS = ('https://cdn.jsdelivr.net/npm/gwbootstrap@1.3.5/'
                   'lib/gwbootstrap.min.js')
 
 CSS_FILES = [

--- a/gwdetchar/io/html.py
+++ b/gwdetchar/io/html.py
@@ -546,7 +546,7 @@ def get_brand(ifo, name, gps, about=None):
     page.li(class_='nav-item dropdown')
     page.a('Links', class_='nav-link dropdown-toggle',
            href='#', role='button', **{'data-bs-toggle': 'dropdown'})
-    page.div(class_='dropdown-menu dropdown-menu-right shadow')
+    page.div(class_='dropdown-menu dropdown-menu-end shadow')
     if about is not None:
         page.h6('Internal', class_='dropdown-header')
         page.a('About this page', href=about, class_='dropdown-item')
@@ -867,7 +867,7 @@ def download_btn(content, label='Download summary',
                 **{'data-bs-toggle': 'dropdown',
                    'aria-expanded': 'false',
                    'aria-haspopup': 'true'})
-    page.div(class_='dropdown-menu dropdown-menu-right shadow')
+    page.div(class_='dropdown-menu dropdown-menu-end shadow')
     for item in content:
         if len(item) == 2:
             text, href = item

--- a/gwdetchar/io/tests/test_html.py
+++ b/gwdetchar/io/tests/test_html.py
@@ -335,7 +335,7 @@ def test_get_brand():
         '<ul class="nav navbar-nav">\n<li class="nav-item dropdown">\n'
         '<a class="nav-link dropdown-toggle" href="#" role="button" '
         'data-bs-toggle="dropdown">Links</a>\n<div class="dropdown-menu '
-        'dropdown-menu-right shadow">\n<h6 class="dropdown-header">Internal'
+        'dropdown-menu-end shadow">\n<h6 class="dropdown-header">Internal'
         '</h6>\n<a href="about" class="dropdown-item">About this page</a>\n'
         '<div class="dropdown-divider"></div>\n<h6 class="dropdown-header">'
         'External</h6>\n<a href="https://ldas-jobs.ligo-wa.caltech.edu/'
@@ -446,7 +446,7 @@ def test_download_btn():
         '<button type="button" class="btn btn-outline-secondary '
         'dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false" '
         'aria-haspopup="true">Download summary</button>\n<div '
-        'class="dropdown-menu dropdown-menu-right shadow">\n<a href="test" '
+        'class="dropdown-menu dropdown-menu-end shadow">\n<a href="test" '
         'download="test" class="dropdown-item">test</a>\n</div>\n</div>')
 
 

--- a/gwdetchar/omega/tests/test_html.py
+++ b/gwdetchar/omega/tests/test_html.py
@@ -252,7 +252,7 @@ def test_write_summary():
         '\n<button type="button" class="btn btn-l1 dropdown-toggle" '
         'data-bs-toggle="dropdown" aria-expanded="false" aria-haspopup="true">'
         'Download summary</button>\n<div class="dropdown-menu dropdown-menu-'
-        'right shadow">\n<a href="data/summary.txt" download="L1_0_summary.txt'
+        'end shadow">\n<a href="data/summary.txt" download="L1_0_summary.txt'
         '" class="dropdown-item">txt</a>\n<a href="data/summary.csv" download='
         '"L1_0_summary.csv" class="dropdown-item">csv</a>'
         '\n<a href="data/summary.tex" download="L1_0_summary.tex" '

--- a/gwdetchar/omega/tests/test_html.py
+++ b/gwdetchar/omega/tests/test_html.py
@@ -61,7 +61,7 @@ HTML_HEADER = """<nav class="navbar fixed-top navbar-expand-md navbar-{ifo} shad
 <ul class="nav navbar-nav">
 <li class="nav-item dropdown">
 <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown">Links</a>
-<div class="dropdown-menu dropdown-menu-right shadow">
+<div class="dropdown-menu dropdown-menu-end shadow">
 <h6 class="dropdown-header">Internal</h6>
 <a href="about" class="dropdown-item">About this page</a>
 <div class="dropdown-divider"></div>


### PR DESCRIPTION
This PR fixes an issue that Bootstrap 5 changed the name of `dropdown-menu-right` to `dropdown-menu-end`. I have searched and replaced those instances.