### PR TITLE
Update TimeSeries filtering arguments and handling for GWpy 4

### DIFF
--- a/gwdetchar/omega/core.py
+++ b/gwdetchar/omega/core.py
@@ -71,7 +71,7 @@ def highpass(series, f_low, order=12, analog=False, ftype='sos'):
     fs = series.sample_rate.to('Hz').value
     hpfilt = butter(order, corner, btype='highpass', analog=analog,
                     output=ftype, fs=fs)
-    hpseries = series.filter(hpfilt, filtfilt=True)
+    hpseries = series.filter(hpfilt, analog=analog, filtfilt=True)
     return hpseries
 
 

--- a/gwdetchar/omega/tests/test_core.py
+++ b/gwdetchar/omega/tests/test_core.py
@@ -38,10 +38,14 @@ FFTLENGTH = 8
 
 NOISE = TimeSeries(
     numpy.random.normal(loc=1, scale=.5, size=16384 * 68),
-    sample_rate=16384, epoch=-34).zpk([], [0], 1)
+    sample_rate=16384,
+    epoch=-34,
+).zpk([], [0], 1, analog=True, filtfilt=False)
 GLITCH = TimeSeries(
     signal.gausspulse(numpy.arange(-1, 1, 1./16384), bw=100),
-    sample_rate=16384, epoch=-1) * 1e-4
+    sample_rate=16384,
+    epoch=-1,
+) * 1e-4
 INPUT = NOISE.inject(GLITCH)
 
 CONFIGURATION = {

--- a/gwdetchar/omega/tests/test_core.py
+++ b/gwdetchar/omega/tests/test_core.py
@@ -102,7 +102,7 @@ def test_conditioner_with_highpass():
     assert isinstance(hpxoft, TimeSeries)
     assert xoft.is_compatible(wxoft)
     assert xoft.is_compatible(hpxoft)
-    nptest.assert_almost_equal(hpxoft.value.mean(), 0, decimal=5)
+    nptest.assert_almost_equal(hpxoft.value.mean(), 0, decimal=3)
     nptest.assert_almost_equal(wxoft.value.mean(), 0, decimal=2)
 
 

--- a/gwdetchar/omega/tests/test_main.py
+++ b/gwdetchar/omega/tests/test_main.py
@@ -144,17 +144,21 @@ TEST_FLAG = DataQualityFlag(
     known=SegmentList([Segment(0, 34)]),
 )
 
+# Analog integrator in ZPK
+ZPK_ARGS = ([], [0], 1)
+ZPK_KWARGS = {"analog": True, "filtfilt": False}
+
 K1_DATA = TimeSeriesDict({
     "K1:GW-PRIMARY_CHANNEL": TimeSeries(
         numpy.random.normal(loc=1, scale=.5, size=4096 * GPS * 2),
         sample_rate=4096,
         epoch=0,
-    ).zpk([], [0], 1).inject(SIGNAL),
+    ).zpk(*ZPK_ARGS, **ZPK_KWARGS).inject(SIGNAL),
     "K1:AUX-HIGH_SIGNIFICANCE": TimeSeries(
         numpy.random.normal(loc=1, scale=.5, size=4096 * GPS * 2),
         sample_rate=4096,
         epoch=0,
-    ).zpk([], [0], 1).inject(SIGNAL),
+    ).zpk(*ZPK_ARGS, **ZPK_KWARGS).inject(SIGNAL),
     "K1:AUX-LOW_SIGNIFICANCE": TimeSeries(
         numpy.random.normal(loc=1, scale=.5, size=4096 * GPS * 2),
         sample_rate=4096,
@@ -172,12 +176,12 @@ NETWORK_DATA = TimeSeriesDict({
         numpy.random.normal(loc=1, scale=.5, size=4096 * GPS * 2),
         sample_rate=4096,
         epoch=0,
-    ).zpk([], [0], 1).inject(SIGNAL),
+    ).zpk(*ZPK_ARGS, **ZPK_KWARGS).inject(SIGNAL),
     "L1:GW-PRIMARY_CHANNEL": TimeSeries(
         numpy.random.normal(loc=1, scale=.5, size=4096 * GPS * 2),
         sample_rate=4096,
         epoch=0,
-    ).zpk([], [0], 1).inject(SIGNAL),
+    ).zpk(*ZPK_ARGS, **ZPK_KWARGS).inject(SIGNAL),
 })
 
 

--- a/gwdetchar/omega/tests/test_plot.py
+++ b/gwdetchar/omega/tests/test_plot.py
@@ -45,7 +45,9 @@ FFTLENGTH = 8
 
 NOISE = TimeSeries(
     numpy.random.normal(loc=1, scale=.5, size=16384 * 68),
-    sample_rate=16384, epoch=-34).zpk([], [0], 1)
+    sample_rate=16384,
+    epoch=-34.,
+).zpk([], [0], 1, analog=True, filtfilt=False)
 GLITCH = TimeSeries(
     signal.gausspulse(numpy.arange(-1, 1, 1./16384), bw=100),
     sample_rate=16384, epoch=-1) * 1e-4

--- a/gwdetchar/scattering/tests/test_plot.py
+++ b/gwdetchar/scattering/tests/test_plot.py
@@ -40,7 +40,9 @@ TWOPI = 2 * numpy.pi
 TIMES = numpy.arange(0, 16384 * 64)
 NOISE = TimeSeries(
     numpy.random.normal(loc=1, scale=.5, size=16384 * 64),
-    sample_rate=16384, epoch=-32).zpk([], [0], 1)
+    sample_rate=16384,
+    epoch=-32,
+).zpk([], [0], 1, analog=True, filtfilt=False)
 FRINGE = TimeSeries(
     numpy.cos(TWOPI * TIMES), sample_rate=16384, epoch=-32)
 DATA = NOISE.inject(FRINGE)


### PR DESCRIPTION
In GWpy 4 the default behaviour of some digital filtering functions, notably `TimeSeries.zpk` and `TimeSeries.resample` changed. This PR updates this project to accommodate those changes - everything should be backwards compatible with GWpy 3.0.x.