### PR TITLE
Fix bug with dropdown menu when using bootstrap 5

### DIFF
--- a/gwdetchar/io/html.py
+++ b/gwdetchar/io/html.py
@@ -359,7 +359,7 @@ def navbar(links, class_='navbar navbar-expand-md fixed-top shadow-sm',
         page.button(
             class_='navbar-toggler navbar-toggler-right', type_='button',
             **{'data-bs-toggle': 'collapse',
-               'data-target': '.navbar-collapse',
+               'data-bs-target': '.navbar-collapse',
                })
         page.span('', class_='navbar-toggler-icon')
         page.button.close()

--- a/gwdetchar/omega/tests/test_html.py
+++ b/gwdetchar/omega/tests/test_html.py
@@ -35,7 +35,7 @@ __credits__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 HTML_HEADER = """<nav class="navbar fixed-top navbar-expand-md navbar-{ifo} shadow-sm">
 <div class="container-fluid">
 <div class="navbar-brand border border-white rounded">{IFO} &Omega;-scan</div>
-<button class="navbar-toggler navbar-toggler-right" type="button" data-bs-toggle="collapse" data-target=".navbar-collapse">
+<button class="navbar-toggler navbar-toggler-right" type="button" data-bs-toggle="collapse" data-bs-target=".navbar-collapse">
 <span class="navbar-toggler-icon"></span>
 </button>
 <div class="collapse navbar-collapse justify-content-between">


### PR DESCRIPTION
This PR fixes a bug that was introduced when switching to bootstrap 5. At present, dropdown menus do not work on mobile platforms or for small windows. This was due to a parameter name change in bootstrap 4>5 not being applied to `gwdetchar`. 

Here is an example of the correct parameter name (`data-bs-target`) in the [bootstrap docs](https://getbootstrap.com/docs/5.0/components/dropdowns/#dark-dropdowns).

This is only a one-line change (and one line changed in the test HTML page). 