### PR TITLE
Update matplotlib dependency package to matplotlib-base

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
   "lalsuite",
   "lxml",
   "MarkupPy >=1.14",
-  "matplotlib >=3.9",
+  "matplotlib-base >=3.9",
   "numpy >=1.16",
   "pandas",
   "pycondor",


### PR DESCRIPTION
This PR updates the `matplotlib` package dependency to `matplotlib-base` for better package dependency requirements with reduced overhead.