### PR TITLE
Remove unused ligo-segments requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,6 @@ dependencies = [
   "gwpy >=3.0.0",
   "gwtrigfind",
   "lalsuite",
-  "ligo-segments",
   "lxml",
   "MarkupPy >=1.14",
   "matplotlib >=3.1.0,<=3.7.1",


### PR DESCRIPTION
This PR removes `ligo-segments` from the `dependencies` for this project, this package is never imported.