### PR TITLE
Pin to numpy versions less than v2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
   "lxml",
   "MarkupPy >=1.14",
   "matplotlib >=3.1.0,<=3.7.1",
-  "numpy >=1.16",
+  "numpy >=1.16,<2.0",
   "pandas",
   "pycondor",
   "pygments >=2.7.3",


### PR DESCRIPTION
Temporary change until other dependencies are updated to handle the new numpy version 2