### PR TITLE
Fix HTML tests with pygments 2.19.0 and CI build actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,10 +61,8 @@ jobs:
       uses: conda-incubator/setup-miniconda@v3
       with:
         auto-update-conda: true
-        channels: conda-forge
+        miniforge-version: latest
         python-version: ${{ matrix.python-version }}
-        # this is needed for caching to work properly:
-        use-only-tar-bz2: true
 
     - name: Conda info
       run: conda info --all

--- a/gwdetchar/io/tests/test_html.py
+++ b/gwdetchar/io/tests/test_html.py
@@ -27,7 +27,6 @@ import sys
 
 from getpass import getuser
 from MarkupPy import markup
-from pygments import __version__ as pygments_version
 from pytz import reference
 from unittest import mock
 
@@ -72,34 +71,15 @@ NEW_BOOTSTRAP_PAGE = """<!DOCTYPE HTML>
 TEST_CONFIGURATION = """[section]
 key = value"""
 
-if pygments_version >= "2.14.0":
-    pygments_space_span = '<span style="color: #bbbbbb"> </span>'
-    pygments_output = (
-        '\n'
-        '<span style="color: #687822">key</span>'
-        f'{pygments_space_span}'
-        '<span style="color: #666666">=</span>'
-        f'{pygments_space_span}'
-        '<span style="color: #BA2121">value</span>'
-    )
-elif pygments_version >= "2.11.0":
-    pygments_output = (
-        '<span style="color: #bbbbbb"></span>\n'
-        '<span style="color: #687822">key</span>'
-        '<span style="color: #bbbbbb"> </span>'
-        '<span style="color: #666666">=</span>'
-        '<span style="color: #bbbbbb"> </span>'
-        '<span style="color: #BA2121">value</span>'
-        '<span style="color: #bbbbbb"></span>'
-    )
-    pygments_space_span = ' '
-else:
-    pygments_output = (
-        '\n'
-        '<span style="color: #7D9029">key</span> '
-        '<span style="color: #666666">=</span> '
-        '<span style="color: #BA2121">value</span>'
-    )
+pygments_space_span = '<span style="color: #BBB"> </span>'
+pygments_output = (
+    '\n'
+    '<span style="color: #687822">key</span>'
+    f'{pygments_space_span}'
+    '<span style="color: #666">=</span>'
+    f'{pygments_space_span}'
+    '<span style="color: #BA2121">value</span>'
+)
 
 ABOUT = f"""<div class="row">
 <div class="col-md-12">

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ dynamic = ["version"]
 [project.optional-dependencies]
 test = [
   "flake8",
+  "pygments >=2.19.0",
   "pytest >=3.3.0",
   "pytest-cov >=2.4.0",
 ]


### PR DESCRIPTION
This PR fixes the HTML tests when using `pygments>=2.19` and changes the cache to use miniforge, which seems to work.

Credit @duncanmmacleod for this suggestion

Closes #467 