### PR TITLE
Explicitly control datetime format for HTML

### DIFF
--- a/gwdetchar/omega/html.py
+++ b/gwdetchar/omega/html.py
@@ -274,7 +274,7 @@ def write_summary(
     page : `~MarkupPy.markup.page`
         the formatted markup object containing the analysis summary table
     """
-    utc = tconvert(gpstime)
+    utcstr = tconvert(gpstime).strftime('%Y-%m-%d %H:%M:%S')
     page = markup.page()
     page.div(class_='banner')
     page.h2(header)
@@ -291,7 +291,7 @@ def write_summary(
     page.tr.close()
     page.tr()
     page.th('UTC Time', scope='row')
-    page.td(str(utc))
+    page.td(utcstr)
     page.tr.close()
     page.tbody.close()
     # close table


### PR DESCRIPTION
This PR fixes an HTML formatting issue where a timezone-aware `datetime` has a different `str` representation to a naive `datetime`.

GWpy 4.0.0 returns aware `datetime`s, including timezone information; the easiest solution is to control it explicitly so there are no surprises.