### PR TITLE
Remove lalsuite requirement

### DIFF
--- a/gwdetchar/io/ligolw.py
+++ b/gwdetchar/io/ligolw.py
@@ -19,17 +19,7 @@
 """Utilties for LIGO_LW XML I/O
 """
 
-from igwn_ligolw import ligolw
-try:
-    from igwn_ligolw import lsctables
-except ModuleNotFoundError as exc:
-    exc.msg = (
-        f"{exc.msg}, please install python-lal / python3-lal / lalsuite "
-        "to handle LIGO_LW files"
-    )
-    exc.args = (exc.msg,)
-    raise
-
+from igwn_ligolw import ligolw, lsctables
 from gwpy.segments import (Segment, DataQualityFlag, DataQualityDict)
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'

--- a/gwdetchar/io/tests/test_ligolw.py
+++ b/gwdetchar/io/tests/test_ligolw.py
@@ -19,16 +19,14 @@
 """Tests for `gwdetchar.io.ligolw`
 """
 
-import pytest
-
 import numpy
 from numpy.testing import (assert_array_equal, assert_allclose)
 
 from gwpy.segments import (Segment, SegmentList)
 from gwpy.testing.utils import assert_segmentlist_equal
+from igwn_ligolw import lsctables
 
-lsctables = pytest.importorskip("igwn_ligolw.lsctables")
-ligolw = pytest.importorskip("gwdetchar.io.ligolw")
+from .. import ligolw
 
 
 def test_new_table():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,6 @@ dependencies = [
   "gwdatafind",
   "gwpy >=3.0.10",
   "gwtrigfind",
-  "lalsuite",
   "lxml",
   "MarkupPy >=1.14",
   "matplotlib >=3.9",
@@ -62,6 +61,7 @@ dynamic = ["version"]
 [project.optional-dependencies]
 test = [
   "flake8",
+  "gwpy[gwf]",
   "pygments >=2.19.0",
   "pytest >=3.3.0",
   "pytest-cov >=2.4.0",


### PR DESCRIPTION
This PR removes the `lalsuite` requirement since it is only needed for reading LIGOLW XML files but the `python-ligo-lw` package already supports this.