### PR TITLE
Switch from python-ligo-lw to igwn_ligolw

### DIFF
--- a/gwdetchar/io/ligolw.py
+++ b/gwdetchar/io/ligolw.py
@@ -19,12 +19,9 @@
 """Utilties for LIGO_LW XML I/O
 """
 
-from ligo.lw import (
-    ligolw,
-    table,
-)
+from igwn_ligolw import ligolw
 try:
-    from ligo.lw import lsctables
+    from igwn_ligolw import lsctables
 except ModuleNotFoundError as exc:
     exc.msg = (
         f"{exc.msg}, please install python-lal / python3-lal / lalsuite "
@@ -39,24 +36,24 @@ __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
 
 def new_table(tab, *args, **kwargs):
-    """Create a new `~ligo.lw.table.Table`
+    """Create a new `~igwn_ligolw.ligolw.Table`
 
-    This is just a convenience wrapper around `~ligo.lw.lsctables.New`
+    This is just a convenience wrapper around `~igwn_ligolw.lsctables.New`
 
     Parameters
     ----------
     tab : `type`, `str`
-        `~ligo.lw.table.Table` subclass, or name of table to create
+        `~igwn_ligolw.ligolw.Table` subclass, or name of table to create
     *args, **kwargs
-        other parameters are passed directly to `~ligo.lw.lsctables.New`
+        other parameters are passed directly to `~igwn_ligolw.lsctables.New`
 
     Returns
     -------
-    table : `~ligo.lw.table.Table`
+    table : `~igwn_ligolw.ligolw.Table`
         a newly-created table with the relevant attributes and structure
     """
     if isinstance(tab, str):
-        tab = lsctables.TableByName[table.Table.TableName(tab)]
+        tab = lsctables.TableByName[ligolw.Table.TableName(tab)]
     return lsctables.New(tab, *args, **kwargs)
 
 

--- a/gwdetchar/io/tests/test_ligolw.py
+++ b/gwdetchar/io/tests/test_ligolw.py
@@ -27,7 +27,7 @@ from numpy.testing import (assert_array_equal, assert_allclose)
 from gwpy.segments import (Segment, SegmentList)
 from gwpy.testing.utils import assert_segmentlist_equal
 
-lsctables = pytest.importorskip("ligo.lw.lsctables")
+lsctables = pytest.importorskip("igwn_ligolw.lsctables")
 ligolw = pytest.importorskip("gwdetchar.io.ligolw")
 
 
@@ -63,7 +63,7 @@ def test_segments_from_sngl_burst():
 
 
 def test_table_to_document():
-    from ligo.lw.ligolw import Document
+    from igwn_ligolw.ligolw import Document
     tab = ligolw.new_table('sngl_burst')
     xmldoc = ligolw.table_to_document(tab)
     assert isinstance(xmldoc, Document)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
   "pandas",
   "pycondor",
   "pygments >=2.7.3",
-  "python-ligo-lw",
+  "igwn-ligolw",
   "pytz",
   "scikit-learn",
   "scipy >=1.2.0",


### PR DESCRIPTION
This PR changes the dependency from `python-ligo-lw` to `igwn_ligolw`.